### PR TITLE
feat: Database Explorer dev tool + Changelog styling

### DIFF
--- a/server/app/api/dbexplorer.py
+++ b/server/app/api/dbexplorer.py
@@ -1,0 +1,284 @@
+"""
+Database Explorer API - Dev tool for browsing database contents.
+
+SECURITY: Only available when DEBUG=true. Read-only queries only.
+"""
+from typing import Any
+from fastapi import APIRouter, Depends, HTTPException, Query
+from sqlalchemy import text, inspect
+from sqlalchemy.ext.asyncio import AsyncSession
+from pydantic import BaseModel
+
+from ..core.config import settings
+from ..core.database import get_db, engine
+
+router = APIRouter(prefix="/api/db", tags=["database-explorer"])
+
+
+# Pydantic models for responses
+class TableInfo(BaseModel):
+    name: str
+    row_count: int
+
+
+class ColumnInfo(BaseModel):
+    name: str
+    type: str
+    nullable: bool
+    default: str | None
+    primary_key: bool
+
+
+class TableSchema(BaseModel):
+    name: str
+    columns: list[ColumnInfo]
+    primary_keys: list[str]
+    foreign_keys: list[dict[str, Any]]
+    indexes: list[dict[str, Any]]
+
+
+class QueryRequest(BaseModel):
+    sql: str
+
+
+class QueryResult(BaseModel):
+    columns: list[str]
+    rows: list[list[Any]]
+    row_count: int
+    truncated: bool
+
+
+def require_debug():
+    """Dependency that blocks access unless DEBUG mode is enabled."""
+    if not settings.debug:
+        raise HTTPException(
+            status_code=403,
+            detail="Database explorer is only available in debug mode"
+        )
+
+
+@router.get("/tables", response_model=list[TableInfo])
+async def list_tables(
+    db: AsyncSession = Depends(get_db),
+    _: None = Depends(require_debug),
+):
+    """List all tables with row counts."""
+    # Get table names using inspector
+    def get_tables(connection):
+        inspector = inspect(connection)
+        return inspector.get_table_names()
+
+    async with engine.connect() as conn:
+        table_names = await conn.run_sync(get_tables)
+
+    # Get row counts for each table
+    tables = []
+    for table_name in sorted(table_names):
+        result = await db.execute(
+            text(f'SELECT COUNT(*) FROM "{table_name}"')
+        )
+        count = result.scalar() or 0
+        tables.append(TableInfo(name=table_name, row_count=count))
+
+    return tables
+
+
+@router.get("/tables/{table_name}/schema", response_model=TableSchema)
+async def get_table_schema(
+    table_name: str,
+    _: None = Depends(require_debug),
+):
+    """Get schema details for a specific table."""
+    def get_schema(connection):
+        inspector = inspect(connection)
+
+        # Verify table exists
+        if table_name not in inspector.get_table_names():
+            return None
+
+        # Get columns
+        columns = []
+        for col in inspector.get_columns(table_name):
+            columns.append(ColumnInfo(
+                name=col["name"],
+                type=str(col["type"]),
+                nullable=col.get("nullable", True),
+                default=str(col.get("default")) if col.get("default") else None,
+                primary_key=False,  # Will be set below
+            ))
+
+        # Get primary keys
+        pk_constraint = inspector.get_pk_constraint(table_name)
+        pk_columns = pk_constraint.get("constrained_columns", []) if pk_constraint else []
+
+        # Mark primary key columns
+        for col in columns:
+            col.primary_key = col.name in pk_columns
+
+        # Get foreign keys
+        fks = []
+        for fk in inspector.get_foreign_keys(table_name):
+            fks.append({
+                "columns": fk.get("constrained_columns", []),
+                "referred_table": fk.get("referred_table"),
+                "referred_columns": fk.get("referred_columns", []),
+            })
+
+        # Get indexes
+        indexes = []
+        for idx in inspector.get_indexes(table_name):
+            indexes.append({
+                "name": idx.get("name"),
+                "columns": idx.get("column_names", []),
+                "unique": idx.get("unique", False),
+            })
+
+        return TableSchema(
+            name=table_name,
+            columns=columns,
+            primary_keys=pk_columns,
+            foreign_keys=fks,
+            indexes=indexes,
+        )
+
+    async with engine.connect() as conn:
+        schema = await conn.run_sync(get_schema)
+
+    if schema is None:
+        raise HTTPException(status_code=404, detail=f"Table '{table_name}' not found")
+
+    return schema
+
+
+@router.get("/tables/{table_name}/data")
+async def get_table_data(
+    table_name: str,
+    db: AsyncSession = Depends(get_db),
+    _: None = Depends(require_debug),
+    page: int = Query(1, ge=1),
+    page_size: int = Query(50, ge=1, le=500),
+    order_by: str | None = None,
+    order_dir: str = Query("asc", pattern="^(asc|desc)$"),
+):
+    """Get paginated data from a table."""
+    # Verify table exists
+    def check_table(connection):
+        inspector = inspect(connection)
+        return table_name in inspector.get_table_names()
+
+    async with engine.connect() as conn:
+        exists = await conn.run_sync(check_table)
+
+    if not exists:
+        raise HTTPException(status_code=404, detail=f"Table '{table_name}' not found")
+
+    # Build query with pagination
+    offset = (page - 1) * page_size
+
+    # Get total count
+    count_result = await db.execute(
+        text(f'SELECT COUNT(*) FROM "{table_name}"')
+    )
+    total_count = count_result.scalar() or 0
+
+    # Build data query
+    order_clause = ""
+    if order_by:
+        # Sanitize order_by to prevent injection
+        order_clause = f' ORDER BY "{order_by}" {order_dir.upper()}'
+
+    query = text(
+        f'SELECT * FROM "{table_name}"{order_clause} LIMIT :limit OFFSET :offset'
+    )
+    result = await db.execute(query, {"limit": page_size, "offset": offset})
+
+    # Get column names and rows
+    columns = list(result.keys())
+    rows = []
+    for row in result.fetchall():
+        # Convert row to list, handling special types
+        row_data = []
+        for val in row:
+            if val is None:
+                row_data.append(None)
+            elif isinstance(val, (dict, list)):
+                row_data.append(val)
+            else:
+                row_data.append(str(val) if not isinstance(val, (int, float, bool)) else val)
+        rows.append(row_data)
+
+    return {
+        "columns": columns,
+        "rows": rows,
+        "total_count": total_count,
+        "page": page,
+        "page_size": page_size,
+        "total_pages": (total_count + page_size - 1) // page_size,
+    }
+
+
+@router.post("/query", response_model=QueryResult)
+async def execute_query(
+    request: QueryRequest,
+    db: AsyncSession = Depends(get_db),
+    _: None = Depends(require_debug),
+):
+    """
+    Execute a read-only SQL query.
+
+    Only SELECT statements are allowed. Results are limited to 1000 rows.
+    """
+    sql = request.sql.strip()
+
+    # Security: Only allow SELECT statements
+    sql_upper = sql.upper()
+    if not sql_upper.startswith("SELECT"):
+        raise HTTPException(
+            status_code=400,
+            detail="Only SELECT queries are allowed"
+        )
+
+    # Block dangerous keywords
+    dangerous = ["INSERT", "UPDATE", "DELETE", "DROP", "CREATE", "ALTER", "TRUNCATE", "GRANT", "REVOKE"]
+    for keyword in dangerous:
+        if keyword in sql_upper:
+            raise HTTPException(
+                status_code=400,
+                detail=f"Query contains forbidden keyword: {keyword}"
+            )
+
+    try:
+        result = await db.execute(text(sql))
+        columns = list(result.keys())
+
+        # Limit results
+        max_rows = 1000
+        rows = []
+        truncated = False
+
+        for i, row in enumerate(result.fetchall()):
+            if i >= max_rows:
+                truncated = True
+                break
+            row_data = []
+            for val in row:
+                if val is None:
+                    row_data.append(None)
+                elif isinstance(val, (dict, list)):
+                    row_data.append(val)
+                else:
+                    row_data.append(str(val) if not isinstance(val, (int, float, bool)) else val)
+            rows.append(row_data)
+
+        return QueryResult(
+            columns=columns,
+            rows=rows,
+            row_count=len(rows),
+            truncated=truncated,
+        )
+
+    except Exception as e:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Query error: {str(e)}"
+        )

--- a/server/app/main.py
+++ b/server/app/main.py
@@ -16,6 +16,7 @@ from .api.profile import router as profile_router
 from .api.friends import router as friends_router
 from .api.saves import router as saves_router
 from .api.daily import router as daily_router
+from .api.dbexplorer import router as dbexplorer_router
 
 
 @asynccontextmanager
@@ -73,6 +74,7 @@ def create_app() -> FastAPI:
     app.include_router(friends_router)
     app.include_router(saves_router)
     app.include_router(daily_router, prefix="/api")
+    app.include_router(dbexplorer_router, tags=["dev-tools"])
 
     return app
 

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,6 +1,6 @@
 import { Routes, Route } from 'react-router-dom';
 import { Layout } from './components/Layout';
-import { Home, Login, Register, Play, Features, About, PlayScene, SceneDemo, Leaderboard, Ghosts, Profile, Achievements, Spectate, Friends, Presentation, Roadmap, CodebaseHealth, Changelog } from './pages';
+import { Home, Login, Register, Play, Features, About, PlayScene, SceneDemo, Leaderboard, Ghosts, Profile, Achievements, Spectate, Friends, Presentation, Roadmap, CodebaseHealth, Changelog, DatabaseExplorer } from './pages';
 import { FirstPersonDemo } from './pages/FirstPersonDemo';
 import { FirstPersonTestPage } from './pages/FirstPersonTestPage';
 import { Debug3DPage } from './pages/Debug3DPage';
@@ -33,6 +33,7 @@ function App() {
         <Route path="roadmap" element={<Roadmap />} />
         <Route path="codebase-health" element={<CodebaseHealth />} />
         <Route path="changelog" element={<Changelog />} />
+        <Route path="db-explorer" element={<DatabaseExplorer />} />
       </Route>
     </Routes>
   );

--- a/web/src/components/Layout.tsx
+++ b/web/src/components/Layout.tsx
@@ -85,6 +85,10 @@ export function Layout() {
                     <span className="menu-icon">📋</span>
                     Patch Notes
                   </Link>
+                  <Link to="/db-explorer" onClick={closeDropdown}>
+                    <span className="menu-icon">🗄️</span>
+                    DB Explorer
+                  </Link>
                 </div>
               )}
             </div>

--- a/web/src/pages/Changelog.css
+++ b/web/src/pages/Changelog.css
@@ -18,9 +18,23 @@
 }
 
 .changelog-stats {
-  margin-top: 1rem;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  gap: 1rem;
+  margin-top: 1.25rem;
   font-size: 0.9rem;
   color: rgba(255, 255, 255, 0.6);
+}
+
+.changelog-stats .stat {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.4rem 0.8rem;
+  background: rgba(255, 255, 255, 0.05);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 20px;
 }
 
 .changelog-stats .stat-value {
@@ -29,8 +43,7 @@
 }
 
 .changelog-stats .stat-sep {
-  margin: 0 0.75rem;
-  opacity: 0.4;
+  display: none;
 }
 
 /* Controls */

--- a/web/src/pages/DatabaseExplorer.css
+++ b/web/src/pages/DatabaseExplorer.css
@@ -1,0 +1,472 @@
+/**
+ * Database Explorer Styles
+ */
+
+.db-explorer {
+  display: flex;
+  height: 100vh;
+  background: #0d1117;
+  color: #e6edf3;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+}
+
+/* Sidebar */
+.db-sidebar {
+  width: 260px;
+  min-width: 260px;
+  background: #161b22;
+  border-right: 1px solid #30363d;
+  display: flex;
+  flex-direction: column;
+}
+
+.sidebar-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 1rem;
+  border-bottom: 1px solid #30363d;
+}
+
+.sidebar-header h2 {
+  margin: 0;
+  font-size: 0.9rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  color: #8b949e;
+}
+
+.refresh-btn {
+  background: none;
+  border: none;
+  color: #8b949e;
+  font-size: 1.2rem;
+  cursor: pointer;
+  padding: 0.25rem 0.5rem;
+  border-radius: 4px;
+  transition: all 0.15s;
+}
+
+.refresh-btn:hover {
+  background: #30363d;
+  color: #e6edf3;
+}
+
+.sidebar-loading,
+.sidebar-error {
+  padding: 1rem;
+  font-size: 0.85rem;
+  color: #8b949e;
+}
+
+.sidebar-error {
+  color: #f85149;
+}
+
+.table-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  overflow-y: auto;
+  flex: 1;
+}
+
+.table-item {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 0.6rem 1rem;
+  cursor: pointer;
+  border-left: 3px solid transparent;
+  transition: all 0.15s;
+}
+
+.table-item:hover {
+  background: #21262d;
+}
+
+.table-item.selected {
+  background: #1f6feb22;
+  border-left-color: #58a6ff;
+}
+
+.table-name {
+  font-size: 0.9rem;
+  font-family: 'JetBrains Mono', 'Fira Code', monospace;
+}
+
+.table-count {
+  font-size: 0.75rem;
+  color: #8b949e;
+  background: #30363d;
+  padding: 0.15rem 0.5rem;
+  border-radius: 10px;
+}
+
+/* Main Content */
+.db-main {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.db-empty {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  height: 100%;
+  color: #8b949e;
+  text-align: center;
+}
+
+.empty-icon {
+  font-size: 4rem;
+  margin-bottom: 1rem;
+}
+
+.db-empty h2 {
+  margin: 0 0 0.5rem;
+  color: #e6edf3;
+}
+
+.db-empty p {
+  margin: 0;
+  font-size: 0.95rem;
+}
+
+/* Header */
+.db-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 1rem 1.5rem;
+  border-bottom: 1px solid #30363d;
+  background: #161b22;
+}
+
+.db-header h1 {
+  margin: 0;
+  font-size: 1.25rem;
+  font-family: 'JetBrains Mono', 'Fira Code', monospace;
+  color: #58a6ff;
+}
+
+.db-tabs {
+  display: flex;
+  gap: 0.25rem;
+}
+
+.db-tabs .tab-btn {
+  padding: 0.5rem 1rem;
+  background: transparent;
+  border: none;
+  color: #8b949e;
+  font-size: 0.9rem;
+  cursor: pointer;
+  border-radius: 6px;
+  transition: all 0.15s;
+}
+
+.db-tabs .tab-btn:hover {
+  background: #21262d;
+  color: #e6edf3;
+}
+
+.db-tabs .tab-btn.active {
+  background: #1f6feb;
+  color: #fff;
+}
+
+/* Error Banner */
+.error-banner {
+  padding: 0.75rem 1.5rem;
+  background: #f8514922;
+  border-bottom: 1px solid #f85149;
+  color: #f85149;
+  font-size: 0.9rem;
+}
+
+/* Schema View */
+.schema-view {
+  flex: 1;
+  overflow-y: auto;
+  padding: 1.5rem;
+}
+
+.schema-section {
+  margin-bottom: 2rem;
+}
+
+.schema-section h3 {
+  margin: 0 0 0.75rem;
+  font-size: 0.85rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  color: #8b949e;
+}
+
+.schema-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.9rem;
+}
+
+.schema-table th,
+.schema-table td {
+  padding: 0.6rem 0.75rem;
+  text-align: left;
+  border-bottom: 1px solid #30363d;
+}
+
+.schema-table th {
+  background: #161b22;
+  font-weight: 600;
+  font-size: 0.8rem;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  color: #8b949e;
+}
+
+.schema-table tr:hover {
+  background: #161b22;
+}
+
+.schema-table .pk-row {
+  background: #1f6feb11;
+}
+
+.col-name {
+  font-family: 'JetBrains Mono', 'Fira Code', monospace;
+  color: #58a6ff;
+}
+
+.col-type {
+  font-family: 'JetBrains Mono', 'Fira Code', monospace;
+  color: #7ee787;
+}
+
+.col-nullable {
+  color: #8b949e;
+}
+
+.col-default {
+  color: #8b949e;
+  font-family: 'JetBrains Mono', 'Fira Code', monospace;
+  font-size: 0.85rem;
+}
+
+.col-key {
+  font-size: 0.8rem;
+}
+
+/* Data View */
+.data-view {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  padding: 1rem 1.5rem;
+}
+
+.data-loading {
+  padding: 2rem;
+  text-align: center;
+  color: #8b949e;
+}
+
+.data-info {
+  margin-bottom: 0.75rem;
+  font-size: 0.85rem;
+  color: #8b949e;
+}
+
+.data-table-container {
+  flex: 1;
+  overflow: auto;
+  border: 1px solid #30363d;
+  border-radius: 6px;
+}
+
+.data-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.85rem;
+  font-family: 'JetBrains Mono', 'Fira Code', monospace;
+}
+
+.data-table th,
+.data-table td {
+  padding: 0.5rem 0.75rem;
+  text-align: left;
+  border-bottom: 1px solid #21262d;
+  white-space: nowrap;
+  max-width: 300px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.data-table th {
+  background: #161b22;
+  font-weight: 600;
+  font-size: 0.8rem;
+  color: #8b949e;
+  position: sticky;
+  top: 0;
+  z-index: 1;
+}
+
+.data-table tr:hover {
+  background: #161b22;
+}
+
+.data-table .null-cell {
+  color: #6e7681;
+  font-style: italic;
+}
+
+/* Pagination */
+.pagination {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  padding: 1rem 0;
+}
+
+.pagination button {
+  padding: 0.4rem 0.75rem;
+  background: #21262d;
+  border: 1px solid #30363d;
+  color: #e6edf3;
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 0.85rem;
+  transition: all 0.15s;
+}
+
+.pagination button:hover:not(:disabled) {
+  background: #30363d;
+}
+
+.pagination button:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.page-info {
+  padding: 0 1rem;
+  font-size: 0.85rem;
+  color: #8b949e;
+}
+
+/* Query View */
+.query-view {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  padding: 1rem 1.5rem;
+}
+
+.query-editor {
+  margin-bottom: 1rem;
+}
+
+.query-editor textarea {
+  width: 100%;
+  height: 120px;
+  padding: 0.75rem;
+  background: #0d1117;
+  border: 1px solid #30363d;
+  border-radius: 6px;
+  color: #e6edf3;
+  font-family: 'JetBrains Mono', 'Fira Code', monospace;
+  font-size: 0.9rem;
+  resize: vertical;
+}
+
+.query-editor textarea:focus {
+  outline: none;
+  border-color: #58a6ff;
+}
+
+.query-actions {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  margin-top: 0.75rem;
+}
+
+.execute-btn {
+  padding: 0.6rem 1.25rem;
+  background: #238636;
+  border: none;
+  color: #fff;
+  font-size: 0.9rem;
+  font-weight: 500;
+  border-radius: 6px;
+  cursor: pointer;
+  transition: background 0.15s;
+}
+
+.execute-btn:hover:not(:disabled) {
+  background: #2ea043;
+}
+
+.execute-btn:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.query-hint {
+  font-size: 0.8rem;
+  color: #8b949e;
+}
+
+.query-error {
+  padding: 0.75rem 1rem;
+  background: #f8514922;
+  border: 1px solid #f85149;
+  border-radius: 6px;
+  color: #f85149;
+  font-size: 0.9rem;
+  margin-bottom: 1rem;
+}
+
+.query-result {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.result-info {
+  margin-bottom: 0.75rem;
+  font-size: 0.85rem;
+  color: #8b949e;
+}
+
+/* Responsive */
+@media (max-width: 768px) {
+  .db-explorer {
+    flex-direction: column;
+  }
+
+  .db-sidebar {
+    width: 100%;
+    min-width: 100%;
+    max-height: 200px;
+    border-right: none;
+    border-bottom: 1px solid #30363d;
+  }
+
+  .db-header {
+    flex-direction: column;
+    gap: 0.75rem;
+    align-items: flex-start;
+  }
+}

--- a/web/src/pages/DatabaseExplorer.tsx
+++ b/web/src/pages/DatabaseExplorer.tsx
@@ -1,0 +1,468 @@
+/**
+ * Database Explorer - Dev tool for browsing database contents
+ *
+ * Features:
+ * - Table list with row counts
+ * - Schema viewer (columns, types, keys)
+ * - Data browser with pagination
+ * - Read-only SQL query runner
+ */
+
+import { useState, useEffect, useCallback } from 'react';
+import './DatabaseExplorer.css';
+
+const API_BASE = 'http://localhost:8000/api/db';
+
+interface TableInfo {
+  name: string;
+  row_count: number;
+}
+
+interface ColumnInfo {
+  name: string;
+  type: string;
+  nullable: boolean;
+  default: string | null;
+  primary_key: boolean;
+}
+
+interface TableSchema {
+  name: string;
+  columns: ColumnInfo[];
+  primary_keys: string[];
+  foreign_keys: { columns: string[]; referred_table: string; referred_columns: string[] }[];
+  indexes: { name: string; columns: string[]; unique: boolean }[];
+}
+
+interface TableData {
+  columns: string[];
+  rows: (string | number | boolean | null)[][];
+  total_count: number;
+  page: number;
+  page_size: number;
+  total_pages: number;
+}
+
+interface QueryResult {
+  columns: string[];
+  rows: (string | number | boolean | null)[][];
+  row_count: number;
+  truncated: boolean;
+}
+
+type TabType = 'schema' | 'data' | 'query';
+
+export function DatabaseExplorer() {
+  const [tables, setTables] = useState<TableInfo[]>([]);
+  const [selectedTable, setSelectedTable] = useState<string | null>(null);
+  const [schema, setSchema] = useState<TableSchema | null>(null);
+  const [data, setData] = useState<TableData | null>(null);
+  const [activeTab, setActiveTab] = useState<TabType>('schema');
+  const [page, setPage] = useState(1);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  // Query state
+  const [query, setQuery] = useState('SELECT * FROM users LIMIT 10');
+  const [queryResult, setQueryResult] = useState<QueryResult | null>(null);
+  const [queryError, setQueryError] = useState<string | null>(null);
+  const [queryLoading, setQueryLoading] = useState(false);
+
+  // Fetch tables on mount
+  useEffect(() => {
+    fetchTables();
+  }, []);
+
+  const fetchTables = async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await fetch(`${API_BASE}/tables`);
+      if (!res.ok) {
+        const err = await res.json();
+        throw new Error(err.detail || 'Failed to fetch tables');
+      }
+      const data = await res.json();
+      setTables(data);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Failed to fetch tables');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const fetchSchema = useCallback(async (tableName: string) => {
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await fetch(`${API_BASE}/tables/${tableName}/schema`);
+      if (!res.ok) {
+        const err = await res.json();
+        throw new Error(err.detail || 'Failed to fetch schema');
+      }
+      const data = await res.json();
+      setSchema(data);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Failed to fetch schema');
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  const fetchData = useCallback(async (tableName: string, pageNum: number) => {
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await fetch(`${API_BASE}/tables/${tableName}/data?page=${pageNum}&page_size=50`);
+      if (!res.ok) {
+        const err = await res.json();
+        throw new Error(err.detail || 'Failed to fetch data');
+      }
+      const data = await res.json();
+      setData(data);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Failed to fetch data');
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  // Handle table selection
+  const handleSelectTable = (tableName: string) => {
+    setSelectedTable(tableName);
+    setPage(1);
+    setSchema(null);
+    setData(null);
+    fetchSchema(tableName);
+  };
+
+  // Handle tab change
+  useEffect(() => {
+    if (!selectedTable) return;
+
+    if (activeTab === 'schema' && !schema) {
+      fetchSchema(selectedTable);
+    } else if (activeTab === 'data') {
+      fetchData(selectedTable, page);
+    }
+  }, [activeTab, selectedTable, page, fetchSchema, fetchData, schema]);
+
+  // Execute query
+  const executeQuery = async () => {
+    setQueryLoading(true);
+    setQueryError(null);
+    setQueryResult(null);
+    try {
+      const res = await fetch(`${API_BASE}/query`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ sql: query }),
+      });
+      if (!res.ok) {
+        const err = await res.json();
+        throw new Error(err.detail || 'Query failed');
+      }
+      const result = await res.json();
+      setQueryResult(result);
+    } catch (e) {
+      setQueryError(e instanceof Error ? e.message : 'Query failed');
+    } finally {
+      setQueryLoading(false);
+    }
+  };
+
+  // Format cell value for display
+  const formatCell = (value: unknown): string => {
+    if (value === null) return 'NULL';
+    if (typeof value === 'boolean') return value ? 'true' : 'false';
+    if (typeof value === 'object') return JSON.stringify(value);
+    return String(value);
+  };
+
+  return (
+    <div className="db-explorer">
+      {/* Sidebar - Table List */}
+      <aside className="db-sidebar">
+        <div className="sidebar-header">
+          <h2>Tables</h2>
+          <button onClick={fetchTables} className="refresh-btn" title="Refresh">
+            ↻
+          </button>
+        </div>
+
+        {loading && tables.length === 0 && (
+          <div className="sidebar-loading">Loading...</div>
+        )}
+
+        {error && tables.length === 0 && (
+          <div className="sidebar-error">{error}</div>
+        )}
+
+        <ul className="table-list">
+          {tables.map((table) => (
+            <li
+              key={table.name}
+              className={`table-item ${selectedTable === table.name ? 'selected' : ''}`}
+              onClick={() => handleSelectTable(table.name)}
+            >
+              <span className="table-name">{table.name}</span>
+              <span className="table-count">{table.row_count}</span>
+            </li>
+          ))}
+        </ul>
+      </aside>
+
+      {/* Main Content */}
+      <main className="db-main">
+        {!selectedTable ? (
+          <div className="db-empty">
+            <div className="empty-icon">🗄️</div>
+            <h2>Database Explorer</h2>
+            <p>Select a table from the sidebar to view its schema and data.</p>
+            {error && <div className="error-banner">{error}</div>}
+          </div>
+        ) : (
+          <>
+            {/* Table Header */}
+            <header className="db-header">
+              <h1>{selectedTable}</h1>
+              <nav className="db-tabs">
+                <button
+                  className={`tab-btn ${activeTab === 'schema' ? 'active' : ''}`}
+                  onClick={() => setActiveTab('schema')}
+                >
+                  Schema
+                </button>
+                <button
+                  className={`tab-btn ${activeTab === 'data' ? 'active' : ''}`}
+                  onClick={() => setActiveTab('data')}
+                >
+                  Data
+                </button>
+                <button
+                  className={`tab-btn ${activeTab === 'query' ? 'active' : ''}`}
+                  onClick={() => setActiveTab('query')}
+                >
+                  Query
+                </button>
+              </nav>
+            </header>
+
+            {error && <div className="error-banner">{error}</div>}
+
+            {/* Schema Tab */}
+            {activeTab === 'schema' && schema && (
+              <div className="schema-view">
+                {/* Columns */}
+                <section className="schema-section">
+                  <h3>Columns ({schema.columns.length})</h3>
+                  <table className="schema-table">
+                    <thead>
+                      <tr>
+                        <th>Name</th>
+                        <th>Type</th>
+                        <th>Nullable</th>
+                        <th>Default</th>
+                        <th>Key</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {schema.columns.map((col) => (
+                        <tr key={col.name} className={col.primary_key ? 'pk-row' : ''}>
+                          <td className="col-name">{col.name}</td>
+                          <td className="col-type">{col.type}</td>
+                          <td className="col-nullable">{col.nullable ? 'YES' : 'NO'}</td>
+                          <td className="col-default">{col.default || '-'}</td>
+                          <td className="col-key">{col.primary_key ? '🔑 PK' : ''}</td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
+                </section>
+
+                {/* Foreign Keys */}
+                {schema.foreign_keys.length > 0 && (
+                  <section className="schema-section">
+                    <h3>Foreign Keys ({schema.foreign_keys.length})</h3>
+                    <table className="schema-table">
+                      <thead>
+                        <tr>
+                          <th>Columns</th>
+                          <th>References</th>
+                        </tr>
+                      </thead>
+                      <tbody>
+                        {schema.foreign_keys.map((fk, i) => (
+                          <tr key={i}>
+                            <td>{fk.columns.join(', ')}</td>
+                            <td>{fk.referred_table}({fk.referred_columns.join(', ')})</td>
+                          </tr>
+                        ))}
+                      </tbody>
+                    </table>
+                  </section>
+                )}
+
+                {/* Indexes */}
+                {schema.indexes.length > 0 && (
+                  <section className="schema-section">
+                    <h3>Indexes ({schema.indexes.length})</h3>
+                    <table className="schema-table">
+                      <thead>
+                        <tr>
+                          <th>Name</th>
+                          <th>Columns</th>
+                          <th>Unique</th>
+                        </tr>
+                      </thead>
+                      <tbody>
+                        {schema.indexes.map((idx, i) => (
+                          <tr key={i}>
+                            <td>{idx.name}</td>
+                            <td>{idx.columns.join(', ')}</td>
+                            <td>{idx.unique ? 'YES' : 'NO'}</td>
+                          </tr>
+                        ))}
+                      </tbody>
+                    </table>
+                  </section>
+                )}
+              </div>
+            )}
+
+            {/* Data Tab */}
+            {activeTab === 'data' && (
+              <div className="data-view">
+                {loading ? (
+                  <div className="data-loading">Loading data...</div>
+                ) : data ? (
+                  <>
+                    <div className="data-info">
+                      Showing {data.rows.length} of {data.total_count} rows
+                      (Page {data.page} of {data.total_pages})
+                    </div>
+
+                    <div className="data-table-container">
+                      <table className="data-table">
+                        <thead>
+                          <tr>
+                            {data.columns.map((col) => (
+                              <th key={col}>{col}</th>
+                            ))}
+                          </tr>
+                        </thead>
+                        <tbody>
+                          {data.rows.map((row, i) => (
+                            <tr key={i}>
+                              {row.map((cell, j) => (
+                                <td key={j} className={cell === null ? 'null-cell' : ''}>
+                                  {formatCell(cell)}
+                                </td>
+                              ))}
+                            </tr>
+                          ))}
+                        </tbody>
+                      </table>
+                    </div>
+
+                    {/* Pagination */}
+                    <div className="pagination">
+                      <button
+                        disabled={page <= 1}
+                        onClick={() => setPage(1)}
+                      >
+                        ««
+                      </button>
+                      <button
+                        disabled={page <= 1}
+                        onClick={() => setPage(p => p - 1)}
+                      >
+                        «
+                      </button>
+                      <span className="page-info">
+                        Page {page} of {data.total_pages}
+                      </span>
+                      <button
+                        disabled={page >= data.total_pages}
+                        onClick={() => setPage(p => p + 1)}
+                      >
+                        »
+                      </button>
+                      <button
+                        disabled={page >= data.total_pages}
+                        onClick={() => setPage(data.total_pages)}
+                      >
+                        »»
+                      </button>
+                    </div>
+                  </>
+                ) : null}
+              </div>
+            )}
+
+            {/* Query Tab */}
+            {activeTab === 'query' && (
+              <div className="query-view">
+                <div className="query-editor">
+                  <textarea
+                    value={query}
+                    onChange={(e) => setQuery(e.target.value)}
+                    placeholder="Enter SQL query (SELECT only)..."
+                    spellCheck={false}
+                  />
+                  <div className="query-actions">
+                    <button
+                      onClick={executeQuery}
+                      disabled={queryLoading || !query.trim()}
+                      className="execute-btn"
+                    >
+                      {queryLoading ? 'Running...' : 'Execute Query'}
+                    </button>
+                    <span className="query-hint">Only SELECT queries allowed. Max 1000 rows.</span>
+                  </div>
+                </div>
+
+                {queryError && (
+                  <div className="query-error">{queryError}</div>
+                )}
+
+                {queryResult && (
+                  <div className="query-result">
+                    <div className="result-info">
+                      {queryResult.row_count} rows returned
+                      {queryResult.truncated && ' (truncated to 1000)'}
+                    </div>
+                    <div className="data-table-container">
+                      <table className="data-table">
+                        <thead>
+                          <tr>
+                            {queryResult.columns.map((col) => (
+                              <th key={col}>{col}</th>
+                            ))}
+                          </tr>
+                        </thead>
+                        <tbody>
+                          {queryResult.rows.map((row, i) => (
+                            <tr key={i}>
+                              {row.map((cell, j) => (
+                                <td key={j} className={cell === null ? 'null-cell' : ''}>
+                                  {formatCell(cell)}
+                                </td>
+                              ))}
+                            </tr>
+                          ))}
+                        </tbody>
+                      </table>
+                    </div>
+                  </div>
+                )}
+              </div>
+            )}
+          </>
+        )}
+      </main>
+    </div>
+  );
+}
+
+export default DatabaseExplorer;

--- a/web/src/pages/index.ts
+++ b/web/src/pages/index.ts
@@ -16,3 +16,4 @@ export { Presentation } from './Presentation';
 export { Roadmap } from './Roadmap';
 export { CodebaseHealth } from './CodebaseHealth';
 export { Changelog } from './Changelog';
+export { DatabaseExplorer } from './DatabaseExplorer';


### PR DESCRIPTION
## Summary
- Add Database Explorer dev tool for browsing PostgreSQL tables, schemas, and running read-only queries
- Improve Changelog page stats styling with pill badges

## Changes

### Database Explorer (`/db-explorer`)
- **Backend API** (`server/app/api/dbexplorer.py`):
  - `GET /api/db/tables` - List tables with row counts
  - `GET /api/db/tables/{name}/schema` - Column types, keys, indexes
  - `GET /api/db/tables/{name}/data` - Paginated data browser
  - `POST /api/db/query` - Read-only SQL (SELECT only)
  - Security: Only available when `DEBUG=true`

- **Frontend** (`web/src/pages/DatabaseExplorer.tsx`):
  - Table sidebar with row counts
  - Schema tab: columns, types, nullable, defaults, keys
  - Data tab: paginated table view (50 rows/page)
  - Query tab: SQL editor with execute button
  - GitHub-inspired dark theme

### Changelog Styling
- Stats section now uses pill badges instead of pipe-separated text

## Test plan
- [ ] Start backend with `DEBUG=true`
- [ ] Navigate to `/db-explorer`
- [ ] Verify tables load in sidebar
- [ ] Click a table, verify schema displays
- [ ] Switch to Data tab, verify pagination works
- [ ] Run a SELECT query, verify results display
- [ ] Verify non-SELECT queries are blocked

🤖 Generated with [Claude Code](https://claude.ai/code)