### PR TITLE
ci: add GitHub Actions pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,55 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - develop
+      - master
+
+jobs:
+  web:
+    name: Web
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: web
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: web/package-lock.json
+      - run: npm ci
+      - run: npx tsc --noEmit
+      - run: npm run build
+
+  server:
+    name: Server
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: server
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: server/requirements.txt
+      - run: pip install -r requirements.txt
+      - run: python -m compileall -q app
+
+  engine:
+    name: Engine
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: requirements.txt
+      - run: pip install -r requirements.txt
+      - run: python -m compileall -q src


### PR DESCRIPTION
### Motivation
- Provide a GitHub Actions CI pipeline to automatically validate the web, server, and engine components on PRs and pushes to `develop` and `master`.
- Ensure the server and engine jobs consistently use Python 3.12.
- Avoid shell globbing and `**` use for Python checks by using `python -m compileall` to precompile files.
- Speed repeated runs by enabling caching for `npm` and `pip` dependencies.

### Description
- Add `.github/workflows/ci.yml` which defines three jobs: `web`, `server`, and `engine`, triggered on pull requests and pushes to `develop`/`master`.
- The `web` job uses `actions/setup-node@v4` with `node-version: 20`, runs `npm ci`, `npx tsc --noEmit`, and `npm run build`, and caches npm via `cache-dependency-path: web/package-lock.json`.
- The `server` and `engine` jobs use `actions/setup-python@v5` with `python-version: "3.12"`, install dependencies with `pip install -r requirements.txt`, and run `python -m compileall -q app` and `python -m compileall -q src` respectively, with pip caching configured.
- All jobs run on `ubuntu-latest` and use `actions/checkout@v4` to check out the repository.

### Testing
- No automated tests were executed as part of this change because it only adds the CI workflow file.
- The CI configuration includes a TypeScript check (`npx tsc --noEmit`) that will run in the `web` job on GitHub Actions.
- The `server` and `engine` jobs will run `python -m compileall` in CI to validate Python sources.
- Dependency caching for `npm` and `pip` is configured and will be exercised by CI runs on GitHub Actions.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695e9ba2fb4c8325b8bf82c304c0d8ea)