### PR TITLE
ci: add release-check workflow

### DIFF
--- a/.github/workflows/release-check.yml
+++ b/.github/workflows/release-check.yml
@@ -1,0 +1,53 @@
+name: Release Check
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  web:
+    name: Web
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: web
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: web/package-lock.json
+      - run: npm ci
+      - run: npx tsc --noEmit
+      - run: npm run build
+
+  server:
+    name: Server
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: server
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: server/requirements.txt
+      - run: pip install -r requirements.txt
+      - run: python -m compileall -q app
+
+  engine:
+    name: Engine
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: requirements.txt
+      - run: pip install -r requirements.txt
+      - run: python -m compileall -q src


### PR DESCRIPTION
### Motivation
- Add a release-triggered GitHub Actions workflow that runs checks when tags matching `v*` are pushed.
- Validate the `web` TypeScript build and `server`/`engine` Python sources on release tags with caching to speed runs.
- Avoid requiring PyYAML in runners by not including the `python -c "import yaml"` validation step.
- Ensure the branch contains only the new workflow file ` .github/workflows/release-check.yml` so no other CI files are modified.

### Description
- Add ` .github/workflows/release-check.yml` defining `web`, `server`, and `engine` jobs triggered on `push` tags `v*`.
- The `web` job uses `actions/setup-node@v4` with `node-version: 20`, caches npm via `web/package-lock.json`, and runs `npm ci`, `npx tsc --noEmit`, and `npm run build`.
- The `server` and `engine` jobs use `actions/setup-python@v5` with `python-version: "3.12"`, cache pip via their requirements paths, run `pip install -r requirements.txt`, and run `python -m compileall -q` on the appropriate directories.
- Remove the PyYAML import check so CI runners do not need PyYAML preinstalled.

### Testing
- No automated tests were executed because this change only adds a CI workflow file.
- The `web` job includes a TypeScript check (`npx tsc --noEmit`) which will run in CI to validate TypeScript sources.
- The `server` and `engine` jobs include `python -m compileall -q` which will run in CI to validate Python sources.
- Dependency caching for `npm` and `pip` is configured and will be exercised by GitHub Actions CI runs.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695e9ba2fb4c8325b8bf82c304c0d8ea)