### PR TITLE
feat: expand dungeon from 5 to 8 levels with biome-specific content

### DIFF
--- a/src/core/constants.py
+++ b/src/core/constants.py
@@ -44,12 +44,15 @@ class UIMode(Enum):
 
 
 class DungeonTheme(Enum):
-    """Visual themes for dungeon levels."""
-    STONE = auto()    # Classic stone dungeon
-    CAVE = auto()     # Natural cave
-    CRYPT = auto()    # Undead tomb
-    LIBRARY = auto()  # Ancient library
-    TREASURY = auto() # Treasure vault
+    """Visual themes for dungeon levels (8 biomes)."""
+    STONE = auto()     # Level 1 - Stone Dungeon
+    ICE = auto()       # Level 2 - Ice Cavern
+    FOREST = auto()    # Level 3 - Forest Depths
+    VOLCANIC = auto()  # Level 4 - Volcanic Depths
+    CRYPT = auto()     # Level 5 - Ancient Crypt
+    SEWER = auto()     # Level 6 - Sewer
+    LIBRARY = auto()   # Level 7 - Ancient Library
+    CRYSTAL = auto()   # Level 8 - Crystal Cave
 
 
 class RoomType(Enum):
@@ -79,12 +82,15 @@ class EnemyType(Enum):
 
 
 class BossType(Enum):
-    """Boss types, one per dungeon level."""
+    """Boss types, one per dungeon level (8 levels)."""
     GOBLIN_KING = auto()      # Level 1 - Stone Dungeon
-    CAVE_TROLL = auto()       # Level 2 - Cave
-    LICH_LORD = auto()        # Level 3 - Crypt
-    ARCANE_KEEPER = auto()    # Level 4 - Library
-    DRAGON_EMPEROR = auto()   # Level 5 - Treasury
+    FROST_GIANT = auto()      # Level 2 - Ice Cavern
+    SPIDER_QUEEN = auto()     # Level 3 - Forest Depths
+    FLAME_LORD = auto()       # Level 4 - Volcanic Depths
+    LICH_LORD = auto()        # Level 5 - Ancient Crypt
+    RAT_KING = auto()         # Level 6 - Sewer
+    ARCANE_KEEPER = auto()    # Level 7 - Ancient Library
+    DRAGON_EMPEROR = auto()   # Level 8 - Crystal Cave
 
 
 class ItemRarity(Enum):
@@ -257,7 +263,7 @@ DUNGEON_HEIGHT = 40
 MIN_ROOM_SIZE = 4
 MAX_ROOM_SIZE = 10
 MAX_BSP_DEPTH = 4
-MAX_DUNGEON_LEVELS = 5
+MAX_DUNGEON_LEVELS = 8
 
 # Entity symbols
 PLAYER_SYMBOL = '@'
@@ -337,7 +343,7 @@ ENEMY_STATS = {
         'xp': 40,
         'weight': 10,
         'min_level': 3,  # Only spawns on levels 3+
-        'max_level': 5,
+        'max_level': 8,
         'ai_type': AIBehavior.RANGED_KITE,
         'element': ElementType.DARK,
         'abilities': ['raise_skeleton', 'dark_bolt'],
@@ -350,7 +356,7 @@ ENEMY_STATS = {
         'xp': 60,
         'weight': 6,
         'min_level': 4,
-        'max_level': 5,
+        'max_level': 8,
         'ai_type': AIBehavior.AGGRESSIVE,
         'element': ElementType.FIRE,
         'abilities': ['fire_strike'],
@@ -364,7 +370,7 @@ ENEMY_STATS = {
         'xp': 35,
         'weight': 12,
         'min_level': 2,
-        'max_level': 5,
+        'max_level': 8,
         'ai_type': AIBehavior.STEALTH,
         'abilities': ['backstab', 'vanish'],
     },
@@ -376,7 +382,7 @@ ENEMY_STATS = {
         'xp': 45,
         'weight': 8,
         'min_level': 3,
-        'max_level': 5,
+        'max_level': 8,
         'ai_type': AIBehavior.ELEMENTAL,
         'element': ElementType.FIRE,
         'abilities': ['fire_bolt'],
@@ -390,7 +396,7 @@ ENEMY_STATS = {
         'xp': 45,
         'weight': 8,
         'min_level': 3,
-        'max_level': 5,
+        'max_level': 8,
         'ai_type': AIBehavior.ELEMENTAL,
         'element': ElementType.ICE,
         'abilities': ['ice_shard'],
@@ -404,7 +410,7 @@ ENEMY_STATS = {
         'xp': 50,
         'weight': 6,
         'min_level': 4,
-        'max_level': 5,
+        'max_level': 8,
         'ai_type': AIBehavior.ELEMENTAL,
         'element': ElementType.LIGHTNING,
         'abilities': ['chain_lightning'],
@@ -412,7 +418,7 @@ ENEMY_STATS = {
     },
 }
 
-# Boss configuration
+# Boss configuration (8 bosses for 8 levels)
 BOSS_STATS = {
     BossType.GOBLIN_KING: {
         'symbol': 'K',
@@ -424,62 +430,98 @@ BOSS_STATS = {
         'abilities': ['summon_goblins', 'war_cry'],
         'description': 'A crowned goblin wielding a bloodied mace',
     },
-    BossType.CAVE_TROLL: {
-        'symbol': 'T',
-        'name': 'Cave Troll',
+    BossType.FROST_GIANT: {
+        'symbol': 'F',
+        'name': 'Frost Giant',
         'hp': 80,
-        'damage': 8,
+        'damage': 12,
         'xp': 300,
         'level': 2,
-        'abilities': ['ground_slam', 'regenerate'],
-        'description': 'A massive troll with stone-like skin',
+        'abilities': ['ice_blast', 'freeze_ground'],
+        'description': 'A towering giant encased in eternal ice',
     },
-    BossType.LICH_LORD: {
-        'symbol': 'L',
-        'name': 'Lich Lord',
+    BossType.SPIDER_QUEEN: {
+        'symbol': 'S',
+        'name': 'Spider Queen',
         'hp': 70,
         'damage': 10,
         'xp': 400,
         'level': 3,
+        'abilities': ['web_trap', 'poison_bite', 'summon_spiders'],
+        'description': 'A massive arachnid matriarch dripping with venom',
+    },
+    BossType.FLAME_LORD: {
+        'symbol': 'Φ',
+        'name': 'Flame Lord',
+        'hp': 100,
+        'damage': 15,
+        'xp': 500,
+        'level': 4,
+        'abilities': ['fire_breath', 'lava_pool', 'inferno'],
+        'description': 'A being of pure fire born from the volcanic depths',
+    },
+    BossType.LICH_LORD: {
+        'symbol': 'L',
+        'name': 'Lich Lord',
+        'hp': 90,
+        'damage': 12,
+        'xp': 600,
+        'level': 5,
         'abilities': ['raise_dead', 'life_drain'],
         'description': 'An ancient undead sorcerer crackling with dark energy',
+    },
+    BossType.RAT_KING: {
+        'symbol': 'R',
+        'name': 'Rat King',
+        'hp': 85,
+        'damage': 11,
+        'xp': 700,
+        'level': 6,
+        'abilities': ['summon_swarm', 'plague_bite', 'burrow'],
+        'description': 'A grotesque fusion of rats bound by diseased flesh',
     },
     BossType.ARCANE_KEEPER: {
         'symbol': 'A',
         'name': 'Arcane Keeper',
-        'hp': 60,
-        'damage': 12,
-        'xp': 500,
-        'level': 4,
+        'hp': 80,
+        'damage': 14,
+        'xp': 800,
+        'level': 7,
         'abilities': ['arcane_bolt', 'teleport'],
         'description': 'A spectral guardian of forbidden knowledge',
     },
     BossType.DRAGON_EMPEROR: {
         'symbol': 'E',
         'name': 'Dragon Emperor',
-        'hp': 150,
-        'damage': 15,
-        'xp': 1000,
-        'level': 5,
-        'abilities': ['fire_breath', 'tail_sweep'],
+        'hp': 200,
+        'damage': 20,
+        'xp': 1500,
+        'level': 8,
+        'abilities': ['fire_breath', 'tail_sweep', 'dragon_fear'],
         'description': 'The ancient dragon lord guarding the ultimate treasure',
     },
 }
 
-# Map dungeon levels to boss types
+# Map dungeon levels to boss types (8 levels)
 LEVEL_BOSS_MAP = {
-    1: BossType.GOBLIN_KING,
-    2: BossType.CAVE_TROLL,
-    3: BossType.LICH_LORD,
-    4: BossType.ARCANE_KEEPER,
-    5: BossType.DRAGON_EMPEROR,
+    1: BossType.GOBLIN_KING,      # Stone Dungeon
+    2: BossType.FROST_GIANT,      # Ice Cavern
+    3: BossType.SPIDER_QUEEN,     # Forest Depths
+    4: BossType.FLAME_LORD,       # Volcanic Depths
+    5: BossType.LICH_LORD,        # Ancient Crypt
+    6: BossType.RAT_KING,         # Sewer
+    7: BossType.ARCANE_KEEPER,    # Ancient Library
+    8: BossType.DRAGON_EMPEROR,   # Crystal Cave
 }
 
 # Boss loot tables (guaranteed drops)
 BOSS_LOOT = {
     BossType.GOBLIN_KING: ['iron_sword', 'chain_mail'],
-    BossType.CAVE_TROLL: ['battle_axe', 'strength_potion', 'strength_potion'],
+    BossType.FROST_GIANT: ['frost_axe', 'ice_shield'],
+    BossType.SPIDER_QUEEN: ['spider_silk_armor', 'venom_dagger'],
+    BossType.FLAME_LORD: ['flame_sword', 'fire_resist_ring'],
     BossType.LICH_LORD: ['plate_armor', 'health_potion', 'health_potion'],
+    BossType.RAT_KING: ['plague_blade', 'rat_king_crown'],
     BossType.ARCANE_KEEPER: ['teleport_scroll', 'teleport_scroll', 'strength_potion'],
     BossType.DRAGON_EMPEROR: ['dragon_slayer', 'dragon_scale'],
 }
@@ -530,69 +572,96 @@ BOX_V_ASCII = '|'
 BOX_LEFT_ASCII = '+'
 BOX_RIGHT_ASCII = '+'
 
-# Dungeon theme visual tiles
+# Dungeon theme visual tiles (8 biomes)
 THEME_TILES = {
     DungeonTheme.STONE: {
         'wall': '#',
         'floor': '.',
         'description': 'Stone Dungeon'
     },
-    DungeonTheme.CAVE: {
-        'wall': '█',
+    DungeonTheme.ICE: {
+        'wall': '▓',
         'floor': '·',
-        'description': 'Natural Cave'
+        'description': 'Ice Cavern'
+    },
+    DungeonTheme.FOREST: {
+        'wall': '♣',
+        'floor': '"',
+        'description': 'Forest Depths'
+    },
+    DungeonTheme.VOLCANIC: {
+        'wall': '▒',
+        'floor': ',',
+        'description': 'Volcanic Depths'
     },
     DungeonTheme.CRYPT: {
-        'wall': '▓',
+        'wall': '█',
         'floor': ',',
         'description': 'Ancient Crypt'
+    },
+    DungeonTheme.SEWER: {
+        'wall': '▓',
+        'floor': '.',
+        'description': 'Sewer'
     },
     DungeonTheme.LIBRARY: {
         'wall': '║',
         'floor': '_',
-        'description': 'Forgotten Library'
+        'description': 'Ancient Library'
     },
-    DungeonTheme.TREASURY: {
-        'wall': '╬',
+    DungeonTheme.CRYSTAL: {
+        'wall': '◊',
         'floor': '·',
-        'description': 'Treasure Vault'
+        'description': 'Crystal Cave'
     },
 }
 
 # ASCII fallbacks for theme tiles (when Unicode not supported)
 THEME_TILES_ASCII = {
     DungeonTheme.STONE: {'wall': '#', 'floor': '.'},
-    DungeonTheme.CAVE: {'wall': '#', 'floor': '.'},
+    DungeonTheme.ICE: {'wall': '#', 'floor': '.'},
+    DungeonTheme.FOREST: {'wall': '#', 'floor': '"'},
+    DungeonTheme.VOLCANIC: {'wall': '#', 'floor': ','},
     DungeonTheme.CRYPT: {'wall': '#', 'floor': ','},
+    DungeonTheme.SEWER: {'wall': '#', 'floor': '.'},
     DungeonTheme.LIBRARY: {'wall': '|', 'floor': '_'},
-    DungeonTheme.TREASURY: {'wall': '+', 'floor': '.'},
+    DungeonTheme.CRYSTAL: {'wall': '#', 'floor': '.'},
 }
 
-# Map dungeon levels to themes
+# Map dungeon levels to themes (8 levels)
 LEVEL_THEMES = {
-    1: DungeonTheme.STONE,
-    2: DungeonTheme.CAVE,
-    3: DungeonTheme.CRYPT,
-    4: DungeonTheme.LIBRARY,
-    5: DungeonTheme.TREASURY,
+    1: DungeonTheme.STONE,      # Stone Dungeon
+    2: DungeonTheme.ICE,        # Ice Cavern
+    3: DungeonTheme.FOREST,     # Forest Depths
+    4: DungeonTheme.VOLCANIC,   # Volcanic Depths
+    5: DungeonTheme.CRYPT,      # Ancient Crypt
+    6: DungeonTheme.SEWER,      # Sewer
+    7: DungeonTheme.LIBRARY,    # Ancient Library
+    8: DungeonTheme.CRYSTAL,    # Crystal Cave
 }
 
 # Decoration characters for each theme
 THEME_DECORATIONS = {
-    DungeonTheme.STONE: ['Θ', '♪'],  # Pillars, braziers
-    DungeonTheme.CAVE: ['*', '"'],    # Rubble, moss
+    DungeonTheme.STONE: ['Θ', '♪'],   # Pillars, braziers
+    DungeonTheme.ICE: ['❄', '◇'],     # Icicles, crystals
+    DungeonTheme.FOREST: ['♠', '¥'],  # Trees, mushrooms
+    DungeonTheme.VOLCANIC: ['∆', '≡'], # Rocks, vents
     DungeonTheme.CRYPT: ['†', 'Ω'],   # Tombstones, statues
+    DungeonTheme.SEWER: ['○', '='],   # Pipes, grates
     DungeonTheme.LIBRARY: ['╤', '║'], # Tables, shelves
-    DungeonTheme.TREASURY: ['ß', 'Ω'], # Barrels, statues
+    DungeonTheme.CRYSTAL: ['◇', '✦'], # Crystals, gems
 }
 
 # ASCII fallbacks for decorations
 THEME_DECORATIONS_ASCII = {
     DungeonTheme.STONE: ['O', '^'],   # Pillars, braziers
-    DungeonTheme.CAVE: ['*', '"'],    # Rubble, moss
+    DungeonTheme.ICE: ['*', '<'],     # Icicles, crystals
+    DungeonTheme.FOREST: ['T', 'm'],  # Trees, mushrooms
+    DungeonTheme.VOLCANIC: ['^', '='], # Rocks, vents
     DungeonTheme.CRYPT: ['+', 'O'],   # Tombstones, statues
+    DungeonTheme.SEWER: ['o', '='],   # Pipes, grates
     DungeonTheme.LIBRARY: ['=', '|'], # Tables, shelves
-    DungeonTheme.TREASURY: ['$', 'O'], # Barrels, statues
+    DungeonTheme.CRYSTAL: ['<', '*'], # Crystals, gems
 }
 
 # Terrain features (walkable floor variations)
@@ -602,23 +671,31 @@ TERRAIN_BLOOD = 'ꕤ'
 TERRAIN_BLOOD_ASCII = '%'
 TERRAIN_GRASS = '"'
 TERRAIN_MOSS = ':'
+TERRAIN_LAVA = '~'
+TERRAIN_ICE = '='
 
 # Theme-specific terrain features
 THEME_TERRAIN = {
-    DungeonTheme.STONE: [],  # No special terrain
-    DungeonTheme.CAVE: [TERRAIN_WATER, TERRAIN_GRASS],  # Water pools, moss
-    DungeonTheme.CRYPT: [],  # Blood added dynamically when enemies die
-    DungeonTheme.LIBRARY: [],  # No special terrain
-    DungeonTheme.TREASURY: [TERRAIN_WATER],  # Water features
+    DungeonTheme.STONE: [],                              # No special terrain
+    DungeonTheme.ICE: [TERRAIN_ICE],                     # Slippery ice
+    DungeonTheme.FOREST: [TERRAIN_WATER, TERRAIN_GRASS], # Water, vegetation
+    DungeonTheme.VOLCANIC: [TERRAIN_LAVA],               # Lava pools
+    DungeonTheme.CRYPT: [],                              # Blood added on kills
+    DungeonTheme.SEWER: [TERRAIN_WATER],                 # Sewer water
+    DungeonTheme.LIBRARY: [],                            # Clean floors
+    DungeonTheme.CRYSTAL: [],                            # Crystal floors
 }
 
 # Theme-specific torch counts (min, max) per level
 THEME_TORCH_COUNTS = {
-    DungeonTheme.STONE: (6, 10),     # Well-lit stone dungeon
-    DungeonTheme.CAVE: (2, 4),       # Natural, sparse lighting
-    DungeonTheme.CRYPT: (4, 6),      # Dim, atmospheric
-    DungeonTheme.LIBRARY: (8, 12),   # Bright for reading
-    DungeonTheme.TREASURY: (6, 8),   # Highlight treasure
+    DungeonTheme.STONE: (6, 10),      # Well-lit stone dungeon
+    DungeonTheme.ICE: (2, 4),         # Cold, sparse lighting
+    DungeonTheme.FOREST: (3, 5),      # Natural bioluminescence
+    DungeonTheme.VOLCANIC: (4, 6),    # Lava glow
+    DungeonTheme.CRYPT: (4, 6),       # Dim, atmospheric
+    DungeonTheme.SEWER: (2, 4),       # Dark and damp
+    DungeonTheme.LIBRARY: (8, 12),    # Bright for reading
+    DungeonTheme.CRYSTAL: (8, 12),    # Crystal glow
 }
 
 # Default torch light properties

--- a/src/entities/abilities.py
+++ b/src/entities/abilities.py
@@ -187,6 +187,96 @@ BOSS_ABILITIES = {
         range=5,
         description='Lightning that can jump to nearby targets',
     ),
+
+    # v5.0 New boss abilities for expanded dungeon
+
+    # Frost Giant abilities
+    'ice_blast': BossAbility(
+        name='Ice Blast',
+        ability_type=AbilityType.AOE_ATTACK,
+        cooldown=4,
+        damage=10,
+        range=3,
+        description='Blasts freezing ice in all directions',
+    ),
+    'freeze_ground': BossAbility(
+        name='Freeze Ground',
+        ability_type=AbilityType.SPECIAL,
+        cooldown=6,
+        damage=0,
+        range=2,
+        description='Freezes the ground, slowing enemies',
+    ),
+
+    # Spider Queen abilities
+    'web_trap': BossAbility(
+        name='Web Trap',
+        ability_type=AbilityType.SPECIAL,
+        cooldown=4,
+        damage=0,
+        range=4,
+        description='Shoots sticky web to immobilize target',
+    ),
+    'poison_bite': BossAbility(
+        name='Poison Bite',
+        ability_type=AbilityType.SPECIAL,
+        cooldown=3,
+        damage=8,
+        range=1,
+        description='Venomous bite that poisons the target',
+    ),
+    'summon_spiders': BossAbility(
+        name='Summon Spiders',
+        ability_type=AbilityType.SUMMON,
+        cooldown=5,
+        damage=0,
+        range=0,
+        description='Summons spider minions to attack',
+    ),
+
+    # Flame Lord abilities
+    'lava_pool': BossAbility(
+        name='Lava Pool',
+        ability_type=AbilityType.SPECIAL,
+        cooldown=5,
+        damage=6,
+        range=3,
+        description='Creates a pool of lava that burns',
+    ),
+    'inferno': BossAbility(
+        name='Inferno',
+        ability_type=AbilityType.AOE_ATTACK,
+        cooldown=6,
+        damage=15,
+        range=2,
+        description='Erupts in flames, damaging all nearby',
+    ),
+
+    # Rat King abilities
+    'summon_swarm': BossAbility(
+        name='Summon Swarm',
+        ability_type=AbilityType.SUMMON,
+        cooldown=4,
+        damage=0,
+        range=0,
+        description='Summons a swarm of rats',
+    ),
+    'plague_bite': BossAbility(
+        name='Plague Bite',
+        ability_type=AbilityType.SPECIAL,
+        cooldown=3,
+        damage=8,
+        range=1,
+        description='Diseased bite that weakens the target',
+    ),
+    'burrow': BossAbility(
+        name='Burrow',
+        ability_type=AbilityType.SPECIAL,
+        cooldown=5,
+        damage=0,
+        range=0,
+        description='Burrows underground to reposition',
+    ),
 }
 
 
@@ -228,6 +318,17 @@ def execute_ability(
         'fire_bolt': _execute_fire_bolt,
         'ice_shard': _execute_ice_shard,
         'chain_lightning': _execute_chain_lightning,
+        # v5.0 new boss abilities
+        'ice_blast': _execute_ice_blast,
+        'freeze_ground': _execute_freeze_ground,
+        'web_trap': _execute_web_trap,
+        'poison_bite': _execute_poison_bite,
+        'summon_spiders': _execute_summon_spiders,
+        'lava_pool': _execute_lava_pool,
+        'inferno': _execute_inferno,
+        'summon_swarm': _execute_summon_swarm,
+        'plague_bite': _execute_plague_bite,
+        'burrow': _execute_burrow,
     }
 
     handler = handlers.get(ability_name)
@@ -588,4 +689,233 @@ def _execute_chain_lightning(
             msg += f" {stun_msg}"
 
         return True, msg, damage
+    return False, "", 0
+
+
+# =============================================================================
+# v5.0 New Boss Ability Handlers
+# =============================================================================
+
+def _execute_ice_blast(
+    ability: BossAbility,
+    caster: 'Enemy',
+    player: 'Player',
+    dungeon: 'Dungeon',
+    entity_manager: 'EntityManager',
+) -> Tuple[bool, str, int]:
+    """AOE ice attack that damages and freezes."""
+    from ..core.constants import StatusEffectType
+
+    distance = max(abs(player.x - caster.x), abs(player.y - caster.y))
+    if distance <= ability.range:
+        damage = player.take_damage(ability.damage)
+        freeze_msg = player.apply_status_effect(StatusEffectType.FREEZE, caster.name)
+        return True, f"The {caster.name} unleashes an ice blast for {damage} damage! {freeze_msg}", damage
+    return False, "", 0
+
+
+def _execute_freeze_ground(
+    ability: BossAbility,
+    caster: 'Enemy',
+    player: 'Player',
+    dungeon: 'Dungeon',
+    entity_manager: 'EntityManager',
+) -> Tuple[bool, str, int]:
+    """Creates frozen ground that slows the player."""
+    from ..core.constants import StatusEffectType
+
+    distance = max(abs(player.x - caster.x), abs(player.y - caster.y))
+    if distance <= ability.range + 1:
+        slow_msg = player.apply_status_effect(StatusEffectType.SLOW, caster.name)
+        return True, f"The {caster.name} freezes the ground! {slow_msg}", 0
+    return False, "", 0
+
+
+def _execute_web_trap(
+    ability: BossAbility,
+    caster: 'Enemy',
+    player: 'Player',
+    dungeon: 'Dungeon',
+    entity_manager: 'EntityManager',
+) -> Tuple[bool, str, int]:
+    """Immobilizes the player with sticky webs."""
+    from ..core.constants import StatusEffectType
+
+    distance = abs(player.x - caster.x) + abs(player.y - caster.y)
+    if distance <= ability.range:
+        stun_msg = player.apply_status_effect(StatusEffectType.STUN, caster.name)
+        return True, f"The {caster.name} shoots sticky webbing! {stun_msg}", 0
+    return False, "", 0
+
+
+def _execute_poison_bite(
+    ability: BossAbility,
+    caster: 'Enemy',
+    player: 'Player',
+    dungeon: 'Dungeon',
+    entity_manager: 'EntityManager',
+) -> Tuple[bool, str, int]:
+    """Melee attack that poisons the target."""
+    from ..core.constants import StatusEffectType
+
+    distance = max(abs(player.x - caster.x), abs(player.y - caster.y))
+    if distance <= ability.range:
+        damage = player.take_damage(ability.damage)
+        poison_msg = player.apply_status_effect(StatusEffectType.POISON, caster.name)
+        return True, f"The {caster.name} bites with venomous fangs for {damage} damage! {poison_msg}", damage
+    return False, "", 0
+
+
+def _execute_summon_spiders(
+    ability: BossAbility,
+    caster: 'Enemy',
+    player: 'Player',
+    dungeon: 'Dungeon',
+    entity_manager: 'EntityManager',
+) -> Tuple[bool, str, int]:
+    """Summons spider minions."""
+    from .entities import Enemy
+    from ..core.constants import EnemyType
+
+    num_spiders = random.randint(2, 3)
+    spawned = 0
+
+    for _ in range(num_spiders):
+        for dx in range(-2, 3):
+            for dy in range(-2, 3):
+                if dx == 0 and dy == 0:
+                    continue
+                nx, ny = caster.x + dx, caster.y + dy
+                if (dungeon.is_walkable(nx, ny) and
+                    not entity_manager.get_enemy_at(nx, ny) and
+                    (nx != player.x or ny != player.y)):
+                    # Use goblin as stand-in for spider minion
+                    spider = Enemy(nx, ny, enemy_type=EnemyType.GOBLIN, is_elite=False)
+                    spider.name = "Spider"
+                    spider.symbol = 's'
+                    entity_manager.enemies.append(spider)
+                    spawned += 1
+                    break
+            if spawned >= num_spiders:
+                break
+
+    if spawned > 0:
+        return True, f"The {caster.name} summons {spawned} spiders!", 0
+    return False, "", 0
+
+
+def _execute_lava_pool(
+    ability: BossAbility,
+    caster: 'Enemy',
+    player: 'Player',
+    dungeon: 'Dungeon',
+    entity_manager: 'EntityManager',
+) -> Tuple[bool, str, int]:
+    """Creates a damaging lava pool (deals damage if player is close)."""
+    from ..core.constants import StatusEffectType
+
+    distance = max(abs(player.x - caster.x), abs(player.y - caster.y))
+    if distance <= ability.range:
+        damage = player.take_damage(ability.damage)
+        burn_msg = player.apply_status_effect(StatusEffectType.BURN, caster.name)
+        return True, f"The {caster.name} creates a pool of molten lava! {damage} damage! {burn_msg}", damage
+    return True, f"The {caster.name} creates a pool of molten lava!", 0
+
+
+def _execute_inferno(
+    ability: BossAbility,
+    caster: 'Enemy',
+    player: 'Player',
+    dungeon: 'Dungeon',
+    entity_manager: 'EntityManager',
+) -> Tuple[bool, str, int]:
+    """Massive AOE fire attack."""
+    from ..core.constants import StatusEffectType
+
+    distance = max(abs(player.x - caster.x), abs(player.y - caster.y))
+    if distance <= ability.range:
+        damage = player.take_damage(ability.damage)
+        burn_msg = player.apply_status_effect(StatusEffectType.BURN, caster.name)
+        return True, f"The {caster.name} erupts in an inferno for {damage} damage! {burn_msg}", damage
+    return False, "", 0
+
+
+def _execute_summon_swarm(
+    ability: BossAbility,
+    caster: 'Enemy',
+    player: 'Player',
+    dungeon: 'Dungeon',
+    entity_manager: 'EntityManager',
+) -> Tuple[bool, str, int]:
+    """Summons a swarm of rat minions."""
+    from .entities import Enemy
+    from ..core.constants import EnemyType
+
+    num_rats = random.randint(3, 5)
+    spawned = 0
+
+    for _ in range(num_rats):
+        for dx in range(-2, 3):
+            for dy in range(-2, 3):
+                if dx == 0 and dy == 0:
+                    continue
+                nx, ny = caster.x + dx, caster.y + dy
+                if (dungeon.is_walkable(nx, ny) and
+                    not entity_manager.get_enemy_at(nx, ny) and
+                    (nx != player.x or ny != player.y)):
+                    # Use goblin as stand-in for rat minion
+                    rat = Enemy(nx, ny, enemy_type=EnemyType.GOBLIN, is_elite=False)
+                    rat.name = "Rat"
+                    rat.symbol = 'r'
+                    rat.hp = rat.hp // 2  # Weaker than goblins
+                    entity_manager.enemies.append(rat)
+                    spawned += 1
+                    break
+            if spawned >= num_rats:
+                break
+
+    if spawned > 0:
+        return True, f"The {caster.name} summons a swarm of {spawned} rats!", 0
+    return False, "", 0
+
+
+def _execute_plague_bite(
+    ability: BossAbility,
+    caster: 'Enemy',
+    player: 'Player',
+    dungeon: 'Dungeon',
+    entity_manager: 'EntityManager',
+) -> Tuple[bool, str, int]:
+    """Diseased bite that poisons and weakens."""
+    from ..core.constants import StatusEffectType
+
+    distance = max(abs(player.x - caster.x), abs(player.y - caster.y))
+    if distance <= ability.range:
+        damage = player.take_damage(ability.damage)
+        poison_msg = player.apply_status_effect(StatusEffectType.POISON, caster.name)
+        weak_msg = player.apply_status_effect(StatusEffectType.WEAK, caster.name)
+        return True, f"The {caster.name} delivers a plague-ridden bite for {damage} damage! {poison_msg} {weak_msg}", damage
+    return False, "", 0
+
+
+def _execute_burrow(
+    ability: BossAbility,
+    caster: 'Enemy',
+    player: 'Player',
+    dungeon: 'Dungeon',
+    entity_manager: 'EntityManager',
+) -> Tuple[bool, str, int]:
+    """Burrows underground and repositions."""
+    # Find a new position near the player
+    for _ in range(10):
+        dx = random.randint(-3, 3)
+        dy = random.randint(-3, 3)
+        nx, ny = player.x + dx, player.y + dy
+        if (dungeon.is_walkable(nx, ny) and
+            not entity_manager.get_enemy_at(nx, ny) and
+            (nx != player.x or ny != player.y)):
+            caster.x = nx
+            caster.y = ny
+            return True, f"The {caster.name} burrows underground and emerges nearby!", 0
+
     return False, "", 0

--- a/src/story/story_data.py
+++ b/src/story/story_data.py
@@ -5,10 +5,13 @@ from typing import Dict, List, Optional, Tuple
 # Level intro messages - shown when entering each dungeon level
 LEVEL_INTRO_MESSAGES: Dict[int, str] = {
     1: "You descend into the Stone Dungeon. Ancient torches flicker with unnatural light.",
-    2: "The air grows damp as you enter the Natural Caves. Water drips from unseen heights.",
-    3: "A chill runs down your spine as you step into the Ancient Crypt. The dead do not rest here.",
-    4: "Dust motes dance in pale light. You have found the Forgotten Library.",
-    5: "Gold glimmers in the darkness. You have reached the Treasure Vault. Something guards it.",
+    2: "A biting cold grips you as you enter the Ice Cavern. Frost clings to every surface.",
+    3: "Roots and vines consume the walls. You have entered the Forest Depths, where nature claims all.",
+    4: "Heat radiates from below. The Volcanic Depths glow with rivers of molten rock.",
+    5: "A chill runs down your spine as you step into the Ancient Crypt. The dead do not rest here.",
+    6: "The stench hits you first. The Sewers of Valdris stretch endlessly into darkness.",
+    7: "Dust motes dance in pale light. You have found the Ancient Library. Knowledge... and danger.",
+    8: "Brilliant light refracts through countless crystals. The Crystal Cave holds the dragon's lair.",
 }
 
 
@@ -49,29 +52,73 @@ LORE_ENTRIES: Dict[str, Dict] = {
         "item_type": "scroll",
     },
 
-    # Level 2 - Cave lore
-    "journal_adventurer_2": {
-        "title": "Water-Stained Pages",
+    # Level 2 - Ice Cavern lore
+    "frozen_explorer": {
+        "title": "Frozen Explorer's Journal",
         "content": [
-            "Day 7: The caves are natural, but something shaped them further.",
-            "I found tool marks on the walls. The people of Valdris dug deeper.",
-            "What were they searching for? Or hiding from?",
+            "Day 12: The cold is unnatural. My torch barely helps.",
+            "I found a giant frozen solid in the ice. Still breathing.",
+            "The Frost Giant was sealed here. Someone is waking it.",
         ],
         "level_hint": 2,
         "item_type": "scroll",
     },
-    "miner_note": {
-        "title": "Miner's Note",
+    "ice_warning": {
+        "title": "Warning Carved in Ice",
         "content": [
-            "We broke through to something today. A tomb, older than Valdris itself.",
-            "Foreman says to keep digging. The king wants what's inside.",
-            "I don't like the sounds coming from below.",
+            "BEWARE THE THAW",
+            "THE GIANT SLEEPS IN FROZEN SLUMBER",
+            "DO NOT MELT THE ICE",
         ],
         "level_hint": 2,
         "item_type": "scroll",
     },
 
-    # Level 3 - Crypt lore
+    # Level 3 - Forest Depths lore
+    "druid_log": {
+        "title": "Druid's Log",
+        "content": [
+            "The forest has grown wild since we abandoned the upper levels.",
+            "Nature reclaims what was taken. The Spider Queen has made her nest.",
+            "We thought we could contain her. We were wrong.",
+        ],
+        "level_hint": 3,
+        "item_type": "scroll",
+    },
+    "webbed_note": {
+        "title": "Note Wrapped in Silk",
+        "content": [
+            "If you can read this, run.",
+            "The spiders are everywhere. Their queen watches.",
+            "She was once human. The forest changed her.",
+        ],
+        "level_hint": 3,
+        "item_type": "scroll",
+    },
+
+    # Level 4 - Volcanic Depths lore
+    "smith_journal": {
+        "title": "Master Smith's Journal",
+        "content": [
+            "We built our forge above the magma flows. The heat was perfect.",
+            "Then the Flame Lord emerged from the depths. Fire given form.",
+            "Our greatest weapons could not harm him. He melted them all.",
+        ],
+        "level_hint": 4,
+        "item_type": "scroll",
+    },
+    "obsidian_tablet": {
+        "title": "Obsidian Tablet",
+        "content": [
+            "THE FLAME LORD WAS BORN OF VALDRIS' GREED",
+            "THEY DUG TOO DEEP FOR GOLD AND GEMS",
+            "AND WOKE THE FIRE THAT NEVER DIES",
+        ],
+        "level_hint": 4,
+        "item_type": "scroll",
+    },
+
+    # Level 5 - Ancient Crypt lore
     "crypt_inscription": {
         "title": "Tomb Inscription",
         "content": [
@@ -81,7 +128,7 @@ LORE_ENTRIES: Dict[str, Dict] = {
             "",
             "The kingdom called. They rose. They did not stop.",
         ],
-        "level_hint": 3,
+        "level_hint": 5,
         "item_type": "scroll",
     },
     "priest_confession": {
@@ -92,11 +139,33 @@ LORE_ENTRIES: Dict[str, Dict] = {
             "But the dead cannot tell friend from foe.",
             "We sealed the crypt, but the magic... it spreads.",
         ],
-        "level_hint": 3,
+        "level_hint": 5,
         "item_type": "book",
     },
 
-    # Level 4 - Library lore
+    # Level 6 - Sewer lore
+    "sewer_worker": {
+        "title": "Sewer Worker's Note",
+        "content": [
+            "The rats have been acting strange. Organized.",
+            "I saw them carrying food to the deep tunnels. Thousands of them.",
+            "There's something down there commanding them. Something big.",
+        ],
+        "level_hint": 6,
+        "item_type": "scroll",
+    },
+    "plague_warning": {
+        "title": "Health Warden's Warning",
+        "content": [
+            "SEWERS CONDEMNED BY ORDER OF THE CROWN",
+            "The Rat King has been sighted. All workers evacuated.",
+            "Disease spreads from below. Burn anything that emerges.",
+        ],
+        "level_hint": 6,
+        "item_type": "scroll",
+    },
+
+    # Level 7 - Ancient Library lore
     "wizard_research": {
         "title": "Arcane Research Notes",
         "content": [
@@ -105,7 +174,7 @@ LORE_ENTRIES: Dict[str, Dict] = {
             "Experiment 61: I understand now. It was never a weapon.",
             "It was a prison. And we have been feeding the prisoner.",
         ],
-        "level_hint": 4,
+        "level_hint": 7,
         "item_type": "book",
     },
     "history_valdris": {
@@ -116,11 +185,11 @@ LORE_ENTRIES: Dict[str, Dict] = {
             "But the miners dug too deep, and found something sleeping.",
             "The Darkness woke, and Valdris fell in a single night.",
         ],
-        "level_hint": 4,
+        "level_hint": 7,
         "item_type": "book",
     },
 
-    # Level 5 - Treasury lore
+    # Level 8 - Crystal Cave / Dragon's Lair lore
     "dragon_pact": {
         "title": "The Dragon's Pact",
         "content": [
@@ -131,7 +200,7 @@ LORE_ENTRIES: Dict[str, Dict] = {
             "",
             "The enemies ran out long ago. I hunger.",
         ],
-        "level_hint": 5,
+        "level_hint": 8,
         "item_type": "scroll",
     },
     "final_entry": {
@@ -145,7 +214,7 @@ LORE_ENTRIES: Dict[str, Dict] = {
             "",
             "- Aldric, Last King of Valdris",
         ],
-        "level_hint": 5,
+        "level_hint": 8,
         "item_type": "book",
     },
 }

--- a/src/world/dungeon.py
+++ b/src/world/dungeon.py
@@ -923,11 +923,21 @@ class Dungeon:
 
     def _get_torch_type_for_theme(self) -> str:
         """Get the appropriate torch type for the current theme."""
-        if self.theme == DungeonTheme.CAVE:
-            return "sconce"  # Simple wall-mounted
-        elif self.theme == DungeonTheme.TREASURY:
-            return "brazier"  # Ornate
+        if self.theme == DungeonTheme.STONE:
+            return "wall"  # Standard dungeon torches
+        elif self.theme == DungeonTheme.ICE:
+            return "crystal"  # Cold blue crystal lights
+        elif self.theme == DungeonTheme.FOREST:
+            return "sconce"  # Natural bioluminescence
+        elif self.theme == DungeonTheme.VOLCANIC:
+            return "brazier"  # Fire braziers
+        elif self.theme == DungeonTheme.CRYPT:
+            return "wall"  # Eerie torches
+        elif self.theme == DungeonTheme.SEWER:
+            return "sconce"  # Dim wall-mounted lights
         elif self.theme == DungeonTheme.LIBRARY:
             return "sconce"  # Clean, functional
+        elif self.theme == DungeonTheme.CRYSTAL:
+            return "crystal"  # Bright crystal formations
         else:
-            return "wall"  # Standard torch
+            return "wall"  # Default


### PR DESCRIPTION
## Summary
- Expands the dungeon from 5 levels to 8 levels to match the 8 biome-specific music tracks
- Each level now has a unique theme, boss, and atmosphere
- Adds full boss ability implementations for 4 new bosses

## Changes
- **5 new dungeon themes**: ICE, FOREST, VOLCANIC, SEWER, CRYSTAL
- **4 new bosses**: Frost Giant, Spider Queen, Flame Lord, Rat King
- **10 new boss abilities**: ice_blast, freeze_ground, web_trap, poison_bite, summon_spiders, lava_pool, inferno, summon_swarm, plague_bite, burrow
- **Updated story content**: New intro messages and lore entries for all 8 biomes

## Level Mapping
| Level | Biome | Boss |
|-------|-------|------|
| 1 | Stone Dungeon | Goblin King |
| 2 | Ice Cavern | Frost Giant |
| 3 | Forest Depths | Spider Queen |
| 4 | Volcanic Depths | Flame Lord |
| 5 | Ancient Crypt | Lich Lord |
| 6 | Sewer | Rat King |
| 7 | Ancient Library | Arcane Keeper |
| 8 | Crystal Cave | Dragon Emperor |

## Test plan
- [ ] Verify game starts and can progress to level 2
- [ ] Check each boss spawns on correct level
- [ ] Verify boss abilities work (ice_blast, web_trap, etc.)
- [ ] Confirm music changes on level transitions
- [ ] Test victory condition on level 8

🤖 Generated with [Claude Code](https://claude.com/claude-code)