### PR TITLE
feat: add System Status dashboard with mission control theme

### DIFF
--- a/server/app/api/status.py
+++ b/server/app/api/status.py
@@ -1,0 +1,255 @@
+"""
+System Status API - Comprehensive health monitoring endpoint.
+
+Provides detailed status information about:
+- Database connectivity and latency
+- Redis connectivity and latency
+- System resources (memory, CPU)
+- Application info (version, uptime)
+"""
+
+import time
+import asyncio
+import platform
+import psutil
+from datetime import datetime
+from typing import Optional
+
+from fastapi import APIRouter, Depends
+from pydantic import BaseModel
+
+from ..core.config import settings
+from ..core.database import async_session_maker
+from ..core.redis import get_redis
+from ..api.dbexplorer import require_debug
+
+router = APIRouter(prefix="/api/status", tags=["status"])
+
+# Track application start time
+APP_START_TIME = datetime.utcnow()
+
+
+class ServiceStatus(BaseModel):
+    """Status of a single service."""
+    name: str
+    status: str  # 'healthy', 'degraded', 'unhealthy', 'unknown'
+    latency_ms: Optional[float] = None
+    message: Optional[str] = None
+    details: Optional[dict] = None
+
+
+class SystemInfo(BaseModel):
+    """System resource information."""
+    platform: str
+    python_version: str
+    cpu_percent: float
+    memory_used_mb: float
+    memory_total_mb: float
+    memory_percent: float
+    disk_used_gb: Optional[float] = None
+    disk_total_gb: Optional[float] = None
+    disk_percent: Optional[float] = None
+
+
+class AppInfo(BaseModel):
+    """Application information."""
+    name: str
+    version: str
+    environment: str
+    debug_mode: bool
+    uptime_seconds: float
+    uptime_human: str
+
+
+class StatusResponse(BaseModel):
+    """Complete system status response."""
+    overall_status: str  # 'healthy', 'degraded', 'unhealthy'
+    timestamp: str
+    services: list[ServiceStatus]
+    system: SystemInfo
+    app: AppInfo
+
+
+def format_uptime(seconds: float) -> str:
+    """Format uptime in human-readable form."""
+    days = int(seconds // 86400)
+    hours = int((seconds % 86400) // 3600)
+    mins = int((seconds % 3600) // 60)
+    secs = int(seconds % 60)
+
+    parts = []
+    if days > 0:
+        parts.append(f"{days}d")
+    if hours > 0:
+        parts.append(f"{hours}h")
+    if mins > 0:
+        parts.append(f"{mins}m")
+    if secs > 0 or not parts:
+        parts.append(f"{secs}s")
+
+    return " ".join(parts)
+
+
+async def check_database() -> ServiceStatus:
+    """Check database connectivity and measure latency."""
+    start = time.perf_counter()
+    try:
+        async with async_session_maker() as session:
+            # Simple query to test connection
+            result = await session.execute("SELECT 1")
+            result.scalar()
+
+        latency = (time.perf_counter() - start) * 1000
+        return ServiceStatus(
+            name="PostgreSQL",
+            status="healthy",
+            latency_ms=round(latency, 2),
+            message="Connected",
+        )
+    except Exception as e:
+        latency = (time.perf_counter() - start) * 1000
+        return ServiceStatus(
+            name="PostgreSQL",
+            status="unhealthy",
+            latency_ms=round(latency, 2),
+            message=str(e)[:100],
+        )
+
+
+async def check_redis() -> ServiceStatus:
+    """Check Redis connectivity and measure latency."""
+    start = time.perf_counter()
+    try:
+        redis = await get_redis()
+        await redis.ping()
+        info = await redis.info("server")
+
+        latency = (time.perf_counter() - start) * 1000
+        return ServiceStatus(
+            name="Redis",
+            status="healthy",
+            latency_ms=round(latency, 2),
+            message="Connected",
+            details={
+                "version": info.get("redis_version", "unknown"),
+                "uptime_days": info.get("uptime_in_days", 0),
+            }
+        )
+    except Exception as e:
+        latency = (time.perf_counter() - start) * 1000
+        return ServiceStatus(
+            name="Redis",
+            status="unhealthy",
+            latency_ms=round(latency, 2),
+            message=str(e)[:100],
+        )
+
+
+def get_system_info() -> SystemInfo:
+    """Gather system resource information."""
+    memory = psutil.virtual_memory()
+
+    # Disk info (may fail in some containers)
+    try:
+        disk = psutil.disk_usage("/")
+        disk_used = round(disk.used / (1024**3), 2)
+        disk_total = round(disk.total / (1024**3), 2)
+        disk_percent = disk.percent
+    except:
+        disk_used = None
+        disk_total = None
+        disk_percent = None
+
+    return SystemInfo(
+        platform=f"{platform.system()} {platform.release()}",
+        python_version=platform.python_version(),
+        cpu_percent=psutil.cpu_percent(interval=0.1),
+        memory_used_mb=round(memory.used / (1024**2), 2),
+        memory_total_mb=round(memory.total / (1024**2), 2),
+        memory_percent=memory.percent,
+        disk_used_gb=disk_used,
+        disk_total_gb=disk_total,
+        disk_percent=disk_percent,
+    )
+
+
+def get_app_info() -> AppInfo:
+    """Get application information."""
+    uptime = (datetime.utcnow() - APP_START_TIME).total_seconds()
+
+    return AppInfo(
+        name=settings.app_name,
+        version=settings.app_version,
+        environment="development" if settings.debug else "production",
+        debug_mode=settings.debug,
+        uptime_seconds=round(uptime, 2),
+        uptime_human=format_uptime(uptime),
+    )
+
+
+@router.get("", response_model=StatusResponse)
+async def get_system_status(_: None = Depends(require_debug)):
+    """
+    Get comprehensive system status.
+
+    Returns status of all services, system resources, and app info.
+    Only available in debug mode.
+    """
+    # Check all services concurrently
+    db_status, redis_status = await asyncio.gather(
+        check_database(),
+        check_redis(),
+    )
+
+    services = [db_status, redis_status]
+
+    # Determine overall status
+    statuses = [s.status for s in services]
+    if all(s == "healthy" for s in statuses):
+        overall = "healthy"
+    elif any(s == "unhealthy" for s in statuses):
+        overall = "unhealthy"
+    else:
+        overall = "degraded"
+
+    return StatusResponse(
+        overall_status=overall,
+        timestamp=datetime.utcnow().isoformat() + "Z",
+        services=services,
+        system=get_system_info(),
+        app=get_app_info(),
+    )
+
+
+@router.get("/ping")
+async def ping():
+    """Simple ping endpoint for basic health checks."""
+    return {"pong": True, "timestamp": datetime.utcnow().isoformat() + "Z"}
+
+
+@router.get("/metrics")
+async def get_metrics(_: None = Depends(require_debug)):
+    """
+    Get Prometheus-style metrics.
+    Only available in debug mode.
+    """
+    uptime = (datetime.utcnow() - APP_START_TIME).total_seconds()
+    memory = psutil.virtual_memory()
+
+    # Simple text-based metrics
+    metrics = [
+        f"# HELP app_uptime_seconds Application uptime in seconds",
+        f"# TYPE app_uptime_seconds gauge",
+        f'app_uptime_seconds{{app="{settings.app_name}"}} {uptime:.2f}',
+        f"",
+        f"# HELP system_memory_bytes System memory usage",
+        f"# TYPE system_memory_bytes gauge",
+        f'system_memory_used_bytes {memory.used}',
+        f'system_memory_total_bytes {memory.total}',
+        f"",
+        f"# HELP system_cpu_percent CPU usage percentage",
+        f"# TYPE system_cpu_percent gauge",
+        f'system_cpu_percent {psutil.cpu_percent(interval=0.1)}',
+    ]
+
+    return "\n".join(metrics)

--- a/server/app/main.py
+++ b/server/app/main.py
@@ -18,6 +18,7 @@ from .api.saves import router as saves_router
 from .api.daily import router as daily_router
 from .api.dbexplorer import router as dbexplorer_router
 from .api.cache import router as cache_router
+from .api.status import router as status_router
 
 
 @asynccontextmanager
@@ -77,6 +78,7 @@ def create_app() -> FastAPI:
     app.include_router(daily_router, prefix="/api")
     app.include_router(dbexplorer_router, tags=["dev-tools"])
     app.include_router(cache_router, tags=["dev-tools"])
+    app.include_router(status_router, tags=["dev-tools"])
 
     return app
 

--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -24,5 +24,8 @@ email-validator==2.1.0
 # WebSockets (included in fastapi)
 websockets==12.0
 
+# System monitoring
+psutil==5.9.8
+
 # Development
 python-dotenv==1.0.0

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,6 +1,6 @@
 import { Routes, Route } from 'react-router-dom';
 import { Layout } from './components/Layout';
-import { Home, Login, Register, Play, Features, About, PlayScene, SceneDemo, Leaderboard, Ghosts, Profile, Achievements, Spectate, Friends, Presentation, Roadmap, CodebaseHealth, Changelog, DatabaseExplorer, CacheInspector, AudioJukebox } from './pages';
+import { Home, Login, Register, Play, Features, About, PlayScene, SceneDemo, Leaderboard, Ghosts, Profile, Achievements, Spectate, Friends, Presentation, Roadmap, CodebaseHealth, Changelog, DatabaseExplorer, CacheInspector, AudioJukebox, SystemStatus } from './pages';
 import { FirstPersonDemo } from './pages/FirstPersonDemo';
 import { FirstPersonTestPage } from './pages/FirstPersonTestPage';
 import { Debug3DPage } from './pages/Debug3DPage';
@@ -36,6 +36,7 @@ function App() {
         <Route path="db-explorer" element={<DatabaseExplorer />} />
         <Route path="cache-inspector" element={<CacheInspector />} />
         <Route path="audio-jukebox" element={<AudioJukebox />} />
+        <Route path="system-status" element={<SystemStatus />} />
       </Route>
     </Routes>
   );

--- a/web/src/components/Layout.tsx
+++ b/web/src/components/Layout.tsx
@@ -97,6 +97,10 @@ export function Layout() {
                     <span className="menu-icon">🎵</span>
                     Audio Jukebox
                   </Link>
+                  <Link to="/system-status" onClick={closeDropdown}>
+                    <span className="menu-icon">📡</span>
+                    System Status
+                  </Link>
                 </div>
               )}
             </div>

--- a/web/src/pages/SystemStatus.css
+++ b/web/src/pages/SystemStatus.css
@@ -1,0 +1,609 @@
+/**
+ * System Status - Mission Control Dashboard Styles
+ */
+
+.system-status {
+  min-height: 100vh;
+  background: linear-gradient(180deg, #0a0c10 0%, #0d1117 50%, #161b22 100%);
+  color: #e6edf3;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+}
+
+/* Loading State */
+.status-loading {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  min-height: 60vh;
+  gap: 1.5rem;
+}
+
+.loading-spinner {
+  width: 60px;
+  height: 60px;
+  border: 3px solid #21262d;
+  border-top-color: #58a6ff;
+  border-radius: 50%;
+  animation: spin 1s linear infinite;
+}
+
+@keyframes spin {
+  to { transform: rotate(360deg); }
+}
+
+.status-loading p {
+  color: #8b949e;
+  font-size: 1rem;
+  letter-spacing: 0.5px;
+}
+
+/* Header */
+.status-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 1.25rem 2rem;
+  background: rgba(0, 0, 0, 0.4);
+  border-bottom: 1px solid #21262d;
+}
+
+.header-left {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+}
+
+.status-header h1 {
+  margin: 0;
+  font-size: 1.5rem;
+  font-weight: 600;
+}
+
+.mission-badge {
+  font-size: 0.65rem;
+  font-weight: 700;
+  letter-spacing: 2px;
+  padding: 0.3rem 0.6rem;
+  background: linear-gradient(135deg, #1f6feb33, #58a6ff22);
+  border: 1px solid #58a6ff44;
+  border-radius: 4px;
+  color: #58a6ff;
+}
+
+.header-right {
+  display: flex;
+  align-items: center;
+  gap: 1.5rem;
+}
+
+.refresh-info {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+}
+
+.refresh-label {
+  font-size: 0.7rem;
+  color: #6b7280;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+
+.refresh-countdown {
+  font-size: 1.1rem;
+  font-weight: 600;
+  font-family: 'JetBrains Mono', 'Fira Code', monospace;
+  color: #58a6ff;
+}
+
+.refresh-btn {
+  padding: 0.5rem 1rem;
+  background: #21262d;
+  border: 1px solid #30363d;
+  color: #e6edf3;
+  border-radius: 6px;
+  cursor: pointer;
+  font-size: 0.9rem;
+  transition: all 0.15s;
+}
+
+.refresh-btn:hover:not(:disabled) {
+  background: #30363d;
+  border-color: #58a6ff;
+}
+
+.refresh-btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+/* Error Banner */
+.status-error {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 1rem 2rem;
+  background: #f8514922;
+  border-bottom: 1px solid #f85149;
+  color: #f85149;
+}
+
+.error-icon {
+  font-size: 1.2rem;
+}
+
+/* Overall Status Banner */
+.overall-status {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 1.25rem 2rem;
+  background: linear-gradient(90deg, var(--status-color)11 0%, transparent 50%);
+  border-bottom: 1px solid var(--status-color)44;
+}
+
+.status-indicator {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+}
+
+.status-dot {
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  background: var(--status-color);
+  box-shadow: 0 0 20px var(--status-color);
+  animation: pulse 2s ease-in-out infinite;
+}
+
+@keyframes pulse {
+  0%, 100% { opacity: 1; transform: scale(1); }
+  50% { opacity: 0.7; transform: scale(1.1); }
+}
+
+.overall-unhealthy .status-dot {
+  animation: pulse-fast 0.5s ease-in-out infinite;
+}
+
+@keyframes pulse-fast {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.3; }
+}
+
+.status-text {
+  font-size: 1.25rem;
+  font-weight: 700;
+  letter-spacing: 2px;
+  color: var(--status-color);
+}
+
+.status-meta {
+  font-size: 0.85rem;
+  color: #8b949e;
+}
+
+/* Grid Layout */
+.status-grid {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 1.5rem;
+  padding: 1.5rem 2rem 2rem;
+}
+
+/* Panels */
+.panel {
+  background: #161b22;
+  border: 1px solid #21262d;
+  border-radius: 12px;
+  overflow: hidden;
+}
+
+.panel-title {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  margin: 0;
+  padding: 1rem 1.25rem;
+  font-size: 0.9rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 1px;
+  color: #8b949e;
+  background: #0d1117;
+  border-bottom: 1px solid #21262d;
+}
+
+.panel-icon {
+  color: #58a6ff;
+}
+
+/* Services Panel */
+.services-list {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  padding: 1.25rem;
+}
+
+.service-card {
+  background: #0d1117;
+  border: 1px solid #21262d;
+  border-radius: 8px;
+  padding: 1rem;
+  transition: border-color 0.15s;
+}
+
+.service-card:hover {
+  border-color: #30363d;
+}
+
+.service-healthy { border-left: 3px solid #22c55e; }
+.service-degraded { border-left: 3px solid #eab308; }
+.service-unhealthy { border-left: 3px solid #ef4444; }
+
+.service-header {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  margin-bottom: 0.75rem;
+}
+
+.service-status-dot {
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  box-shadow: 0 0 8px currentColor;
+}
+
+.service-name {
+  font-weight: 600;
+  flex: 1;
+}
+
+.service-badge {
+  font-size: 0.7rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+
+.service-body {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.service-latency {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.latency-label {
+  font-size: 0.75rem;
+  color: #6b7280;
+  min-width: 50px;
+}
+
+.latency-bar-container {
+  flex: 1;
+  height: 6px;
+  background: #21262d;
+  border-radius: 3px;
+  overflow: hidden;
+}
+
+.latency-bar {
+  height: 100%;
+  border-radius: 3px;
+  transition: width 0.3s ease;
+}
+
+.latency-value {
+  font-size: 0.85rem;
+  font-weight: 600;
+  font-family: 'JetBrains Mono', 'Fira Code', monospace;
+  min-width: 60px;
+  text-align: right;
+}
+
+.service-message {
+  font-size: 0.8rem;
+  color: #8b949e;
+}
+
+.service-details {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin-top: 0.25rem;
+}
+
+.detail-item {
+  font-size: 0.75rem;
+  padding: 0.2rem 0.5rem;
+  background: #21262d;
+  border-radius: 4px;
+  color: #8b949e;
+}
+
+/* Resources Panel */
+.gauges-container {
+  display: flex;
+  justify-content: space-around;
+  padding: 1.5rem 1rem;
+  gap: 1rem;
+}
+
+.gauge {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.gauge-label {
+  font-size: 0.8rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 1px;
+  color: #8b949e;
+}
+
+.gauge-ring {
+  position: relative;
+  width: 100px;
+  height: 100px;
+}
+
+.gauge-ring svg {
+  transform: rotate(0deg);
+}
+
+.gauge-value {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+}
+
+.gauge-number {
+  font-size: 1.1rem;
+  font-weight: 700;
+  font-family: 'JetBrains Mono', 'Fira Code', monospace;
+}
+
+.gauge-unit {
+  font-size: 0.65rem;
+  color: #6b7280;
+}
+
+.gauge-max {
+  font-size: 0.7rem;
+  color: #6b7280;
+}
+
+.system-info-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 1rem;
+  padding: 0 1.25rem 1.25rem;
+  border-top: 1px solid #21262d;
+  margin-top: 0.5rem;
+  padding-top: 1rem;
+}
+
+.info-item {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.info-label {
+  font-size: 0.7rem;
+  color: #6b7280;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+
+.info-value {
+  font-size: 0.85rem;
+  font-family: 'JetBrains Mono', 'Fira Code', monospace;
+  color: #e6edf3;
+}
+
+/* App Panel */
+.app-info {
+  padding: 1.5rem 1.25rem;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 1rem;
+}
+
+.app-name {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.25rem;
+}
+
+.app-title {
+  font-size: 1.25rem;
+  font-weight: 700;
+}
+
+.app-version {
+  font-size: 0.9rem;
+  color: #58a6ff;
+  font-family: 'JetBrains Mono', 'Fira Code', monospace;
+}
+
+.app-env {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.env-badge {
+  font-size: 0.7rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  padding: 0.3rem 0.6rem;
+  border-radius: 4px;
+}
+
+.env-development {
+  background: #eab30822;
+  color: #eab308;
+  border: 1px solid #eab30844;
+}
+
+.env-production {
+  background: #22c55e22;
+  color: #22c55e;
+  border: 1px solid #22c55e44;
+}
+
+.debug-badge {
+  font-size: 0.7rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  padding: 0.3rem 0.6rem;
+  border-radius: 4px;
+  background: #f9731622;
+  color: #f97316;
+  border: 1px solid #f9731644;
+}
+
+.uptime-display {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.25rem;
+  padding: 1rem;
+  background: #0d1117;
+  border-radius: 8px;
+  border: 1px solid #21262d;
+  width: 100%;
+}
+
+.uptime-label {
+  font-size: 0.7rem;
+  color: #6b7280;
+  text-transform: uppercase;
+  letter-spacing: 1px;
+}
+
+.uptime-value {
+  font-size: 1.5rem;
+  font-weight: 700;
+  font-family: 'JetBrains Mono', 'Fira Code', monospace;
+  color: #7ee787;
+}
+
+.uptime-seconds {
+  font-size: 0.75rem;
+  color: #6b7280;
+  font-family: 'JetBrains Mono', 'Fira Code', monospace;
+}
+
+/* Stats Panel */
+.quick-stats {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 1rem;
+  padding: 1.25rem;
+}
+
+.stat-card {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 1rem;
+  background: #0d1117;
+  border: 1px solid #21262d;
+  border-radius: 8px;
+}
+
+.stat-icon {
+  font-size: 1.5rem;
+}
+
+.stat-info {
+  display: flex;
+  flex-direction: column;
+  gap: 0.1rem;
+}
+
+.stat-label {
+  font-size: 0.7rem;
+  color: #6b7280;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+
+.stat-value {
+  font-size: 1rem;
+  font-weight: 600;
+  font-family: 'JetBrains Mono', 'Fira Code', monospace;
+}
+
+/* Responsive */
+@media (max-width: 1024px) {
+  .status-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .gauges-container {
+    flex-wrap: wrap;
+  }
+}
+
+@media (max-width: 600px) {
+  .status-header {
+    flex-direction: column;
+    gap: 1rem;
+    align-items: flex-start;
+  }
+
+  .header-right {
+    width: 100%;
+    justify-content: space-between;
+  }
+
+  .overall-status {
+    flex-direction: column;
+    gap: 0.75rem;
+    align-items: flex-start;
+  }
+
+  .quick-stats {
+    grid-template-columns: 1fr;
+  }
+
+  .system-info-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+/* Scanlines effect (optional) */
+.system-status::before {
+  content: '';
+  position: fixed;
+  inset: 0;
+  background: repeating-linear-gradient(
+    0deg,
+    transparent,
+    transparent 2px,
+    rgba(0, 0, 0, 0.03) 2px,
+    rgba(0, 0, 0, 0.03) 4px
+  );
+  pointer-events: none;
+  z-index: 1000;
+}

--- a/web/src/pages/SystemStatus.tsx
+++ b/web/src/pages/SystemStatus.tsx
@@ -1,0 +1,425 @@
+/**
+ * System Status - Mission Control Dashboard
+ *
+ * Features:
+ * - Real-time service health monitoring
+ * - System resource gauges (CPU, Memory, Disk)
+ * - Latency visualization
+ * - Auto-refresh with countdown
+ * - Uptime display
+ */
+
+import { useState, useEffect, useCallback } from 'react';
+import './SystemStatus.css';
+
+const API_BASE = 'http://localhost:8000/api/status';
+const REFRESH_INTERVAL = 10000; // 10 seconds
+
+interface ServiceStatus {
+  name: string;
+  status: 'healthy' | 'degraded' | 'unhealthy' | 'unknown';
+  latency_ms: number | null;
+  message: string | null;
+  details?: Record<string, unknown>;
+}
+
+interface SystemInfo {
+  platform: string;
+  python_version: string;
+  cpu_percent: number;
+  memory_used_mb: number;
+  memory_total_mb: number;
+  memory_percent: number;
+  disk_used_gb: number | null;
+  disk_total_gb: number | null;
+  disk_percent: number | null;
+}
+
+interface AppInfo {
+  name: string;
+  version: string;
+  environment: string;
+  debug_mode: boolean;
+  uptime_seconds: number;
+  uptime_human: string;
+}
+
+interface StatusResponse {
+  overall_status: 'healthy' | 'degraded' | 'unhealthy';
+  timestamp: string;
+  services: ServiceStatus[];
+  system: SystemInfo;
+  app: AppInfo;
+}
+
+// Status colors
+const STATUS_COLORS: Record<string, string> = {
+  healthy: '#22c55e',
+  degraded: '#eab308',
+  unhealthy: '#ef4444',
+  unknown: '#6b7280',
+};
+
+// Status icons
+const STATUS_ICONS: Record<string, string> = {
+  healthy: '●',
+  degraded: '◐',
+  unhealthy: '○',
+  unknown: '?',
+};
+
+export function SystemStatus() {
+  const [status, setStatus] = useState<StatusResponse | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [countdown, setCountdown] = useState(REFRESH_INTERVAL / 1000);
+  const [lastUpdated, setLastUpdated] = useState<Date | null>(null);
+
+  const fetchStatus = useCallback(async () => {
+    try {
+      const res = await fetch(API_BASE);
+      if (!res.ok) {
+        const err = await res.json();
+        throw new Error(err.detail || 'Failed to fetch status');
+      }
+      const data = await res.json();
+      setStatus(data);
+      setError(null);
+      setLastUpdated(new Date());
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Failed to fetch status');
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  // Initial fetch and auto-refresh
+  useEffect(() => {
+    fetchStatus();
+
+    const interval = setInterval(() => {
+      fetchStatus();
+      setCountdown(REFRESH_INTERVAL / 1000);
+    }, REFRESH_INTERVAL);
+
+    return () => clearInterval(interval);
+  }, [fetchStatus]);
+
+  // Countdown timer
+  useEffect(() => {
+    const timer = setInterval(() => {
+      setCountdown((c) => Math.max(0, c - 1));
+    }, 1000);
+
+    return () => clearInterval(timer);
+  }, []);
+
+  // Format bytes
+  const formatBytes = (mb: number): string => {
+    if (mb >= 1024) {
+      return `${(mb / 1024).toFixed(1)} GB`;
+    }
+    return `${mb.toFixed(0)} MB`;
+  };
+
+  // Get latency color
+  const getLatencyColor = (ms: number): string => {
+    if (ms < 50) return '#22c55e';
+    if (ms < 100) return '#84cc16';
+    if (ms < 200) return '#eab308';
+    if (ms < 500) return '#f97316';
+    return '#ef4444';
+  };
+
+  // Render gauge
+  const renderGauge = (
+    label: string,
+    value: number,
+    max: number,
+    unit: string,
+    color: string
+  ) => {
+    const percent = Math.min(100, (value / max) * 100);
+    return (
+      <div className="gauge">
+        <div className="gauge-label">{label}</div>
+        <div className="gauge-ring">
+          <svg viewBox="0 0 100 100">
+            {/* Background circle */}
+            <circle
+              cx="50"
+              cy="50"
+              r="42"
+              fill="none"
+              stroke="#21262d"
+              strokeWidth="8"
+            />
+            {/* Value arc */}
+            <circle
+              cx="50"
+              cy="50"
+              r="42"
+              fill="none"
+              stroke={color}
+              strokeWidth="8"
+              strokeLinecap="round"
+              strokeDasharray={`${percent * 2.64} 264`}
+              transform="rotate(-90 50 50)"
+              style={{ filter: `drop-shadow(0 0 6px ${color})` }}
+            />
+          </svg>
+          <div className="gauge-value">
+            <span className="gauge-number">{value.toFixed(1)}</span>
+            <span className="gauge-unit">{unit}</span>
+          </div>
+        </div>
+        <div className="gauge-max">/ {max.toFixed(0)} {unit}</div>
+      </div>
+    );
+  };
+
+  if (loading && !status) {
+    return (
+      <div className="system-status">
+        <div className="status-loading">
+          <div className="loading-spinner" />
+          <p>Establishing connection...</p>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="system-status">
+      {/* Header */}
+      <header className="status-header">
+        <div className="header-left">
+          <h1>System Status</h1>
+          <span className="mission-badge">MISSION CONTROL</span>
+        </div>
+        <div className="header-right">
+          <div className="refresh-info">
+            <span className="refresh-label">Next update in</span>
+            <span className="refresh-countdown">{countdown}s</span>
+          </div>
+          <button onClick={fetchStatus} className="refresh-btn" disabled={loading}>
+            {loading ? '...' : '↻'} Refresh
+          </button>
+        </div>
+      </header>
+
+      {error && (
+        <div className="status-error">
+          <span className="error-icon">⚠</span>
+          {error}
+        </div>
+      )}
+
+      {status && (
+        <>
+          {/* Overall Status Banner */}
+          <div
+            className={`overall-status overall-${status.overall_status}`}
+            style={{ '--status-color': STATUS_COLORS[status.overall_status] } as React.CSSProperties}
+          >
+            <div className="status-indicator">
+              <span className="status-dot" />
+              <span className="status-text">
+                {status.overall_status.toUpperCase()}
+              </span>
+            </div>
+            <div className="status-meta">
+              <span>Last check: {lastUpdated?.toLocaleTimeString()}</span>
+            </div>
+          </div>
+
+          <div className="status-grid">
+            {/* Services Panel */}
+            <section className="panel services-panel">
+              <h2 className="panel-title">
+                <span className="panel-icon">◈</span>
+                Services
+              </h2>
+              <div className="services-list">
+                {status.services.map((service) => (
+                  <div
+                    key={service.name}
+                    className={`service-card service-${service.status}`}
+                  >
+                    <div className="service-header">
+                      <span
+                        className="service-status-dot"
+                        style={{ backgroundColor: STATUS_COLORS[service.status] }}
+                      />
+                      <span className="service-name">{service.name}</span>
+                      <span
+                        className="service-badge"
+                        style={{ color: STATUS_COLORS[service.status] }}
+                      >
+                        {service.status}
+                      </span>
+                    </div>
+                    <div className="service-body">
+                      {service.latency_ms !== null && (
+                        <div className="service-latency">
+                          <span className="latency-label">Latency</span>
+                          <div className="latency-bar-container">
+                            <div
+                              className="latency-bar"
+                              style={{
+                                width: `${Math.min(100, service.latency_ms / 5)}%`,
+                                backgroundColor: getLatencyColor(service.latency_ms),
+                              }}
+                            />
+                          </div>
+                          <span
+                            className="latency-value"
+                            style={{ color: getLatencyColor(service.latency_ms) }}
+                          >
+                            {service.latency_ms.toFixed(1)}ms
+                          </span>
+                        </div>
+                      )}
+                      {service.message && (
+                        <div className="service-message">{service.message}</div>
+                      )}
+                      {service.details && (
+                        <div className="service-details">
+                          {Object.entries(service.details).map(([key, value]) => (
+                            <span key={key} className="detail-item">
+                              {key}: {String(value)}
+                            </span>
+                          ))}
+                        </div>
+                      )}
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </section>
+
+            {/* System Resources Panel */}
+            <section className="panel resources-panel">
+              <h2 className="panel-title">
+                <span className="panel-icon">◉</span>
+                System Resources
+              </h2>
+              <div className="gauges-container">
+                {renderGauge(
+                  'CPU',
+                  status.system.cpu_percent,
+                  100,
+                  '%',
+                  status.system.cpu_percent > 80 ? '#ef4444' : status.system.cpu_percent > 60 ? '#eab308' : '#22c55e'
+                )}
+                {renderGauge(
+                  'Memory',
+                  status.system.memory_used_mb,
+                  status.system.memory_total_mb,
+                  'MB',
+                  status.system.memory_percent > 80 ? '#ef4444' : status.system.memory_percent > 60 ? '#eab308' : '#22c55e'
+                )}
+                {status.system.disk_percent !== null && (
+                  renderGauge(
+                    'Disk',
+                    status.system.disk_used_gb || 0,
+                    status.system.disk_total_gb || 100,
+                    'GB',
+                    (status.system.disk_percent || 0) > 80 ? '#ef4444' : (status.system.disk_percent || 0) > 60 ? '#eab308' : '#22c55e'
+                  )
+                )}
+              </div>
+              <div className="system-info-grid">
+                <div className="info-item">
+                  <span className="info-label">Platform</span>
+                  <span className="info-value">{status.system.platform}</span>
+                </div>
+                <div className="info-item">
+                  <span className="info-label">Python</span>
+                  <span className="info-value">{status.system.python_version}</span>
+                </div>
+              </div>
+            </section>
+
+            {/* Application Info Panel */}
+            <section className="panel app-panel">
+              <h2 className="panel-title">
+                <span className="panel-icon">◆</span>
+                Application
+              </h2>
+              <div className="app-info">
+                <div className="app-name">
+                  <span className="app-title">{status.app.name}</span>
+                  <span className="app-version">v{status.app.version}</span>
+                </div>
+                <div className="app-env">
+                  <span
+                    className={`env-badge env-${status.app.environment}`}
+                  >
+                    {status.app.environment}
+                  </span>
+                  {status.app.debug_mode && (
+                    <span className="debug-badge">DEBUG</span>
+                  )}
+                </div>
+                <div className="uptime-display">
+                  <div className="uptime-label">Uptime</div>
+                  <div className="uptime-value">{status.app.uptime_human}</div>
+                  <div className="uptime-seconds">
+                    {status.app.uptime_seconds.toLocaleString()}s
+                  </div>
+                </div>
+              </div>
+            </section>
+
+            {/* Quick Stats Panel */}
+            <section className="panel stats-panel">
+              <h2 className="panel-title">
+                <span className="panel-icon">◇</span>
+                Quick Stats
+              </h2>
+              <div className="quick-stats">
+                <div className="stat-card">
+                  <div className="stat-icon">🗄️</div>
+                  <div className="stat-info">
+                    <div className="stat-label">Database</div>
+                    <div className="stat-value">
+                      {status.services.find(s => s.name === 'PostgreSQL')?.latency_ms?.toFixed(0) || '—'}ms
+                    </div>
+                  </div>
+                </div>
+                <div className="stat-card">
+                  <div className="stat-icon">⚡</div>
+                  <div className="stat-info">
+                    <div className="stat-label">Cache</div>
+                    <div className="stat-value">
+                      {status.services.find(s => s.name === 'Redis')?.latency_ms?.toFixed(0) || '—'}ms
+                    </div>
+                  </div>
+                </div>
+                <div className="stat-card">
+                  <div className="stat-icon">💾</div>
+                  <div className="stat-info">
+                    <div className="stat-label">Memory</div>
+                    <div className="stat-value">
+                      {formatBytes(status.system.memory_used_mb)}
+                    </div>
+                  </div>
+                </div>
+                <div className="stat-card">
+                  <div className="stat-icon">⏱️</div>
+                  <div className="stat-info">
+                    <div className="stat-label">Uptime</div>
+                    <div className="stat-value">{status.app.uptime_human}</div>
+                  </div>
+                </div>
+              </div>
+            </section>
+          </div>
+        </>
+      )}
+    </div>
+  );
+}
+
+export default SystemStatus;

--- a/web/src/pages/index.ts
+++ b/web/src/pages/index.ts
@@ -19,3 +19,4 @@ export { Changelog } from './Changelog';
 export { DatabaseExplorer } from './DatabaseExplorer';
 export { CacheInspector } from './CacheInspector';
 export { AudioJukebox } from './AudioJukebox';
+export { SystemStatus } from './SystemStatus';


### PR DESCRIPTION
## Summary
- Add comprehensive system health monitoring dashboard
- Backend API checks PostgreSQL, Redis connectivity with latency
- Frontend mission control themed UI with gauges and status indicators
- Auto-refresh every 10 seconds with countdown

## Features
**Backend:**
- `/api/status` - Full system status (services, resources, app info)
- `/api/status/ping` - Simple health ping
- `/api/status/metrics` - Prometheus-style metrics
- psutil for CPU/memory/disk monitoring

**Frontend:**
- Pulsing status dot (faster when unhealthy)
- Circular SVG gauges for CPU/Memory/Disk
- Latency bars with color coding
- Scanline overlay effect
- Responsive layout

## Test plan
- [ ] Navigate to /system-status
- [ ] Verify services show healthy (PostgreSQL, Redis)
- [ ] Check latency values update on refresh
- [ ] Verify gauges display CPU/Memory correctly
- [ ] Test auto-refresh countdown
- [ ] Stop Redis and verify status changes to unhealthy

🤖 Generated with [Claude Code](https://claude.com/claude-code)