### PR TITLE
feat: fix lore reading, add journal pane, and 3D mode toggle

### DIFF
--- a/server/app/services/game_session.py
+++ b/server/app/services/game_session.py
@@ -524,6 +524,21 @@ class GameSessionManager:
                 "message": engine.dialog_message,
             }
 
+        if engine.ui_mode == UIMode.READING:
+            state["reading"] = {
+                "title": engine.reading_title,
+                "content": engine.reading_content,
+            }
+
+        # Include lore journal data (always available)
+        if engine.story_manager:
+            discovered, total = engine.story_manager.get_lore_progress()
+            state["lore_journal"] = {
+                "entries": engine.story_manager.get_discovered_lore_entries(),
+                "discovered_count": discovered,
+                "total_count": total,
+            }
+
         return state
 
     def _sanitize_event_data(self, data: dict) -> dict:

--- a/src/story/story_manager.py
+++ b/src/story/story_manager.py
@@ -92,6 +92,25 @@ class StoryManager:
         from .story_data import LORE_ENTRIES
         return len(self.discovered_lore), len(LORE_ENTRIES)
 
+    def get_discovered_lore_entries(self) -> list:
+        """
+        Get full data for all discovered lore entries.
+
+        Returns:
+            List of dicts with id, title, content for each discovered entry
+        """
+        from .story_data import LORE_ENTRIES
+        entries = []
+        for lore_id in sorted(self.discovered_lore):
+            if lore_id in LORE_ENTRIES:
+                entry = LORE_ENTRIES[lore_id]
+                entries.append({
+                    'id': lore_id,
+                    'title': entry['title'],
+                    'content': entry['content'],
+                })
+        return entries
+
     def to_dict(self) -> Dict[str, Any]:
         """Serialize story state to dictionary for saving."""
         return {

--- a/web/src/components/LoreJournal.css
+++ b/web/src/components/LoreJournal.css
@@ -1,0 +1,204 @@
+/**
+ * LoreJournal Modal Styles
+ */
+
+.lore-journal-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.85);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+  animation: fadeIn 0.2s ease;
+}
+
+@keyframes fadeIn {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+
+.lore-journal {
+  background: #1a1a2e;
+  border: 2px solid #4ade80;
+  border-radius: 8px;
+  width: 90%;
+  max-width: 900px;
+  max-height: 80vh;
+  display: flex;
+  flex-direction: column;
+  box-shadow: 0 0 30px rgba(74, 222, 128, 0.3);
+}
+
+.lore-journal-header {
+  display: flex;
+  align-items: center;
+  padding: 1rem 1.5rem;
+  border-bottom: 1px solid #333;
+  gap: 1rem;
+}
+
+.lore-journal-header h2 {
+  margin: 0;
+  color: #4ade80;
+  font-size: 1.3rem;
+  font-weight: 500;
+}
+
+.lore-progress {
+  color: #888;
+  font-size: 0.9rem;
+  margin-left: auto;
+}
+
+.lore-close-btn {
+  background: transparent;
+  border: 1px solid #444;
+  color: #888;
+  padding: 0.25rem 0.5rem;
+  cursor: pointer;
+  font-family: inherit;
+  transition: all 0.2s;
+}
+
+.lore-close-btn:hover {
+  border-color: #4ade80;
+  color: #4ade80;
+}
+
+.lore-journal-content {
+  display: flex;
+  flex: 1;
+  min-height: 0;
+  overflow: hidden;
+}
+
+.lore-empty {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  flex: 1;
+  padding: 3rem;
+  text-align: center;
+  color: #666;
+}
+
+.lore-empty p {
+  margin: 0.5rem 0;
+}
+
+.lore-hint {
+  font-size: 0.9rem;
+  color: #555;
+  font-style: italic;
+}
+
+.lore-list {
+  width: 280px;
+  border-right: 1px solid #333;
+  overflow-y: auto;
+  flex-shrink: 0;
+}
+
+.lore-list-item {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.75rem 1rem;
+  cursor: pointer;
+  border-bottom: 1px solid #252538;
+  transition: background 0.2s;
+}
+
+.lore-list-item:hover {
+  background: rgba(74, 222, 128, 0.1);
+}
+
+.lore-list-item.selected {
+  background: rgba(74, 222, 128, 0.2);
+  border-left: 3px solid #4ade80;
+}
+
+.lore-icon {
+  color: #4ade80;
+  font-size: 1.1rem;
+  width: 1.5rem;
+  text-align: center;
+}
+
+.lore-title {
+  color: #c0c0c0;
+  font-size: 0.95rem;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.lore-list-item.selected .lore-title {
+  color: #fff;
+}
+
+.lore-detail {
+  flex: 1;
+  padding: 1.5rem;
+  overflow-y: auto;
+}
+
+.lore-detail-title {
+  color: #4ade80;
+  font-size: 1.2rem;
+  margin: 0 0 1.5rem;
+  padding-bottom: 0.75rem;
+  border-bottom: 1px solid #333;
+}
+
+.lore-detail-content {
+  color: #c0c0c0;
+  line-height: 1.7;
+}
+
+.lore-detail-content p {
+  margin: 0 0 1rem;
+}
+
+.lore-select-hint {
+  color: #555;
+  font-style: italic;
+  text-align: center;
+  margin-top: 3rem;
+}
+
+.lore-journal-footer {
+  padding: 0.75rem 1.5rem;
+  border-top: 1px solid #333;
+  text-align: center;
+}
+
+.lore-hint-text {
+  color: #555;
+  font-size: 0.85rem;
+}
+
+/* Responsive */
+@media (max-width: 700px) {
+  .lore-journal {
+    width: 95%;
+    max-height: 90vh;
+  }
+
+  .lore-journal-content {
+    flex-direction: column;
+  }
+
+  .lore-list {
+    width: 100%;
+    max-height: 200px;
+    border-right: none;
+    border-bottom: 1px solid #333;
+  }
+
+  .lore-detail {
+    padding: 1rem;
+  }
+}

--- a/web/src/components/LoreJournal.tsx
+++ b/web/src/components/LoreJournal.tsx
@@ -1,0 +1,92 @@
+/**
+ * LoreJournal - Modal overlay showing discovered lore entries
+ */
+import { useState } from 'react';
+import './LoreJournal.css';
+
+interface LoreEntry {
+  id: string;
+  title: string;
+  content: string[];
+}
+
+interface LoreJournalProps {
+  entries: LoreEntry[];
+  discoveredCount: number;
+  totalCount: number;
+  onClose: () => void;
+}
+
+export function LoreJournal({
+  entries,
+  discoveredCount,
+  totalCount,
+  onClose,
+}: LoreJournalProps) {
+  const [selectedEntry, setSelectedEntry] = useState<LoreEntry | null>(
+    entries.length > 0 ? entries[0] : null
+  );
+
+  return (
+    <div className="lore-journal-overlay" onClick={onClose}>
+      <div className="lore-journal" onClick={(e) => e.stopPropagation()}>
+        <div className="lore-journal-header">
+          <h2>Lore Journal</h2>
+          <span className="lore-progress">
+            {discoveredCount} / {totalCount} discovered
+          </span>
+          <button className="lore-close-btn" onClick={onClose}>
+            [X]
+          </button>
+        </div>
+
+        <div className="lore-journal-content">
+          {entries.length === 0 ? (
+            <div className="lore-empty">
+              <p>No lore discovered yet.</p>
+              <p className="lore-hint">
+                Find and read scrolls and books throughout the dungeon to uncover its secrets.
+              </p>
+            </div>
+          ) : (
+            <>
+              <div className="lore-list">
+                {entries.map((entry) => (
+                  <div
+                    key={entry.id}
+                    className={`lore-list-item ${selectedEntry?.id === entry.id ? 'selected' : ''}`}
+                    onClick={() => setSelectedEntry(entry)}
+                  >
+                    <span className="lore-icon">
+                      {entry.id.includes('book') ? '+' : '?'}
+                    </span>
+                    <span className="lore-title">{entry.title}</span>
+                  </div>
+                ))}
+              </div>
+
+              <div className="lore-detail">
+                {selectedEntry ? (
+                  <>
+                    <h3 className="lore-detail-title">{selectedEntry.title}</h3>
+                    <div className="lore-detail-content">
+                      {selectedEntry.content.map((paragraph, idx) => (
+                        <p key={idx}>{paragraph}</p>
+                      ))}
+                    </div>
+                  </>
+                ) : (
+                  <p className="lore-select-hint">Select an entry to read</p>
+                )}
+              </div>
+            </>
+          )}
+        </div>
+
+        <div className="lore-journal-footer">
+          <span className="lore-hint-text">Press [J] or [ESC] to close</span>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/web/src/components/SceneRenderer/index.ts
+++ b/web/src/components/SceneRenderer/index.ts
@@ -6,6 +6,7 @@
 
 export { SceneRenderer, default } from './SceneRenderer';
 export { FirstPersonRenderer, type RenderSettings, type CorridorInfoEntry } from './FirstPersonRenderer';
+export { FirstPersonRenderer3D } from './FirstPersonRenderer3D';
 export { BIOMES, getBiome, type BiomeTheme, type BiomeId } from './biomes';
 export { useSceneFrame, gameStateToSceneFrame } from './useSceneRenderer';
 export { SpriteManager } from './SpriteManager';

--- a/web/src/hooks/useGameSocket.ts
+++ b/web/src/hooks/useGameSocket.ts
@@ -200,6 +200,19 @@ export interface FullGameState {
     title: string;
     message: string;
   };
+  reading?: {
+    title: string;
+    content: string[];
+  };
+  lore_journal?: {
+    entries: Array<{
+      id: string;
+      title: string;
+      content: string[];
+    }>;
+    discovered_count: number;
+    total_count: number;
+  };
   first_person_view?: FirstPersonView;
 }
 

--- a/web/src/pages/Play.css
+++ b/web/src/pages/Play.css
@@ -131,6 +131,34 @@
   cursor: pointer;
 }
 
+.journal-btn {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.4rem 0.75rem;
+  background: rgba(74, 222, 128, 0.1);
+  border: 1px solid #4ade80;
+  border-radius: 4px;
+  color: #4ade80;
+  font-size: 0.85rem;
+  font-family: inherit;
+  cursor: pointer;
+  transition: all 0.2s;
+}
+
+.journal-btn:hover {
+  background: rgba(74, 222, 128, 0.2);
+}
+
+.journal-count {
+  background: #4ade80;
+  color: #0a0a0f;
+  padding: 0.1rem 0.4rem;
+  border-radius: 10px;
+  font-size: 0.75rem;
+  font-weight: 600;
+}
+
 .game-status {
   display: flex;
   align-items: center;


### PR DESCRIPTION
## Summary
- Fix lore items not opening when read (backend wasn't sending reading data)
- Fix XP bar crash caused by negative repeat value
- Add permanent lore journal accessible via J key or Journal button
- Add 3D mode toggle for Three.js renderer

## Changes
**Backend:**
- Add `reading` data to websocket game state when in READING mode
- Add `get_discovered_lore_entries()` to StoryManager
- Include `lore_journal` in game state with entries and progress count

**Frontend:**
- Add `renderReadingScreen` to GameTerminal for lore display
- Create LoreJournal modal component with list/detail view
- Add 3D Mode checkbox that toggles FirstPersonRenderer3D
- Add Journal button with discovery count badge
- Fix XP bar to clamp values (prevent negative repeat)

## Test plan
- [ ] Pick up a lore scroll/book and press R to read it - should display content
- [ ] Press J to open lore journal - shows discovered entries
- [ ] Click Journal button - same as J key
- [ ] Toggle 3D Mode checkbox - switches to Three.js renderer
- [ ] Level up to trigger XP bar - verify no crash

🤖 Generated with [Claude Code](https://claude.com/claude-code)