### PR TITLE
feat: enhanced cinematic intro and responsive 3D view

### DIFF
--- a/web/src/components/GameIntro.css
+++ b/web/src/components/GameIntro.css
@@ -1,54 +1,527 @@
 /**
- * GameIntro - Cinematic intro overlay styles
+ * GameIntro - Cinematic intro with visual scenes and effects
  */
 
+/* ============================================
+   BASE LAYOUT
+   ============================================ */
 .game-intro {
   position: fixed;
   inset: 0;
   z-index: 1000;
-  background: linear-gradient(135deg, #0a0a12 0%, #0f0f1a 50%, #080810 100%);
   display: flex;
   flex-direction: column;
   align-items: center;
   justify-content: center;
   color: #e0e0e0;
   cursor: pointer;
-  opacity: 0;
-  transition: opacity 0.5s ease;
+  overflow: hidden;
+  background: #000; /* Always solid black - never fades */
 }
 
-.game-intro.fade-in {
+/* Content wrapper - handles fading so background stays solid */
+.intro-content-wrapper {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  z-index: 10;
+  transition: opacity 0.8s ease;
+}
+
+/* Fade states - only affect content, not background */
+.game-intro.fade-in .intro-content-wrapper,
+.game-intro.fade-in .scene-background,
+.game-intro.fade-in .particles,
+.game-intro.fade-in .ambient-overlay {
+  animation: fadeIn 1s ease-out forwards;
+}
+
+.game-intro.fade-visible .intro-content-wrapper {
   opacity: 1;
 }
 
-.game-intro.fade-out {
-  opacity: 0;
+/* Content fades out between scenes */
+.intro-content-wrapper.content-fade-out {
+  animation: fadeOut 0.8s ease-in forwards;
 }
 
+@keyframes fadeIn {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+
+@keyframes fadeOut {
+  from { opacity: 1; }
+  to { opacity: 0; }
+}
+
+/* ============================================
+   CINEMATIC BARS (letterbox effect)
+   ============================================ */
+.cinematic-bar {
+  position: absolute;
+  left: 0;
+  right: 0;
+  height: 8vh;
+  background: #000;
+  z-index: 100;
+}
+
+.cinematic-bar.top {
+  top: 0;
+}
+
+.cinematic-bar.bottom {
+  bottom: 0;
+}
+
+/* ============================================
+   SCENE BACKGROUNDS
+   ============================================ */
+.scene-background {
+  position: absolute;
+  inset: 0;
+  overflow: hidden;
+}
+
+.bg-layer {
+  position: absolute;
+  inset: 0;
+  background-size: cover;
+  background-position: center;
+  transition: transform 8s ease-out, opacity 2s ease;
+}
+
+/* Far layer - slowest parallax */
+.bg-far {
+  transform: scale(1.1);
+  animation: parallaxFar 20s ease-in-out infinite alternate;
+}
+
+/* Mid layer */
+.bg-mid {
+  animation: parallaxMid 15s ease-in-out infinite alternate;
+}
+
+/* Near layer - fastest parallax */
+.bg-near {
+  animation: parallaxNear 10s ease-in-out infinite alternate;
+}
+
+@keyframes parallaxFar {
+  from { transform: scale(1.05) translateX(-1%); }
+  to { transform: scale(1.1) translateX(1%); }
+}
+
+@keyframes parallaxMid {
+  from { transform: translateX(-2%) translateY(-1%); }
+  to { transform: translateX(2%) translateY(1%); }
+}
+
+@keyframes parallaxNear {
+  from { transform: translateX(-3%); }
+  to { transform: translateX(3%); }
+}
+
+/* ============================================
+   SCENE: TITLE
+   ============================================ */
+.scene-title .scene-background {
+  background: radial-gradient(ellipse at 50% 30%, #1a1a2e 0%, #0a0a12 60%, #000 100%);
+}
+
+.scene-title .bg-far {
+  background:
+    radial-gradient(ellipse at 30% 20%, rgba(255, 215, 0, 0.03) 0%, transparent 30%),
+    radial-gradient(ellipse at 70% 30%, rgba(255, 215, 0, 0.02) 0%, transparent 25%);
+}
+
+/* ============================================
+   SCENE: KINGDOM
+   ============================================ */
+.scene-kingdom .scene-background {
+  background: linear-gradient(to bottom,
+    #0a1628 0%,
+    #1a2a48 30%,
+    #2a3a58 50%,
+    #1a2a48 70%,
+    #0a1628 100%
+  );
+}
+
+.scene-kingdom .bg-far {
+  background:
+    /* Stars */
+    radial-gradient(1px 1px at 20% 30%, rgba(255, 255, 255, 0.8), transparent),
+    radial-gradient(1px 1px at 40% 20%, rgba(255, 255, 255, 0.6), transparent),
+    radial-gradient(1px 1px at 60% 40%, rgba(255, 255, 255, 0.7), transparent),
+    radial-gradient(1px 1px at 80% 25%, rgba(255, 255, 255, 0.5), transparent),
+    radial-gradient(2px 2px at 50% 15%, rgba(255, 255, 255, 0.9), transparent),
+    radial-gradient(1px 1px at 30% 45%, rgba(255, 255, 255, 0.4), transparent),
+    radial-gradient(1px 1px at 70% 35%, rgba(255, 255, 255, 0.6), transparent),
+    /* Moon glow */
+    radial-gradient(ellipse at 80% 20%, rgba(200, 220, 255, 0.15) 0%, transparent 40%);
+}
+
+.scene-kingdom .bg-mid {
+  /* Mountain silhouettes */
+  background:
+    linear-gradient(165deg, transparent 45%, #1a2a48 45.5%, #1a2a48 100%),
+    linear-gradient(195deg, transparent 50%, #152238 50.5%, #152238 100%),
+    linear-gradient(175deg, transparent 55%, #0f1a28 55.5%, #0f1a28 100%);
+}
+
+.scene-kingdom .bg-near {
+  /* Castle silhouette */
+  background: linear-gradient(to bottom, transparent 60%, #0a0f18 60%);
+  mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 40'%3E%3Cpath d='M0,40 L0,25 L5,25 L5,20 L8,20 L8,25 L15,25 L15,15 L18,10 L21,15 L21,25 L30,25 L30,20 L35,18 L40,20 L40,25 L45,25 L45,12 L48,8 L51,12 L51,25 L60,25 L60,22 L65,20 L70,22 L70,25 L80,25 L80,18 L85,15 L90,18 L90,25 L95,25 L95,20 L100,20 L100,40 Z' fill='black'/%3E%3C/svg%3E");
+  mask-size: 100% 100%;
+  mask-position: bottom;
+  mask-repeat: no-repeat;
+  opacity: 0.9;
+}
+
+/* ============================================
+   SCENE: DARKNESS
+   ============================================ */
+.scene-darkness .scene-background {
+  background: radial-gradient(ellipse at 50% 50%, #1a0a1a 0%, #0a0508 50%, #000 100%);
+  animation: darknessFlicker 0.5s ease-in-out infinite;
+}
+
+@keyframes darknessFlicker {
+  0%, 100% { filter: brightness(1); }
+  50% { filter: brightness(0.95); }
+}
+
+.scene-darkness .bg-far {
+  background: radial-gradient(ellipse at 50% 40%, rgba(80, 0, 40, 0.3) 0%, transparent 60%);
+  animation: darknessPulse 3s ease-in-out infinite;
+}
+
+@keyframes darknessPulse {
+  0%, 100% { opacity: 0.5; transform: scale(1); }
+  50% { opacity: 0.8; transform: scale(1.1); }
+}
+
+.scene-darkness .bg-mid {
+  /* Shadowy tendrils */
+  background:
+    radial-gradient(ellipse at 30% 60%, rgba(0, 0, 0, 0.8) 0%, transparent 40%),
+    radial-gradient(ellipse at 70% 50%, rgba(0, 0, 0, 0.7) 0%, transparent 35%),
+    radial-gradient(ellipse at 50% 70%, rgba(0, 0, 0, 0.9) 0%, transparent 45%);
+  animation: shadowsMove 8s ease-in-out infinite;
+}
+
+@keyframes shadowsMove {
+  0%, 100% { transform: translateX(0) translateY(0); }
+  25% { transform: translateX(2%) translateY(-1%); }
+  50% { transform: translateX(-1%) translateY(2%); }
+  75% { transform: translateX(-2%) translateY(-1%); }
+}
+
+.scene-darkness .bg-near {
+  /* Red cracks/fissures */
+  background:
+    linear-gradient(45deg, transparent 48%, rgba(200, 0, 50, 0.3) 49%, rgba(200, 0, 50, 0.3) 51%, transparent 52%),
+    linear-gradient(-30deg, transparent 45%, rgba(150, 0, 30, 0.2) 46%, rgba(150, 0, 30, 0.2) 54%, transparent 55%);
+  animation: cracksGlow 2s ease-in-out infinite alternate;
+}
+
+@keyframes cracksGlow {
+  from { opacity: 0.3; }
+  to { opacity: 0.7; }
+}
+
+/* ============================================
+   SCENE: UNDERGROUND
+   ============================================ */
+.scene-underground .scene-background {
+  background: linear-gradient(to bottom,
+    #0a0a0f 0%,
+    #0f0f18 30%,
+    #141420 60%,
+    #0a0a10 100%
+  );
+}
+
+.scene-underground .bg-far {
+  /* Torch glow spots */
+  background:
+    radial-gradient(ellipse at 20% 50%, rgba(255, 150, 50, 0.1) 0%, transparent 30%),
+    radial-gradient(ellipse at 80% 40%, rgba(255, 150, 50, 0.08) 0%, transparent 25%),
+    radial-gradient(ellipse at 50% 60%, rgba(255, 150, 50, 0.05) 0%, transparent 35%);
+  animation: torchFlicker 0.3s ease-in-out infinite;
+}
+
+@keyframes torchFlicker {
+  0%, 100% { opacity: 0.8; }
+  50% { opacity: 1; }
+}
+
+.scene-underground .bg-mid {
+  /* Stone pillars/columns */
+  background:
+    linear-gradient(to bottom, transparent 30%, #0f0f18 30%, #0f0f18 100%),
+    repeating-linear-gradient(90deg,
+      transparent 0px, transparent 80px,
+      #0a0a12 80px, #0a0a12 100px,
+      transparent 100px, transparent 180px
+    );
+  opacity: 0.7;
+}
+
+.scene-underground .bg-near {
+  /* Arch frame */
+  background: radial-gradient(ellipse at 50% 100%, transparent 40%, #050508 60%);
+}
+
+/* ============================================
+   SCENE: DEPTHS
+   ============================================ */
+.scene-depths .scene-background {
+  background: linear-gradient(to bottom,
+    #050508 0%,
+    #080810 50%,
+    #0a0a12 100%
+  );
+}
+
+.scene-depths .bg-far {
+  /* Distant glowing eyes */
+  background:
+    radial-gradient(2px 2px at 25% 45%, rgba(255, 50, 50, 0.8), transparent 3px),
+    radial-gradient(2px 2px at 27% 45%, rgba(255, 50, 50, 0.8), transparent 3px),
+    radial-gradient(2px 2px at 75% 55%, rgba(200, 150, 50, 0.6), transparent 3px),
+    radial-gradient(2px 2px at 77% 55%, rgba(200, 150, 50, 0.6), transparent 3px);
+  animation: eyesBlink 4s ease-in-out infinite;
+}
+
+@keyframes eyesBlink {
+  0%, 45%, 55%, 100% { opacity: 1; }
+  50% { opacity: 0; }
+}
+
+.scene-depths .bg-mid {
+  /* Fog/mist */
+  background:
+    linear-gradient(to top, rgba(20, 20, 30, 0.8) 0%, transparent 40%),
+    radial-gradient(ellipse at 30% 80%, rgba(30, 30, 40, 0.6) 0%, transparent 50%),
+    radial-gradient(ellipse at 70% 70%, rgba(25, 25, 35, 0.5) 0%, transparent 45%);
+  animation: fogDrift 12s ease-in-out infinite alternate;
+}
+
+@keyframes fogDrift {
+  from { transform: translateX(-5%); }
+  to { transform: translateX(5%); }
+}
+
+/* ============================================
+   SCENE: ENTRANCE
+   ============================================ */
+.scene-entrance .scene-background {
+  background: linear-gradient(to bottom,
+    #1a1a28 0%,
+    #12121a 40%,
+    #0a0a10 70%,
+    #000 100%
+  );
+}
+
+.scene-entrance .bg-far {
+  /* Dim sky/horizon */
+  background: linear-gradient(to bottom,
+    rgba(40, 35, 50, 0.3) 0%,
+    transparent 40%
+  );
+}
+
+.scene-entrance .bg-mid {
+  /* Rocky hillside silhouette */
+  background:
+    linear-gradient(170deg, transparent 50%, #0f0f18 50.5%),
+    linear-gradient(190deg, transparent 55%, #0a0a12 55.5%);
+}
+
+.scene-entrance .bg-near {
+  /* Cave entrance frame - dark arch */
+  background: radial-gradient(ellipse 60% 80% at 50% 100%,
+    #000 0%,
+    #000 30%,
+    transparent 31%
+  );
+  /* Glow from within */
+  box-shadow: inset 0 -50px 100px rgba(255, 100, 30, 0.1);
+}
+
+.scene-entrance .bg-near::after {
+  content: '';
+  position: absolute;
+  bottom: 10%;
+  left: 50%;
+  transform: translateX(-50%);
+  width: 30%;
+  height: 40%;
+  background: radial-gradient(ellipse at 50% 100%,
+    rgba(255, 100, 30, 0.15) 0%,
+    transparent 70%
+  );
+  animation: entranceGlow 3s ease-in-out infinite alternate;
+}
+
+@keyframes entranceGlow {
+  from { opacity: 0.6; }
+  to { opacity: 1; }
+}
+
+/* ============================================
+   AMBIENT OVERLAY
+   ============================================ */
+.ambient-overlay {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  z-index: 5;
+}
+
+/* Vignette */
+.game-intro::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(ellipse at center, transparent 30%, rgba(0, 0, 0, 0.6) 100%);
+  pointer-events: none;
+  z-index: 6;
+}
+
+/* ============================================
+   PARTICLES
+   ============================================ */
+.particles {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  z-index: 4;
+  overflow: hidden;
+}
+
+.particle {
+  position: absolute;
+  border-radius: 50%;
+  left: var(--x);
+  top: var(--y);
+  width: var(--size);
+  height: var(--size);
+  animation-delay: var(--delay);
+  animation-duration: var(--duration);
+  animation-iteration-count: infinite;
+}
+
+/* Stars */
+.particles-stars .particle {
+  background: rgba(255, 255, 255, 0.8);
+  box-shadow: 0 0 4px rgba(255, 255, 255, 0.5);
+  animation-name: starTwinkle;
+}
+
+@keyframes starTwinkle {
+  0%, 100% { opacity: 0.3; transform: scale(1); }
+  50% { opacity: 1; transform: scale(1.2); }
+}
+
+/* Embers */
+.particles-embers .particle {
+  background: radial-gradient(circle, rgba(255, 150, 50, 1) 0%, rgba(255, 100, 30, 0.8) 50%, transparent 100%);
+  animation-name: emberFloat;
+}
+
+@keyframes emberFloat {
+  0% {
+    opacity: 0;
+    transform: translateY(0) translateX(0);
+  }
+  10% {
+    opacity: 1;
+  }
+  90% {
+    opacity: 0.8;
+  }
+  100% {
+    opacity: 0;
+    transform: translateY(-100px) translateX(20px);
+  }
+}
+
+/* Dust */
+.particles-dust .particle {
+  background: rgba(150, 140, 120, 0.4);
+  animation-name: dustDrift;
+}
+
+@keyframes dustDrift {
+  0%, 100% {
+    opacity: 0.2;
+    transform: translateY(0) translateX(0);
+  }
+  50% {
+    opacity: 0.5;
+    transform: translateY(-30px) translateX(15px);
+  }
+}
+
+/* Darkness particles */
+.particles-darkness .particle {
+  background: radial-gradient(circle, rgba(50, 0, 30, 0.8) 0%, transparent 70%);
+  width: calc(var(--size) * 3);
+  height: calc(var(--size) * 3);
+  animation-name: darknessDrift;
+}
+
+@keyframes darknessDrift {
+  0%, 100% {
+    opacity: 0.3;
+    transform: scale(1) translateY(0);
+  }
+  50% {
+    opacity: 0.6;
+    transform: scale(1.5) translateY(-20px);
+  }
+}
+
+/* ============================================
+   CONTENT
+   ============================================ */
 .intro-content {
+  position: relative;
+  z-index: 10;
   flex: 1;
   display: flex;
   flex-direction: column;
   align-items: center;
   justify-content: center;
   padding: 2rem;
-  max-width: 800px;
+  max-width: 900px;
   text-align: center;
 }
 
-/* Title Screen */
+/* ============================================
+   TITLE SCREEN
+   ============================================ */
 .title-screen {
-  animation: titleFadeIn 1s ease-out;
+  animation: titleReveal 2s ease-out;
 }
 
-@keyframes titleFadeIn {
+@keyframes titleReveal {
   from {
     opacity: 0;
-    transform: translateY(-20px);
+    transform: translateY(-30px) scale(0.95);
   }
   to {
     opacity: 1;
-    transform: translateY(0);
+    transform: translateY(0) scale(1);
   }
 }
 
@@ -60,7 +533,7 @@
   text-shadow:
     0 0 10px rgba(255, 215, 0, 0.5),
     0 0 20px rgba(255, 215, 0, 0.3),
-    0 0 30px rgba(255, 215, 0, 0.2);
+    0 0 40px rgba(255, 215, 0, 0.2);
   margin: 0;
   white-space: pre;
   animation: titleGlow 3s ease-in-out infinite alternate;
@@ -71,105 +544,261 @@
     text-shadow:
       0 0 10px rgba(255, 215, 0, 0.5),
       0 0 20px rgba(255, 215, 0, 0.3),
-      0 0 30px rgba(255, 215, 0, 0.2);
+      0 0 40px rgba(255, 215, 0, 0.2);
+    filter: brightness(1);
   }
   to {
     text-shadow:
-      0 0 15px rgba(255, 215, 0, 0.7),
-      0 0 30px rgba(255, 215, 0, 0.5),
-      0 0 45px rgba(255, 215, 0, 0.3);
+      0 0 20px rgba(255, 215, 0, 0.8),
+      0 0 40px rgba(255, 215, 0, 0.5),
+      0 0 60px rgba(255, 215, 0, 0.3);
+    filter: brightness(1.1);
   }
 }
 
 .title-subtitle {
-  font-size: clamp(1.5rem, 4vw, 2.5rem);
+  font-size: clamp(1.5rem, 4vw, 3rem);
   font-weight: bold;
   letter-spacing: 0.5em;
-  margin-top: 1.5rem;
+  margin-top: 2rem;
   color: #ffffff;
-  text-shadow: 2px 2px 4px rgba(0, 0, 0, 0.8);
+  text-shadow:
+    2px 2px 4px rgba(0, 0, 0, 0.8),
+    0 0 30px rgba(255, 215, 0, 0.3);
+  animation: subtitleFade 2s ease-out 0.5s both;
 }
 
-.title-tagline {
-  font-size: clamp(0.9rem, 2vw, 1.2rem);
-  color: #888;
-  margin-top: 1rem;
-  font-style: italic;
-}
-
-/* Prologue Screen */
-.prologue-screen {
-  animation: prologueFadeIn 0.5s ease-out;
-}
-
-@keyframes prologueFadeIn {
+@keyframes subtitleFade {
   from {
     opacity: 0;
+    letter-spacing: 1em;
   }
   to {
     opacity: 1;
+    letter-spacing: 0.5em;
   }
 }
 
-.prologue-title {
-  font-size: clamp(1.2rem, 3vw, 1.8rem);
+.title-tagline {
+  font-size: clamp(0.9rem, 2vw, 1.4rem);
+  color: #888;
+  margin-top: 1rem;
+  font-style: italic;
+  animation: taglineFade 2s ease-out 1s both;
+}
+
+@keyframes taglineFade {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+
+.title-prompt {
+  margin-top: 3rem;
+  font-size: 1rem;
+  color: #666;
+  animation: promptPulse 2s ease-in-out infinite, promptFade 2s ease-out 1.5s both;
+}
+
+@keyframes promptFade {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+
+@keyframes promptPulse {
+  0%, 100% { opacity: 0.5; }
+  50% { opacity: 1; }
+}
+
+/* ============================================
+   NARRATIVE SCREEN
+   ============================================ */
+.narrative-screen {
+  animation: narrativeEnter 1s ease-out;
+}
+
+@keyframes narrativeEnter {
+  from {
+    opacity: 0;
+    transform: translateY(20px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+.scene-title {
+  font-size: clamp(1.2rem, 3vw, 2rem);
   color: #ffd700;
   margin-bottom: 2rem;
   font-weight: normal;
-  letter-spacing: 0.2em;
-  text-shadow: 0 0 10px rgba(255, 215, 0, 0.3);
+  letter-spacing: 0.3em;
+  text-shadow:
+    0 0 10px rgba(255, 215, 0, 0.4),
+    0 0 20px rgba(255, 215, 0, 0.2);
+  animation: sceneTitleGlow 3s ease-in-out infinite alternate;
 }
 
-.prologue-text {
-  font-size: clamp(1rem, 2.5vw, 1.3rem);
-  line-height: 1.8;
-  max-width: 600px;
+@keyframes sceneTitleGlow {
+  from { text-shadow: 0 0 10px rgba(255, 215, 0, 0.4); }
+  to { text-shadow: 0 0 20px rgba(255, 215, 0, 0.6), 0 0 40px rgba(255, 215, 0, 0.3); }
 }
 
-.prologue-text p {
+.narrative-text {
+  font-size: clamp(1rem, 2.5vw, 1.4rem);
+  line-height: 2;
+  max-width: 700px;
+}
+
+.narrative-line {
   margin: 0;
-  padding: 0.3em 0;
+  padding: 0.2em 0;
+  opacity: 0;
+  animation: lineReveal 0.6s ease-out forwards;
+  animation-delay: calc(var(--line-index, 0) * 0.1s);
 }
 
-.prologue-text p.empty-line {
-  height: 1em;
+@keyframes lineReveal {
+  from {
+    opacity: 0;
+    transform: translateY(10px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
 }
 
-.page-indicator {
-  margin-top: 2rem;
-  font-size: 0.85rem;
-  color: #666;
+.narrative-line.empty-line {
+  height: 0.8em;
 }
 
-/* Controls */
+/* ============================================
+   BEGIN ADVENTURE BUTTON
+   ============================================ */
+.begin-adventure-button {
+  margin-top: 3rem;
+  padding: 1rem 3rem;
+  font-size: 1.4rem;
+  font-weight: bold;
+  letter-spacing: 0.1em;
+  color: #ffd700;
+  background: linear-gradient(to bottom, rgba(80, 60, 20, 0.8), rgba(40, 30, 10, 0.9));
+  border: 2px solid #ffd700;
+  border-radius: 8px;
+  cursor: pointer;
+  text-shadow: 0 0 10px rgba(255, 215, 0, 0.5);
+  box-shadow:
+    0 0 20px rgba(255, 215, 0, 0.3),
+    inset 0 1px 0 rgba(255, 255, 255, 0.1);
+  transition: all 0.3s ease;
+  animation: buttonAppear 0.8s ease-out, buttonGlow 2s ease-in-out infinite alternate;
+}
+
+@keyframes buttonAppear {
+  from {
+    opacity: 0;
+    transform: translateY(20px) scale(0.9);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
+}
+
+@keyframes buttonGlow {
+  from {
+    box-shadow:
+      0 0 20px rgba(255, 215, 0, 0.3),
+      inset 0 1px 0 rgba(255, 255, 255, 0.1);
+  }
+  to {
+    box-shadow:
+      0 0 40px rgba(255, 215, 0, 0.5),
+      0 0 60px rgba(255, 215, 0, 0.2),
+      inset 0 1px 0 rgba(255, 255, 255, 0.1);
+  }
+}
+
+.begin-adventure-button:hover {
+  transform: scale(1.05);
+  background: linear-gradient(to bottom, rgba(100, 80, 30, 0.9), rgba(60, 45, 15, 0.95));
+  box-shadow:
+    0 0 50px rgba(255, 215, 0, 0.6),
+    0 0 80px rgba(255, 215, 0, 0.3),
+    inset 0 1px 0 rgba(255, 255, 255, 0.2);
+}
+
+.begin-adventure-button:active {
+  transform: scale(0.98);
+}
+
+/* When intro is complete, change cursor style */
+.game-intro.intro-complete {
+  cursor: default;
+}
+
+/* ============================================
+   PROGRESS INDICATOR
+   ============================================ */
+.scene-progress {
+  position: absolute;
+  bottom: 12vh;
+  left: 50%;
+  transform: translateX(-50%);
+  display: flex;
+  gap: 8px;
+  z-index: 20;
+}
+
+.progress-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: rgba(255, 255, 255, 0.2);
+  transition: all 0.3s ease;
+}
+
+.progress-dot.active {
+  background: #ffd700;
+  box-shadow: 0 0 10px rgba(255, 215, 0, 0.5);
+  transform: scale(1.2);
+}
+
+.progress-dot.complete {
+  background: rgba(255, 215, 0, 0.5);
+}
+
+/* ============================================
+   CONTROLS
+   ============================================ */
 .intro-controls {
-  padding: 2rem;
+  position: absolute;
+  bottom: 2vh;
+  left: 0;
+  right: 0;
+  padding: 0 2rem;
   display: flex;
   justify-content: space-between;
   align-items: center;
-  width: 100%;
-  max-width: 800px;
+  z-index: 20;
 }
 
 .control-hint {
   font-size: 0.9rem;
-  color: #666;
+  color: #555;
   animation: hintPulse 2s ease-in-out infinite;
 }
 
 @keyframes hintPulse {
-  0%, 100% {
-    opacity: 0.6;
-  }
-  50% {
-    opacity: 1;
-  }
+  0%, 100% { opacity: 0.5; }
+  50% { opacity: 0.8; }
 }
 
 .skip-button {
   background: transparent;
-  border: 1px solid rgba(255, 255, 255, 0.2);
-  color: #666;
+  border: 1px solid rgba(255, 255, 255, 0.15);
+  color: #555;
   padding: 0.5rem 1rem;
   font-size: 0.85rem;
   border-radius: 4px;
@@ -178,47 +807,53 @@
 }
 
 .skip-button:hover {
-  background: rgba(255, 255, 255, 0.1);
-  border-color: rgba(255, 255, 255, 0.4);
-  color: #aaa;
+  background: rgba(255, 255, 255, 0.05);
+  border-color: rgba(255, 255, 255, 0.3);
+  color: #888;
 }
 
-/* Responsive adjustments */
-@media (max-width: 600px) {
+/* ============================================
+   RESPONSIVE
+   ============================================ */
+@media (max-width: 768px) {
   .intro-content {
     padding: 1rem;
   }
 
   .title-art {
-    font-size: 0.45rem;
+    font-size: 0.4rem;
   }
 
   .title-subtitle {
     letter-spacing: 0.3em;
   }
 
+  .narrative-text {
+    font-size: 1rem;
+    line-height: 1.8;
+  }
+
+  .cinematic-bar {
+    height: 5vh;
+  }
+
+  .scene-progress {
+    bottom: 8vh;
+  }
+
   .intro-controls {
     flex-direction: column;
-    gap: 1rem;
+    gap: 0.5rem;
+    bottom: 1vh;
   }
 }
 
-/* Ambient background effect */
-.game-intro::before {
-  content: '';
-  position: absolute;
-  inset: 0;
-  background:
-    radial-gradient(ellipse at 50% 0%, rgba(255, 215, 0, 0.03) 0%, transparent 50%),
-    radial-gradient(ellipse at 50% 100%, rgba(100, 50, 0, 0.05) 0%, transparent 40%);
-  pointer-events: none;
-}
+@media (max-width: 480px) {
+  .title-art {
+    font-size: 0.32rem;
+  }
 
-/* Subtle vignette */
-.game-intro::after {
-  content: '';
-  position: absolute;
-  inset: 0;
-  background: radial-gradient(ellipse at center, transparent 40%, rgba(0, 0, 0, 0.4) 100%);
-  pointer-events: none;
+  .cinematic-bar {
+    height: 3vh;
+  }
 }

--- a/web/src/components/GameIntro.tsx
+++ b/web/src/components/GameIntro.tsx
@@ -1,8 +1,8 @@
 /**
- * GameIntro - Title screen and prologue overlay shown before starting the game.
- * Displays a cinematic introduction with the game logo and story pages.
+ * GameIntro - Cinematic intro with visual scenes, parallax backgrounds,
+ * animated particles, and typewriter text effects.
  */
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, useRef } from 'react';
 import './GameIntro.css';
 
 interface GameIntroProps {
@@ -10,6 +10,123 @@ interface GameIntroProps {
   onSkip?: () => void;
   onMusicChange?: (trackId: string) => void;
 }
+
+// Scene definitions with timing and content
+interface Scene {
+  id: string;
+  duration: number; // milliseconds
+  background: 'kingdom' | 'darkness' | 'underground' | 'depths' | 'entrance' | 'title';
+  title?: string;
+  lines: string[];
+  fadeStyle?: 'slow' | 'fast' | 'dramatic';
+}
+
+const SCENES: Scene[] = [
+  {
+    id: 'title',
+    duration: 5000,
+    background: 'title',
+    lines: [],
+    fadeStyle: 'slow',
+  },
+  {
+    id: 'kingdom',
+    duration: 8000,
+    background: 'kingdom',
+    title: 'THE KINGDOM OF VALDRIS',
+    lines: [
+      'In ages past, the kingdom of Valdris stood proud upon the mountain.',
+      '',
+      'Its towers reached toward the heavens,',
+      'its people prospered in the light.',
+    ],
+    fadeStyle: 'slow',
+  },
+  {
+    id: 'darkness',
+    duration: 9000,
+    background: 'darkness',
+    title: 'THE COMING DARKNESS',
+    lines: [
+      'Then came the Darkness...',
+      '',
+      'A shadow that devoured the sun,',
+      'twisted the land, and corrupted all it touched.',
+      '',
+      'The dead rose. The living fled.',
+    ],
+    fadeStyle: 'dramatic',
+  },
+  {
+    id: 'underground',
+    duration: 8000,
+    background: 'underground',
+    title: 'THE DESCENT',
+    lines: [
+      'The survivors retreated into the depths below.',
+      '',
+      'They sealed the entrances with ancient magic,',
+      'taking their treasures and their secrets with them.',
+      '',
+      'There, in the darkness, they waited...',
+    ],
+    fadeStyle: 'slow',
+  },
+  {
+    id: 'time',
+    duration: 6000,
+    background: 'depths',
+    title: 'CENTURIES PASS',
+    lines: [
+      'Generations lived and died in the underground halls.',
+      '',
+      'The world above became legend.',
+      'The seals began to weaken.',
+      '',
+      'And something ancient stirred in the deepest chambers...',
+    ],
+    fadeStyle: 'dramatic',
+  },
+  {
+    id: 'present',
+    duration: 8000,
+    background: 'entrance',
+    title: 'THE PRESENT DAY',
+    lines: [
+      'The entrance has been found.',
+      '',
+      'A gaping maw in the hillside,',
+      'breathing cold, stale air from forgotten depths.',
+      '',
+      'Treasure hunters came first. None returned.',
+      'Then mercenaries. Then heroes.',
+      '',
+      'All swallowed by the dark.',
+    ],
+    fadeStyle: 'slow',
+  },
+  {
+    id: 'you',
+    duration: 10000,
+    background: 'entrance',
+    title: 'YOUR STORY BEGINS',
+    lines: [
+      'Now you stand before the ancient gate.',
+      '',
+      'Gold? Glory? Redemption?',
+      'What drives you matters not to the depths.',
+      '',
+      'Only survival.',
+      '',
+      'Steel your nerves.',
+      'Ready your blade.',
+      'Light your torch.',
+      '',
+      'The dungeon awaits...',
+    ],
+    fadeStyle: 'dramatic',
+  },
+];
 
 const TITLE_ART = [
   '  ____                        _ _ _        ',
@@ -20,88 +137,134 @@ const TITLE_ART = [
   '             |___/                         ',
 ];
 
-const PROLOGUE_PAGES = [
-  {
-    title: 'PROLOGUE',
-    lines: [
-      'Long ago, the kingdom of Valdris flourished above these depths.',
-      '',
-      'When the Darkness came, the people fled underground,',
-      'sealing themselves in with their treasures and their dead.',
-      '',
-      'Centuries passed. The seals weakened.',
-      '',
-      'Now, something stirs below...',
-    ],
-  },
-  {
-    title: 'YOUR JOURNEY BEGINS',
-    lines: [
-      'You are an adventurer, drawn by rumors of gold and glory.',
-      '',
-      'The entrance to the ancient dungeons has been rediscovered,',
-      'a gaping maw in the hillside that breathes cold, stale air.',
-      '',
-      'Many have entered. None have returned.',
-      '',
-      'But you are different. You must be.',
-      '',
-      'Steel your nerves. Ready your blade.',
-      '',
-      'The depths await.',
-    ],
-  },
-];
+// Particle component for atmospheric effects
+function Particles({ type }: { type: 'embers' | 'dust' | 'darkness' | 'stars' }) {
+  const count = type === 'stars' ? 50 : type === 'embers' ? 30 : 20;
 
-type IntroPhase = 'title' | 'prologue';
+  return (
+    <div className={`particles particles-${type}`}>
+      {Array.from({ length: count }).map((_, i) => (
+        <div
+          key={i}
+          className="particle"
+          style={{
+            '--delay': `${Math.random() * 5}s`,
+            '--x': `${Math.random() * 100}%`,
+            '--y': `${Math.random() * 100}%`,
+            '--duration': `${3 + Math.random() * 4}s`,
+            '--size': `${2 + Math.random() * 4}px`,
+          } as React.CSSProperties}
+        />
+      ))}
+    </div>
+  );
+}
+
+// Pause duration at end of each scene before transitioning (ms)
+const SCENE_END_PAUSE = 3000;
 
 export function GameIntro({ onComplete, onSkip, onMusicChange }: GameIntroProps) {
-  const [phase, setPhase] = useState<IntroPhase>('title');
-  const [prologuePage, setProloguePage] = useState(0);
-  const [fadeIn, setFadeIn] = useState(false);
-  const [fadeOut, setFadeOut] = useState(false);
+  const [currentSceneIndex, setCurrentSceneIndex] = useState(0);
+  const [fadeState, setFadeState] = useState<'in' | 'visible' | 'out'>('in');
+  const [visibleLines, setVisibleLines] = useState<number>(0);
+  const [introComplete, setIntroComplete] = useState(false);
+  const timerRef = useRef<number | null>(null);
+  const lineTimerRef = useRef<number | null>(null);
+
+  const currentScene = SCENES[currentSceneIndex];
+  const isLastScene = currentSceneIndex === SCENES.length - 1;
 
   // Trigger intro music on mount
   useEffect(() => {
     onMusicChange?.('intro');
   }, [onMusicChange]);
 
-  // Fade in on mount
+  // Scene progression
   useEffect(() => {
-    const timer = setTimeout(() => setFadeIn(true), 50);
-    return () => clearTimeout(timer);
-  }, []);
+    // Don't run scene progression if intro is complete (waiting for button click)
+    if (introComplete) return;
+
+    // Clear any existing timers
+    if (timerRef.current) clearTimeout(timerRef.current);
+    if (lineTimerRef.current) clearTimeout(lineTimerRef.current);
+
+    // Fade in
+    setFadeState('in');
+    setVisibleLines(0);
+
+    const fadeInDuration = currentScene.fadeStyle === 'dramatic' ? 1500 : 800;
+    const fadeDuration = 800;
+
+    // After fade in, show content
+    timerRef.current = window.setTimeout(() => {
+      setFadeState('visible');
+
+      // Progressively reveal lines
+      if (currentScene.lines.length > 0) {
+        let lineIndex = 0;
+        const revealNextLine = () => {
+          if (lineIndex < currentScene.lines.length) {
+            setVisibleLines(lineIndex + 1);
+            lineIndex++;
+            lineTimerRef.current = window.setTimeout(revealNextLine, 600);
+          }
+        };
+        lineTimerRef.current = window.setTimeout(revealNextLine, 500);
+      }
+
+      // After duration + pause, fade out and advance (unless last scene)
+      if (!isLastScene) {
+        timerRef.current = window.setTimeout(() => {
+          setFadeState('out');
+
+          timerRef.current = window.setTimeout(() => {
+            setCurrentSceneIndex((i) => i + 1);
+          }, fadeDuration);
+        }, currentScene.duration + SCENE_END_PAUSE);
+      } else {
+        // Last scene: after content is shown, wait then show the begin button
+        timerRef.current = window.setTimeout(() => {
+          setIntroComplete(true);
+        }, currentScene.duration + SCENE_END_PAUSE);
+      }
+    }, fadeInDuration);
+
+    return () => {
+      if (timerRef.current) clearTimeout(timerRef.current);
+      if (lineTimerRef.current) clearTimeout(lineTimerRef.current);
+    };
+  }, [currentSceneIndex, currentScene, isLastScene, introComplete]);
 
   const handleAdvance = useCallback(() => {
-    if (fadeOut) return; // Prevent double-clicks during transition
+    // If intro is complete, don't allow advancing with space/click
+    // User must click the Begin button
+    if (introComplete) return;
 
-    if (phase === 'title') {
-      // Transition from title to prologue
-      setFadeOut(true);
+    if (timerRef.current) clearTimeout(timerRef.current);
+    if (lineTimerRef.current) clearTimeout(lineTimerRef.current);
+
+    if (currentSceneIndex < SCENES.length - 1) {
+      setFadeState('out');
       setTimeout(() => {
-        setPhase('prologue');
-        setFadeOut(false);
+        setCurrentSceneIndex((i) => i + 1);
       }, 300);
-    } else if (phase === 'prologue') {
-      if (prologuePage < PROLOGUE_PAGES.length - 1) {
-        // Next prologue page
-        setFadeOut(true);
-        setTimeout(() => {
-          setProloguePage((p) => p + 1);
-          setFadeOut(false);
-        }, 300);
-      } else {
-        // Complete intro
-        setFadeOut(true);
-        setTimeout(() => {
-          onComplete();
-        }, 500);
-      }
+    } else {
+      // On last scene, skip to showing the begin button
+      setIntroComplete(true);
     }
-  }, [phase, prologuePage, fadeOut, onComplete]);
+  }, [currentSceneIndex, introComplete]);
+
+  const handleBeginAdventure = useCallback(() => {
+    if (timerRef.current) clearTimeout(timerRef.current);
+    if (lineTimerRef.current) clearTimeout(lineTimerRef.current);
+    onComplete();
+  }, [onComplete]);
 
   const handleSkip = useCallback(() => {
-    setFadeOut(true);
+    if (timerRef.current) clearTimeout(timerRef.current);
+    if (lineTimerRef.current) clearTimeout(lineTimerRef.current);
+
+    setFadeState('out');
     setTimeout(() => {
       if (onSkip) {
         onSkip();
@@ -118,58 +281,134 @@ export function GameIntro({ onComplete, onSkip, onMusicChange }: GameIntroProps)
         handleSkip();
       } else if (e.key === ' ' || e.key === 'Enter') {
         e.preventDefault();
-        handleAdvance();
+        if (introComplete) {
+          handleBeginAdventure();
+        } else {
+          handleAdvance();
+        }
       }
     };
 
     window.addEventListener('keydown', handleKeyDown);
     return () => window.removeEventListener('keydown', handleKeyDown);
-  }, [handleAdvance, handleSkip]);
+  }, [handleAdvance, handleSkip, handleBeginAdventure, introComplete]);
 
-  const currentPage = PROLOGUE_PAGES[prologuePage];
-  const isLastPage = phase === 'prologue' && prologuePage === PROLOGUE_PAGES.length - 1;
+  // Get particle type based on background
+  const getParticleType = () => {
+    switch (currentScene.background) {
+      case 'kingdom':
+      case 'title':
+        return 'stars';
+      case 'darkness':
+        return 'darkness';
+      case 'underground':
+      case 'depths':
+        return 'dust';
+      case 'entrance':
+        return 'embers';
+      default:
+        return 'dust';
+    }
+  };
 
   return (
     <div
-      className={`game-intro ${fadeIn ? 'fade-in' : ''} ${fadeOut ? 'fade-out' : ''}`}
-      onClick={handleAdvance}
+      className={`game-intro scene-${currentScene.background} fade-${fadeState} ${introComplete ? 'intro-complete' : ''}`}
+      onClick={introComplete ? undefined : handleAdvance}
     >
-      <div className="intro-content">
-        {phase === 'title' && (
-          <div className="title-screen">
-            <pre className="title-art">{TITLE_ART.join('\n')}</pre>
-            <div className="title-subtitle">DUNGEON CRAWLER</div>
-            <div className="title-tagline">A Terminal Adventure</div>
-          </div>
-        )}
-
-        {phase === 'prologue' && (
-          <div className="prologue-screen">
-            <h2 className="prologue-title">~ {currentPage.title} ~</h2>
-            <div className="prologue-text">
-              {currentPage.lines.map((line, i) => (
-                <p key={i} className={line === '' ? 'empty-line' : ''}>
-                  {line}
-                </p>
-              ))}
-            </div>
-            <div className="page-indicator">
-              Page {prologuePage + 1} of {PROLOGUE_PAGES.length}
-            </div>
-          </div>
-        )}
+      {/* Background layers */}
+      <div className="scene-background">
+        <div className="bg-layer bg-far" />
+        <div className="bg-layer bg-mid" />
+        <div className="bg-layer bg-near" />
       </div>
 
+      {/* Particles */}
+      <Particles type={getParticleType()} />
+
+      {/* Ambient overlay */}
+      <div className="ambient-overlay" />
+
+      {/* Content wrapper - this fades, not the whole component */}
+      <div className={`intro-content-wrapper ${fadeState === 'out' ? 'content-fade-out' : ''}`}>
+        {/* Content */}
+        <div className="intro-content">
+          {currentScene.background === 'title' ? (
+            <div className="title-screen">
+              <pre className="title-art">{TITLE_ART.join('\n')}</pre>
+              <div className="title-subtitle">DUNGEON CRAWLER</div>
+              <div className="title-tagline">A Tale of Darkness and Treasure</div>
+              <div className="title-prompt">Press SPACE to begin...</div>
+            </div>
+          ) : (
+            <div className="narrative-screen">
+              {currentScene.title && (
+                <h2 className="scene-title">{currentScene.title}</h2>
+              )}
+              <div className="narrative-text">
+                {currentScene.lines.slice(0, visibleLines).map((line, i) => (
+                  <p
+                    key={i}
+                    className={`narrative-line ${line === '' ? 'empty-line' : ''}`}
+                    style={{ '--line-index': i } as React.CSSProperties}
+                  >
+                    {line}
+                  </p>
+                ))}
+              </div>
+
+              {/* Begin Adventure button - shown after last scene completes */}
+              {introComplete && (
+                <button
+                  className="begin-adventure-button"
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    handleBeginAdventure();
+                  }}
+                >
+                  Begin Your Adventure
+                </button>
+              )}
+            </div>
+          )}
+        </div>
+      </div>
+
+      {/* Progress indicator */}
+      <div className="scene-progress">
+        {SCENES.map((_, i) => (
+          <div
+            key={i}
+            className={`progress-dot ${i === currentSceneIndex ? 'active' : ''} ${i < currentSceneIndex ? 'complete' : ''}`}
+          />
+        ))}
+      </div>
+
+      {/* Controls */}
       <div className="intro-controls">
-        <span className="control-hint">
-          {isLastPage
-            ? 'Press SPACE or ENTER to begin your adventure...'
-            : 'Press SPACE or ENTER to continue'}
-        </span>
-        <button className="skip-button" onClick={(e) => { e.stopPropagation(); handleSkip(); }}>
-          Skip (ESC)
+        {introComplete ? (
+          <span className="control-hint">Click the button or press ENTER to continue</span>
+        ) : (
+          <span className="control-hint">
+            {isLastScene
+              ? 'The dungeon awaits...'
+              : 'Press SPACE to continue'}
+          </span>
+        )}
+        <button
+          className="skip-button"
+          onClick={(e) => {
+            e.stopPropagation();
+            handleSkip();
+          }}
+        >
+          Skip Intro (ESC)
         </button>
       </div>
+
+      {/* Cinematic bars */}
+      <div className="cinematic-bar top" />
+      <div className="cinematic-bar bottom" />
     </div>
   );
 }

--- a/web/src/components/SceneRenderer/FirstPersonRenderer3D.tsx
+++ b/web/src/components/SceneRenderer/FirstPersonRenderer3D.tsx
@@ -55,7 +55,6 @@ interface FirstPersonRenderer3DProps {
 // Check tile types
 const isWallTile = (tile: string) => tile === '#';
 const isDoorTile = (tile: string) => tile === 'D' || tile === 'd' || tile === '+';
-const isFloorTile = (tile: string) => tile === '.' || tile === '>' || tile === '<';
 
 export function FirstPersonRenderer3D({
   view,

--- a/web/src/pages/Play.css
+++ b/web/src/pages/Play.css
@@ -98,6 +98,7 @@
 .scene-wrapper {
   flex: 1;
   min-width: 0;
+  min-height: 0;
   border: 1px solid #333;
   border-radius: 8px;
   overflow: hidden;
@@ -107,9 +108,7 @@
 }
 
 .scene-wrapper canvas {
-  width: 100%;
-  height: 100%;
-  object-fit: contain;
+  display: block;
 }
 
 .game-controls {

--- a/web/src/pages/Play.tsx
+++ b/web/src/pages/Play.tsx
@@ -49,6 +49,31 @@ export function Play() {
   } = useDebugRenderer();
   const corridorInfoRef = useRef<CorridorInfoEntry[]>([]);
 
+  // Track scene container size for responsive renderer
+  const sceneContainerRef = useRef<HTMLDivElement>(null);
+  const [sceneSize, setSceneSize] = useState({ width: 800, height: 600 });
+
+  useEffect(() => {
+    const container = sceneContainerRef.current;
+    if (!container) return;
+
+    const updateSize = () => {
+      const rect = container.getBoundingClientRect();
+      if (rect.width > 0 && rect.height > 0) {
+        setSceneSize({ width: rect.width, height: rect.height });
+      }
+    };
+
+    // Initial size
+    updateSize();
+
+    // Watch for resize
+    const observer = new ResizeObserver(updateSize);
+    observer.observe(container);
+
+    return () => observer.disconnect();
+  }, [showSceneView]);
+
   // Audio management
   const { crossfadeTo, isUnlocked, unlockAudio } = useAudioManager();
   const lastLevelRef = useRef<number | null>(null);
@@ -342,20 +367,20 @@ export function Play() {
             </div>
 
             {showSceneView && (
-              <div className="scene-wrapper">
+              <div className="scene-wrapper" ref={sceneContainerRef}>
                 {use3DMode ? (
                   <FirstPersonRenderer3D
                     view={gameState?.first_person_view}
                     settings={{ biome: 'dungeon', useTileGrid }}
-                    width={800}
-                    height={600}
+                    width={sceneSize.width}
+                    height={sceneSize.height}
                   />
                 ) : (
                   <FirstPersonRenderer
                     view={gameState?.first_person_view}
                     settings={{ biome: 'dungeon', useTileGrid }}
-                    width={800}
-                    height={600}
+                    width={sceneSize.width}
+                    height={sceneSize.height}
                     enableAnimations={true}
                     debugShowWireframe={showWireframe}
                     debugShowOccluded={showOccluded}


### PR DESCRIPTION
## Summary
- Enhanced cinematic intro with 7 narrative scenes, parallax backgrounds, and particle effects
- Fixed scene transitions to maintain solid black background (no character creation bleed-through)
- Added 3-second pause at end of each scene and "Begin Your Adventure" button
- Made 3D/2D renderers responsive to fill 100% of their container

## Changes
- **GameIntro.tsx/css**: Complete overhaul with scene system, particles, parallax layers
- **Play.tsx/css**: Added ResizeObserver for responsive renderer sizing
- **FirstPersonRenderer3D.tsx**: Removed unused variable

## Test plan
- [ ] Watch full intro - scenes should transition smoothly with solid black between
- [ ] Skip intro with ESC - should work at any point
- [ ] Final scene shows "Begin Your Adventure" button
- [ ] 3D view fills available space and resizes with window

🤖 Generated with [Claude Code](https://claude.com/claude-code)