### PR TITLE
feat: add Audio Jukebox dev tool with vinyl visualization

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,6 +1,6 @@
 import { Routes, Route } from 'react-router-dom';
 import { Layout } from './components/Layout';
-import { Home, Login, Register, Play, Features, About, PlayScene, SceneDemo, Leaderboard, Ghosts, Profile, Achievements, Spectate, Friends, Presentation, Roadmap, CodebaseHealth, Changelog, DatabaseExplorer, CacheInspector } from './pages';
+import { Home, Login, Register, Play, Features, About, PlayScene, SceneDemo, Leaderboard, Ghosts, Profile, Achievements, Spectate, Friends, Presentation, Roadmap, CodebaseHealth, Changelog, DatabaseExplorer, CacheInspector, AudioJukebox } from './pages';
 import { FirstPersonDemo } from './pages/FirstPersonDemo';
 import { FirstPersonTestPage } from './pages/FirstPersonTestPage';
 import { Debug3DPage } from './pages/Debug3DPage';
@@ -35,6 +35,7 @@ function App() {
         <Route path="changelog" element={<Changelog />} />
         <Route path="db-explorer" element={<DatabaseExplorer />} />
         <Route path="cache-inspector" element={<CacheInspector />} />
+        <Route path="audio-jukebox" element={<AudioJukebox />} />
       </Route>
     </Routes>
   );

--- a/web/src/components/Layout.tsx
+++ b/web/src/components/Layout.tsx
@@ -93,6 +93,10 @@ export function Layout() {
                     <span className="menu-icon">⚡</span>
                     Cache Inspector
                   </Link>
+                  <Link to="/audio-jukebox" onClick={closeDropdown}>
+                    <span className="menu-icon">🎵</span>
+                    Audio Jukebox
+                  </Link>
                 </div>
               )}
             </div>

--- a/web/src/pages/AudioJukebox.css
+++ b/web/src/pages/AudioJukebox.css
@@ -1,0 +1,551 @@
+/**
+ * Audio Jukebox Styles
+ * Vinyl record aesthetic with modern visualizer
+ */
+
+.audio-jukebox {
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh;
+  background: linear-gradient(135deg, #0d1117 0%, #161b22 50%, #1a1a2e 100%);
+  color: #e6edf3;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+}
+
+/* Header */
+.jukebox-header {
+  padding: 1.5rem 2rem;
+  background: rgba(0, 0, 0, 0.3);
+  border-bottom: 1px solid rgba(255, 255, 255, 0.1);
+}
+
+.header-title {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+}
+
+.header-title h1 {
+  margin: 0;
+  font-size: 1.5rem;
+  font-weight: 600;
+  background: linear-gradient(135deg, #58a6ff, #d2a8ff);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+}
+
+.track-count {
+  font-size: 0.8rem;
+  padding: 0.3rem 0.6rem;
+  background: rgba(88, 166, 255, 0.2);
+  color: #58a6ff;
+  border-radius: 12px;
+}
+
+.header-subtitle {
+  margin: 0.5rem 0 0;
+  font-size: 0.9rem;
+  color: #8b949e;
+}
+
+/* Body Layout */
+.jukebox-body {
+  display: flex;
+  flex: 1;
+  overflow: hidden;
+}
+
+/* Now Playing Panel (Left) */
+.now-playing-panel {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 2rem;
+  background: radial-gradient(ellipse at center, rgba(88, 166, 255, 0.05) 0%, transparent 70%);
+}
+
+/* Vinyl Record */
+.vinyl-container {
+  position: relative;
+  width: 320px;
+  height: 320px;
+  margin-bottom: 1.5rem;
+}
+
+.vinyl-record {
+  width: 300px;
+  height: 300px;
+  border-radius: 50%;
+  background: linear-gradient(
+    145deg,
+    #1a1a1a 0%,
+    #2a2a2a 20%,
+    var(--vinyl-color, #1a1a2e) 40%,
+    #1a1a1a 60%,
+    #2a2a2a 80%,
+    #1a1a1a 100%
+  );
+  position: relative;
+  box-shadow:
+    0 0 0 8px #0a0a0a,
+    0 0 0 10px #1a1a1a,
+    0 20px 50px rgba(0, 0, 0, 0.5),
+    inset 0 0 50px rgba(0, 0, 0, 0.5);
+  transition: transform 0.3s ease;
+}
+
+.vinyl-record.spinning {
+  animation: spin 2s linear infinite;
+}
+
+@keyframes spin {
+  from { transform: rotate(0deg); }
+  to { transform: rotate(360deg); }
+}
+
+/* Vinyl Grooves */
+.vinyl-grooves {
+  position: absolute;
+  inset: 30px;
+  border-radius: 50%;
+}
+
+.groove {
+  position: absolute;
+  inset: calc(var(--i) * 12px);
+  border: 1px solid rgba(255, 255, 255, 0.03);
+  border-radius: 50%;
+}
+
+/* Vinyl Label (center) */
+.vinyl-label {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  width: 100px;
+  height: 100px;
+  border-radius: 50%;
+  background: linear-gradient(145deg, #2a2a3a, #1a1a2a);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  box-shadow: inset 0 0 20px rgba(0, 0, 0, 0.5);
+  border: 2px solid rgba(255, 255, 255, 0.1);
+}
+
+.label-title {
+  font-size: 0.65rem;
+  font-weight: 600;
+  text-align: center;
+  padding: 0 8px;
+  color: #e6edf3;
+  text-overflow: ellipsis;
+  overflow: hidden;
+  white-space: nowrap;
+  max-width: 80px;
+}
+
+.label-floor {
+  font-size: 0.55rem;
+  color: #8b949e;
+  margin-top: 2px;
+}
+
+.label-empty {
+  font-size: 0.6rem;
+  color: #6b7280;
+}
+
+.vinyl-center {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  background: #0a0a0a;
+  box-shadow: inset 0 0 5px rgba(255, 255, 255, 0.1);
+}
+
+/* Tonearm */
+.tonearm {
+  position: absolute;
+  top: 20px;
+  right: -30px;
+  width: 120px;
+  height: 150px;
+  transform-origin: top right;
+  transition: transform 0.5s ease;
+}
+
+.tonearm.playing {
+  transform: rotate(-25deg);
+}
+
+.tonearm-base {
+  position: absolute;
+  top: 0;
+  right: 0;
+  width: 30px;
+  height: 30px;
+  border-radius: 50%;
+  background: linear-gradient(145deg, #3a3a4a, #2a2a3a);
+  box-shadow: 0 5px 15px rgba(0, 0, 0, 0.3);
+}
+
+.tonearm-arm {
+  position: absolute;
+  top: 15px;
+  right: 10px;
+  width: 100px;
+  height: 8px;
+  background: linear-gradient(to bottom, #4a4a5a, #3a3a4a);
+  transform-origin: right center;
+  transform: rotate(-10deg);
+  border-radius: 4px;
+}
+
+.tonearm-head {
+  position: absolute;
+  top: 8px;
+  left: -5px;
+  width: 20px;
+  height: 15px;
+  background: #2a2a3a;
+  border-radius: 3px;
+  transform: rotate(-10deg);
+}
+
+.tonearm-head::after {
+  content: '';
+  position: absolute;
+  bottom: -5px;
+  left: 50%;
+  transform: translateX(-50%);
+  width: 3px;
+  height: 8px;
+  background: #8b949e;
+}
+
+/* Visualizer */
+.visualizer {
+  display: flex;
+  align-items: flex-end;
+  justify-content: center;
+  gap: 3px;
+  height: 80px;
+  width: 100%;
+  max-width: 400px;
+  padding: 0 1rem;
+  margin-bottom: 1.5rem;
+}
+
+.visualizer-bar {
+  flex: 1;
+  max-width: 10px;
+  min-height: 4px;
+  border-radius: 2px 2px 0 0;
+  transition: height 0.05s ease;
+  box-shadow: 0 0 10px currentColor;
+}
+
+/* Track Info */
+.track-info {
+  text-align: center;
+  margin-bottom: 1rem;
+  min-height: 70px;
+}
+
+.track-name {
+  margin: 0 0 0.5rem;
+  font-size: 1.25rem;
+  font-weight: 600;
+}
+
+.track-name.empty {
+  color: #6b7280;
+  font-weight: 400;
+}
+
+.track-meta {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.75rem;
+}
+
+.track-category {
+  font-size: 0.7rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  padding: 0.2rem 0.5rem;
+  border-radius: 4px;
+  color: #0d1117;
+}
+
+.track-boss {
+  font-size: 0.85rem;
+  color: #8b949e;
+}
+
+/* Progress Bar */
+.progress-container {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  width: 100%;
+  max-width: 400px;
+  margin-bottom: 1.5rem;
+}
+
+.time-current,
+.time-total {
+  font-size: 0.8rem;
+  font-family: 'JetBrains Mono', 'Fira Code', monospace;
+  color: #8b949e;
+  min-width: 45px;
+}
+
+.time-current {
+  text-align: right;
+}
+
+.progress-slider {
+  flex: 1;
+  height: 6px;
+  -webkit-appearance: none;
+  appearance: none;
+  background: #30363d;
+  border-radius: 3px;
+  cursor: pointer;
+}
+
+.progress-slider::-webkit-slider-thumb {
+  -webkit-appearance: none;
+  width: 14px;
+  height: 14px;
+  border-radius: 50%;
+  background: #58a6ff;
+  cursor: pointer;
+  box-shadow: 0 0 10px rgba(88, 166, 255, 0.5);
+  transition: transform 0.15s;
+}
+
+.progress-slider::-webkit-slider-thumb:hover {
+  transform: scale(1.2);
+}
+
+.progress-slider:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+/* Playback Controls */
+.playback-controls {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+}
+
+.control-btn {
+  width: 50px;
+  height: 50px;
+  border-radius: 50%;
+  border: 2px solid #30363d;
+  background: #161b22;
+  color: #e6edf3;
+  font-size: 1.2rem;
+  cursor: pointer;
+  transition: all 0.15s;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.control-btn:hover:not(:disabled) {
+  background: #21262d;
+  border-color: #58a6ff;
+  box-shadow: 0 0 15px rgba(88, 166, 255, 0.3);
+}
+
+.control-btn:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+.play-btn {
+  width: 70px;
+  height: 70px;
+  font-size: 1.5rem;
+  background: linear-gradient(145deg, #1f6feb, #58a6ff);
+  border: none;
+  box-shadow: 0 5px 20px rgba(88, 166, 255, 0.3);
+}
+
+.play-btn:hover:not(:disabled) {
+  transform: scale(1.05);
+  box-shadow: 0 5px 30px rgba(88, 166, 255, 0.5);
+}
+
+/* Track List Panel (Right) */
+.track-list-panel {
+  width: 400px;
+  background: #161b22;
+  border-left: 1px solid #30363d;
+  overflow-y: auto;
+  padding: 1rem 0;
+}
+
+.track-group {
+  margin-bottom: 1.5rem;
+}
+
+.group-title {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  margin: 0 0 0.5rem;
+  padding: 0 1rem;
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: #8b949e;
+}
+
+.group-icon {
+  font-size: 0.65rem;
+  font-weight: 700;
+  padding: 0.2rem 0.4rem;
+  border-radius: 3px;
+  color: #0d1117;
+}
+
+.track-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.track-item {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.75rem 1rem;
+  cursor: pointer;
+  transition: background 0.15s;
+  border-left: 3px solid transparent;
+}
+
+.track-item:hover {
+  background: rgba(88, 166, 255, 0.1);
+}
+
+.track-item.active {
+  background: rgba(88, 166, 255, 0.15);
+  border-left-color: #58a6ff;
+}
+
+.track-play-indicator {
+  width: 20px;
+  color: #58a6ff;
+  font-size: 0.9rem;
+  text-align: center;
+}
+
+.track-floor-badge {
+  font-size: 0.7rem;
+  font-weight: 700;
+  padding: 0.2rem 0.4rem;
+  border-radius: 4px;
+  color: #fff;
+  min-width: 28px;
+  text-align: center;
+}
+
+.track-item-info {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+}
+
+.track-item-name {
+  font-size: 0.9rem;
+  color: #e6edf3;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.track-item-boss {
+  font-size: 0.75rem;
+  color: #6b7280;
+}
+
+/* Scrollbar */
+.track-list-panel::-webkit-scrollbar {
+  width: 8px;
+}
+
+.track-list-panel::-webkit-scrollbar-track {
+  background: #0d1117;
+}
+
+.track-list-panel::-webkit-scrollbar-thumb {
+  background: #30363d;
+  border-radius: 4px;
+}
+
+.track-list-panel::-webkit-scrollbar-thumb:hover {
+  background: #484f58;
+}
+
+/* Responsive */
+@media (max-width: 900px) {
+  .jukebox-body {
+    flex-direction: column;
+  }
+
+  .now-playing-panel {
+    padding: 1.5rem 1rem;
+  }
+
+  .vinyl-container {
+    width: 260px;
+    height: 260px;
+  }
+
+  .vinyl-record {
+    width: 240px;
+    height: 240px;
+  }
+
+  .vinyl-label {
+    width: 80px;
+    height: 80px;
+  }
+
+  .tonearm {
+    display: none;
+  }
+
+  .track-list-panel {
+    width: 100%;
+    max-height: 50vh;
+    border-left: none;
+    border-top: 1px solid #30363d;
+  }
+}
+
+/* Glow animations */
+@keyframes glow-pulse {
+  0%, 100% { box-shadow: 0 0 20px rgba(88, 166, 255, 0.3); }
+  50% { box-shadow: 0 0 40px rgba(88, 166, 255, 0.5); }
+}
+
+.vinyl-record.spinning {
+  animation: spin 2s linear infinite, glow-pulse 2s ease-in-out infinite;
+}

--- a/web/src/pages/AudioJukebox.tsx
+++ b/web/src/pages/AudioJukebox.tsx
@@ -1,0 +1,479 @@
+/**
+ * Audio Jukebox - Dev tool for previewing all game audio
+ *
+ * Features:
+ * - Vinyl record visualization that spins when playing
+ * - Real-time audio frequency visualizer
+ * - Track browser organized by category
+ * - Playback controls with seek bar
+ * - Waveform display
+ * - Integration with game's audio system
+ */
+
+import { useState, useEffect, useRef, useCallback } from 'react';
+import { Howl } from 'howler';
+import { useAudio } from '../contexts/AudioContext';
+import { MUSIC_TRACKS, BIOME_NAMES } from '../config/audioConfig';
+import './AudioJukebox.css';
+
+interface TrackInfo {
+  id: string;
+  name: string;
+  category: 'ui' | 'biome' | 'special';
+  floor?: number;
+  boss?: string;
+  file: string;
+  duration?: number;
+}
+
+// Build track catalog from config
+const TRACK_CATALOG: TrackInfo[] = [
+  // UI Tracks
+  { id: 'menu', name: 'Main Menu', category: 'ui', file: MUSIC_TRACKS.menu.file },
+  { id: 'character_creation', name: 'Character Creation', category: 'ui', file: MUSIC_TRACKS.character_creation.file },
+  { id: 'intro', name: 'Intro / Prologue', category: 'ui', file: MUSIC_TRACKS.intro.file },
+
+  // Biome Tracks
+  { id: 'biome_stone', name: 'Stone Dungeon', category: 'biome', floor: 1, boss: 'Goblin King', file: MUSIC_TRACKS.biome_stone.file },
+  { id: 'biome_sewer', name: 'Sewers of Valdris', category: 'biome', floor: 2, boss: 'Rat King', file: MUSIC_TRACKS.biome_sewer.file },
+  { id: 'biome_forest', name: 'Forest Depths', category: 'biome', floor: 3, boss: 'Spider Queen', file: MUSIC_TRACKS.biome_forest.file },
+  { id: 'biome_crypt', name: 'Mirror Valdris', category: 'biome', floor: 4, boss: 'The Regent', file: MUSIC_TRACKS.biome_crypt.file },
+  { id: 'biome_ice', name: 'Ice Cavern', category: 'biome', floor: 5, boss: 'Frost Giant', file: MUSIC_TRACKS.biome_ice.file },
+  { id: 'biome_library', name: 'Ancient Library', category: 'biome', floor: 6, boss: 'Arcane Keeper', file: MUSIC_TRACKS.biome_library.file },
+  { id: 'biome_volcanic', name: 'Volcanic Depths', category: 'biome', floor: 7, boss: 'Flame Lord', file: MUSIC_TRACKS.biome_volcanic.file },
+  { id: 'biome_crystal', name: 'Crystal Cave', category: 'biome', floor: 8, boss: 'Dragon Emperor', file: MUSIC_TRACKS.biome_crystal.file },
+
+  // Special Tracks
+  { id: 'victory', name: 'Victory', category: 'special', file: MUSIC_TRACKS.victory.file },
+  { id: 'death', name: 'Death', category: 'special', file: MUSIC_TRACKS.death.file },
+];
+
+// Category colors
+const CATEGORY_COLORS: Record<string, string> = {
+  ui: '#58a6ff',
+  biome: '#7ee787',
+  special: '#d2a8ff',
+};
+
+// Floor colors for vinyl
+const FLOOR_COLORS: Record<number, string> = {
+  1: '#6b7280', // Stone - gray
+  2: '#065f46', // Sewer - dark green
+  3: '#166534', // Forest - green
+  4: '#7c3aed', // Crypt - purple
+  5: '#0ea5e9', // Ice - cyan
+  6: '#c2410c', // Library - amber
+  7: '#dc2626', // Volcanic - red
+  8: '#8b5cf6', // Crystal - violet
+};
+
+export function AudioJukebox() {
+  const { getEffectiveVolume, isUnlocked, unlockAudio } = useAudio();
+  const [currentTrack, setCurrentTrack] = useState<TrackInfo | null>(null);
+  const [isPlaying, setIsPlaying] = useState(false);
+  const [progress, setProgress] = useState(0);
+  const [duration, setDuration] = useState(0);
+  const [isLoading, setIsLoading] = useState(false);
+  const [analyserData, setAnalyserData] = useState<number[]>(new Array(64).fill(0));
+
+  const howlRef = useRef<Howl | null>(null);
+  const analyserRef = useRef<AnalyserNode | null>(null);
+  const audioContextRef = useRef<AudioContext | null>(null);
+  const animationRef = useRef<number>(0);
+  const progressIntervalRef = useRef<number>(0);
+
+  // Cleanup on unmount
+  useEffect(() => {
+    return () => {
+      if (howlRef.current) {
+        howlRef.current.stop();
+        howlRef.current.unload();
+      }
+      if (animationRef.current) {
+        cancelAnimationFrame(animationRef.current);
+      }
+      if (progressIntervalRef.current) {
+        clearInterval(progressIntervalRef.current);
+      }
+    };
+  }, []);
+
+  // Setup audio analyser
+  const setupAnalyser = useCallback((howl: Howl) => {
+    try {
+      // Get or create audio context
+      if (!audioContextRef.current) {
+        audioContextRef.current = new (window.AudioContext || (window as unknown as { webkitAudioContext: typeof AudioContext }).webkitAudioContext)();
+      }
+      const ctx = audioContextRef.current;
+
+      // Create analyser
+      const analyser = ctx.createAnalyser();
+      analyser.fftSize = 128;
+      analyser.smoothingTimeConstant = 0.8;
+      analyserRef.current = analyser;
+
+      // Connect Howler to analyser
+      // Howler exposes the audio node through _sounds
+      const sounds = (howl as unknown as { _sounds: Array<{ _node: HTMLAudioElement }> })._sounds;
+      if (sounds && sounds[0] && sounds[0]._node) {
+        const source = ctx.createMediaElementSource(sounds[0]._node);
+        source.connect(analyser);
+        analyser.connect(ctx.destination);
+      }
+
+      // Start visualization loop
+      const updateVisualizer = () => {
+        if (!analyserRef.current) return;
+
+        const dataArray = new Uint8Array(analyserRef.current.frequencyBinCount);
+        analyserRef.current.getByteFrequencyData(dataArray);
+
+        // Normalize to 0-1 range
+        const normalized = Array.from(dataArray).map(v => v / 255);
+        setAnalyserData(normalized);
+
+        animationRef.current = requestAnimationFrame(updateVisualizer);
+      };
+      updateVisualizer();
+    } catch (e) {
+      console.warn('Could not setup audio analyser:', e);
+    }
+  }, []);
+
+  // Play track
+  const playTrack = useCallback((track: TrackInfo) => {
+    if (!isUnlocked) {
+      unlockAudio();
+    }
+
+    // Stop current track
+    if (howlRef.current) {
+      howlRef.current.stop();
+      howlRef.current.unload();
+    }
+    if (animationRef.current) {
+      cancelAnimationFrame(animationRef.current);
+    }
+
+    setIsLoading(true);
+    setCurrentTrack(track);
+    setProgress(0);
+
+    const effectiveVolume = getEffectiveVolume('music');
+
+    const howl = new Howl({
+      src: [track.file],
+      html5: true,
+      volume: effectiveVolume,
+      onload: () => {
+        setDuration(howl.duration());
+        setIsLoading(false);
+      },
+      onplay: () => {
+        setIsPlaying(true);
+        setupAnalyser(howl);
+
+        // Update progress
+        progressIntervalRef.current = window.setInterval(() => {
+          const seek = howl.seek() as number;
+          setProgress(seek);
+        }, 100);
+      },
+      onpause: () => setIsPlaying(false),
+      onstop: () => {
+        setIsPlaying(false);
+        if (progressIntervalRef.current) {
+          clearInterval(progressIntervalRef.current);
+        }
+      },
+      onend: () => {
+        setIsPlaying(false);
+        setProgress(0);
+        if (progressIntervalRef.current) {
+          clearInterval(progressIntervalRef.current);
+        }
+      },
+      onloaderror: (_, err) => {
+        console.error('Failed to load track:', err);
+        setIsLoading(false);
+      },
+    });
+
+    howlRef.current = howl;
+    howl.play();
+  }, [isUnlocked, unlockAudio, getEffectiveVolume, setupAnalyser]);
+
+  // Toggle play/pause
+  const togglePlayPause = useCallback(() => {
+    if (!howlRef.current) return;
+
+    if (isPlaying) {
+      howlRef.current.pause();
+    } else {
+      howlRef.current.play();
+    }
+  }, [isPlaying]);
+
+  // Stop playback
+  const stopPlayback = useCallback(() => {
+    if (howlRef.current) {
+      howlRef.current.stop();
+    }
+    setProgress(0);
+    setAnalyserData(new Array(64).fill(0));
+  }, []);
+
+  // Seek
+  const handleSeek = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
+    const seekTime = parseFloat(e.target.value);
+    if (howlRef.current) {
+      howlRef.current.seek(seekTime);
+      setProgress(seekTime);
+    }
+  }, []);
+
+  // Skip to next/previous track
+  const skipTrack = useCallback((direction: 1 | -1) => {
+    if (!currentTrack) return;
+    const currentIndex = TRACK_CATALOG.findIndex(t => t.id === currentTrack.id);
+    const newIndex = (currentIndex + direction + TRACK_CATALOG.length) % TRACK_CATALOG.length;
+    playTrack(TRACK_CATALOG[newIndex]);
+  }, [currentTrack, playTrack]);
+
+  // Format time
+  const formatTime = (seconds: number): string => {
+    const mins = Math.floor(seconds / 60);
+    const secs = Math.floor(seconds % 60);
+    return `${mins}:${secs.toString().padStart(2, '0')}`;
+  };
+
+  // Get vinyl color based on current track
+  const getVinylColor = (): string => {
+    if (!currentTrack) return '#1a1a2e';
+    if (currentTrack.floor) return FLOOR_COLORS[currentTrack.floor] || '#1a1a2e';
+    if (currentTrack.category === 'special') return '#d2a8ff';
+    return '#58a6ff';
+  };
+
+  // Group tracks by category
+  const groupedTracks = {
+    ui: TRACK_CATALOG.filter(t => t.category === 'ui'),
+    biome: TRACK_CATALOG.filter(t => t.category === 'biome'),
+    special: TRACK_CATALOG.filter(t => t.category === 'special'),
+  };
+
+  return (
+    <div className="audio-jukebox">
+      {/* Header */}
+      <header className="jukebox-header">
+        <div className="header-title">
+          <h1>Audio Jukebox</h1>
+          <span className="track-count">{TRACK_CATALOG.length} tracks</span>
+        </div>
+        <p className="header-subtitle">Preview and test all game music</p>
+      </header>
+
+      <div className="jukebox-body">
+        {/* Left: Now Playing */}
+        <div className="now-playing-panel">
+          {/* Vinyl Record */}
+          <div className="vinyl-container">
+            <div
+              className={`vinyl-record ${isPlaying ? 'spinning' : ''}`}
+              style={{ '--vinyl-color': getVinylColor() } as React.CSSProperties}
+            >
+              <div className="vinyl-grooves">
+                {[...Array(8)].map((_, i) => (
+                  <div key={i} className="groove" style={{ '--i': i } as React.CSSProperties} />
+                ))}
+              </div>
+              <div className="vinyl-label">
+                {currentTrack ? (
+                  <>
+                    <div className="label-title">{currentTrack.name}</div>
+                    {currentTrack.floor && (
+                      <div className="label-floor">Floor {currentTrack.floor}</div>
+                    )}
+                  </>
+                ) : (
+                  <div className="label-empty">No Track</div>
+                )}
+              </div>
+              <div className="vinyl-center" />
+            </div>
+            <div className={`tonearm ${isPlaying ? 'playing' : ''}`}>
+              <div className="tonearm-base" />
+              <div className="tonearm-arm" />
+              <div className="tonearm-head" />
+            </div>
+          </div>
+
+          {/* Visualizer */}
+          <div className="visualizer">
+            {analyserData.slice(0, 32).map((value, i) => (
+              <div
+                key={i}
+                className="visualizer-bar"
+                style={{
+                  height: `${Math.max(4, value * 100)}%`,
+                  backgroundColor: `hsl(${200 + i * 5}, 80%, ${50 + value * 30}%)`,
+                }}
+              />
+            ))}
+          </div>
+
+          {/* Track Info */}
+          <div className="track-info">
+            {currentTrack ? (
+              <>
+                <h2 className="track-name">{currentTrack.name}</h2>
+                <div className="track-meta">
+                  <span
+                    className="track-category"
+                    style={{ backgroundColor: CATEGORY_COLORS[currentTrack.category] }}
+                  >
+                    {currentTrack.category}
+                  </span>
+                  {currentTrack.boss && (
+                    <span className="track-boss">Boss: {currentTrack.boss}</span>
+                  )}
+                </div>
+              </>
+            ) : (
+              <h2 className="track-name empty">Select a track to play</h2>
+            )}
+          </div>
+
+          {/* Progress Bar */}
+          <div className="progress-container">
+            <span className="time-current">{formatTime(progress)}</span>
+            <input
+              type="range"
+              min={0}
+              max={duration || 100}
+              value={progress}
+              onChange={handleSeek}
+              className="progress-slider"
+              disabled={!currentTrack}
+            />
+            <span className="time-total">{formatTime(duration)}</span>
+          </div>
+
+          {/* Playback Controls */}
+          <div className="playback-controls">
+            <button
+              className="control-btn skip-btn"
+              onClick={() => skipTrack(-1)}
+              disabled={!currentTrack}
+              title="Previous track"
+            >
+              ⏮
+            </button>
+            <button
+              className="control-btn play-btn"
+              onClick={togglePlayPause}
+              disabled={!currentTrack || isLoading}
+              title={isPlaying ? 'Pause' : 'Play'}
+            >
+              {isLoading ? '...' : isPlaying ? '⏸' : '▶'}
+            </button>
+            <button
+              className="control-btn stop-btn"
+              onClick={stopPlayback}
+              disabled={!currentTrack}
+              title="Stop"
+            >
+              ⏹
+            </button>
+            <button
+              className="control-btn skip-btn"
+              onClick={() => skipTrack(1)}
+              disabled={!currentTrack}
+              title="Next track"
+            >
+              ⏭
+            </button>
+          </div>
+        </div>
+
+        {/* Right: Track List */}
+        <div className="track-list-panel">
+          {/* UI Tracks */}
+          <div className="track-group">
+            <h3 className="group-title">
+              <span className="group-icon" style={{ backgroundColor: CATEGORY_COLORS.ui }}>UI</span>
+              Menu & Interface
+            </h3>
+            <ul className="track-list">
+              {groupedTracks.ui.map(track => (
+                <li
+                  key={track.id}
+                  className={`track-item ${currentTrack?.id === track.id ? 'active' : ''}`}
+                  onClick={() => playTrack(track)}
+                >
+                  <span className="track-play-indicator">
+                    {currentTrack?.id === track.id && isPlaying ? '▶' : '○'}
+                  </span>
+                  <span className="track-item-name">{track.name}</span>
+                </li>
+              ))}
+            </ul>
+          </div>
+
+          {/* Biome Tracks */}
+          <div className="track-group">
+            <h3 className="group-title">
+              <span className="group-icon" style={{ backgroundColor: CATEGORY_COLORS.biome }}>BIOME</span>
+              Dungeon Floors
+            </h3>
+            <ul className="track-list">
+              {groupedTracks.biome.map(track => (
+                <li
+                  key={track.id}
+                  className={`track-item ${currentTrack?.id === track.id ? 'active' : ''}`}
+                  onClick={() => playTrack(track)}
+                >
+                  <span className="track-play-indicator">
+                    {currentTrack?.id === track.id && isPlaying ? '▶' : '○'}
+                  </span>
+                  <span className="track-floor-badge" style={{ backgroundColor: FLOOR_COLORS[track.floor!] }}>
+                    F{track.floor}
+                  </span>
+                  <div className="track-item-info">
+                    <span className="track-item-name">{track.name}</span>
+                    <span className="track-item-boss">{track.boss}</span>
+                  </div>
+                </li>
+              ))}
+            </ul>
+          </div>
+
+          {/* Special Tracks */}
+          <div className="track-group">
+            <h3 className="group-title">
+              <span className="group-icon" style={{ backgroundColor: CATEGORY_COLORS.special }}>EVENT</span>
+              Special Events
+            </h3>
+            <ul className="track-list">
+              {groupedTracks.special.map(track => (
+                <li
+                  key={track.id}
+                  className={`track-item ${currentTrack?.id === track.id ? 'active' : ''}`}
+                  onClick={() => playTrack(track)}
+                >
+                  <span className="track-play-indicator">
+                    {currentTrack?.id === track.id && isPlaying ? '▶' : '○'}
+                  </span>
+                  <span className="track-item-name">{track.name}</span>
+                </li>
+              ))}
+            </ul>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default AudioJukebox;

--- a/web/src/pages/index.ts
+++ b/web/src/pages/index.ts
@@ -18,3 +18,4 @@ export { CodebaseHealth } from './CodebaseHealth';
 export { Changelog } from './Changelog';
 export { DatabaseExplorer } from './DatabaseExplorer';
 export { CacheInspector } from './CacheInspector';
+export { AudioJukebox } from './AudioJukebox';


### PR DESCRIPTION
## Summary
- Add Audio Jukebox page for previewing all game music tracks
- Creative vinyl record UI with spinning animation during playback
- Animated tonearm that moves when music plays
- Real-time 32-bar frequency visualizer using Web Audio API
- Track browser organized by category (UI, Biome, Special)

## Features
- Floor badges with biome-specific colors
- Boss names displayed for dungeon tracks  
- Progress bar with seek functionality
- Skip next/previous track controls
- Integrates with existing Howler.js audio system
- Responsive layout for mobile

## Test plan
- [ ] Navigate to /audio-jukebox
- [ ] Click a track to play - vinyl should spin
- [ ] Verify frequency visualizer responds to audio
- [ ] Test progress bar seek functionality
- [ ] Test skip next/previous buttons
- [ ] Verify responsive layout on mobile viewport

🤖 Generated with [Claude Code](https://claude.com/claude-code)