### PR TITLE
feat: add Cleric class

### DIFF
--- a/src/core/constants.py
+++ b/src/core/constants.py
@@ -168,6 +168,7 @@ class PlayerClass(Enum):
     WARRIOR = auto()
     MAGE = auto()
     ROGUE = auto()
+    CLERIC = auto()
 
 
 # Race stat modifiers and special traits
@@ -253,6 +254,15 @@ CLASS_STATS = {
         'def_modifier': -1,
         'active_abilities': ['backstab', 'smoke_bomb'],
         'passive_abilities': ['critical_strike'],
+    },
+    PlayerClass.CLERIC: {
+        'name': 'Cleric',
+        'description': 'Divine light in darkness',
+        'hp_modifier': 2,
+        'atk_modifier': 0,
+        'def_modifier': 1,
+        'active_abilities': ['heal', 'smite'],
+        'passive_abilities': ['divine_protection'],
     },
 }
 

--- a/src/entities/player_abilities.py
+++ b/src/entities/player_abilities.py
@@ -130,6 +130,35 @@ PLAYER_ABILITIES = {
         category=AbilityCategory.PASSIVE,
         passive_bonus=0.20,
     ),
+
+    # ========== CLERIC ABILITIES ==========
+    'heal': PlayerAbility(
+        id='heal',
+        name='Heal',
+        description='Restore 10 HP to yourself',
+        category=AbilityCategory.ACTIVE,
+        cooldown=5,
+        target_type=TargetType.SELF,
+        damage=-10,  # Negative damage = healing
+    ),
+    'smite': PlayerAbility(
+        id='smite',
+        name='Smite',
+        description='Holy strike dealing 6 damage, 2x to undead',
+        category=AbilityCategory.ACTIVE,
+        cooldown=3,
+        target_type=TargetType.SINGLE,
+        range=1,
+        damage=6,
+        damage_multiplier=2.0,  # Double vs undead (handled in combat)
+    ),
+    'divine_protection': PlayerAbility(
+        id='divine_protection',
+        name='Divine Protection',
+        description='20% of incoming damage is negated by divine favor',
+        category=AbilityCategory.PASSIVE,
+        passive_bonus=0.20,
+    ),
 }
 
 

--- a/web/src/data/characterData.ts
+++ b/web/src/data/characterData.ts
@@ -92,6 +92,16 @@ export const CLASSES: Record<ClassId, ClassDefinition> = {
     active_abilities: ['backstab', 'smoke_bomb'],
     passive_abilities: ['critical_strike'],
   },
+  CLERIC: {
+    id: 'CLERIC',
+    name: 'Cleric',
+    description: 'Divine light in darkness',
+    hp_modifier: 2,
+    atk_modifier: 0,
+    def_modifier: 1,
+    active_abilities: ['heal', 'smite'],
+    passive_abilities: ['divine_protection'],
+  },
 };
 
 // Ability descriptions for display
@@ -137,6 +147,20 @@ export const ABILITY_DESCRIPTIONS: Record<string, { name: string; description: s
   critical_strike: {
     name: 'Critical Strike',
     description: '20% chance for double damage (passive)',
+  },
+  heal: {
+    name: 'Heal',
+    description: 'Restore 10 HP to yourself',
+    cooldown: 5,
+  },
+  smite: {
+    name: 'Smite',
+    description: '6 damage, 2x to undead',
+    cooldown: 3,
+  },
+  divine_protection: {
+    name: 'Divine Protection',
+    description: '20% damage reduction (passive)',
   },
 };
 

--- a/web/src/types/index.ts
+++ b/web/src/types/index.ts
@@ -31,7 +31,7 @@ export interface RegisterData {
 
 // Character Creation types
 export type RaceId = 'HUMAN' | 'ELF' | 'DWARF' | 'HALFLING' | 'ORC';
-export type ClassId = 'WARRIOR' | 'MAGE' | 'ROGUE';
+export type ClassId = 'WARRIOR' | 'MAGE' | 'ROGUE' | 'CLERIC';
 
 export interface RaceDefinition {
   id: RaceId;


### PR DESCRIPTION
## Summary
- Adds Cleric as the fourth playable class
- Implements heal, smite, and divine_protection abilities
- Updates both Python backend and TypeScript frontend

## Test plan
- [ ] Verify Cleric appears in character creation
- [ ] Test heal ability restores HP
- [ ] Test smite ability deals damage
- [ ] Verify divine_protection passive reduces damage

🤖 Generated with [Claude Code](https://claude.com/claude-code)