### PR TITLE
feat: add API Playground dev tool with Postman-style interface

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,6 +1,6 @@
 import { Routes, Route } from 'react-router-dom';
 import { Layout } from './components/Layout';
-import { Home, Login, Register, Play, Features, About, PlayScene, SceneDemo, Leaderboard, Ghosts, Profile, Achievements, Spectate, Friends, Presentation, Roadmap, CodebaseHealth, Changelog, DatabaseExplorer, CacheInspector, AudioJukebox, SystemStatus } from './pages';
+import { Home, Login, Register, Play, Features, About, PlayScene, SceneDemo, Leaderboard, Ghosts, Profile, Achievements, Spectate, Friends, Presentation, Roadmap, CodebaseHealth, Changelog, DatabaseExplorer, CacheInspector, AudioJukebox, SystemStatus, ApiPlayground } from './pages';
 import { FirstPersonDemo } from './pages/FirstPersonDemo';
 import { FirstPersonTestPage } from './pages/FirstPersonTestPage';
 import { Debug3DPage } from './pages/Debug3DPage';
@@ -37,6 +37,7 @@ function App() {
         <Route path="cache-inspector" element={<CacheInspector />} />
         <Route path="audio-jukebox" element={<AudioJukebox />} />
         <Route path="system-status" element={<SystemStatus />} />
+        <Route path="api-playground" element={<ApiPlayground />} />
       </Route>
     </Routes>
   );

--- a/web/src/components/Layout.tsx
+++ b/web/src/components/Layout.tsx
@@ -101,6 +101,10 @@ export function Layout() {
                     <span className="menu-icon">📡</span>
                     System Status
                   </Link>
+                  <Link to="/api-playground" onClick={closeDropdown}>
+                    <span className="menu-icon">🧪</span>
+                    API Playground
+                  </Link>
                 </div>
               )}
             </div>

--- a/web/src/pages/ApiPlayground.css
+++ b/web/src/pages/ApiPlayground.css
@@ -1,0 +1,760 @@
+/**
+ * API Playground Styles - IDE/Postman-inspired theme
+ */
+
+.api-playground {
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh;
+  background: #0d1117;
+  color: #e6edf3;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+}
+
+/* Header */
+.playground-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 1rem 1.5rem;
+  background: #161b22;
+  border-bottom: 1px solid #30363d;
+}
+
+.header-left {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+}
+
+.playground-header h1 {
+  margin: 0;
+  font-size: 1.25rem;
+  font-weight: 600;
+}
+
+.header-badge {
+  font-size: 0.65rem;
+  font-weight: 700;
+  letter-spacing: 1px;
+  padding: 0.25rem 0.5rem;
+  background: #f9731622;
+  color: #f97316;
+  border-radius: 4px;
+}
+
+.header-actions {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.action-btn {
+  padding: 0.5rem 0.75rem;
+  background: #21262d;
+  border: 1px solid #30363d;
+  color: #e6edf3;
+  border-radius: 6px;
+  cursor: pointer;
+  font-size: 0.85rem;
+  transition: all 0.15s;
+}
+
+.action-btn:hover {
+  background: #30363d;
+}
+
+.action-btn.active {
+  background: #1f6feb22;
+  border-color: #58a6ff;
+  color: #58a6ff;
+}
+
+/* Templates Panel */
+.templates-panel {
+  padding: 1rem 1.5rem;
+  background: #161b22;
+  border-bottom: 1px solid #30363d;
+}
+
+.templates-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(180px, 1fr));
+  gap: 0.75rem;
+}
+
+.template-card {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 0.25rem;
+  padding: 0.75rem;
+  background: #0d1117;
+  border: 1px solid #30363d;
+  border-radius: 6px;
+  cursor: pointer;
+  text-align: left;
+  transition: all 0.15s;
+}
+
+.template-card:hover {
+  border-color: #58a6ff;
+  background: #21262d;
+}
+
+.template-method {
+  font-size: 0.7rem;
+  font-weight: 700;
+  font-family: 'JetBrains Mono', 'Fira Code', monospace;
+}
+
+.template-name {
+  font-size: 0.9rem;
+  font-weight: 600;
+  color: #e6edf3;
+}
+
+.template-desc {
+  font-size: 0.75rem;
+  color: #8b949e;
+}
+
+/* Environment Panel */
+.env-panel {
+  padding: 1rem 1.5rem;
+  background: #161b22;
+  border-bottom: 1px solid #30363d;
+}
+
+.env-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 0.75rem;
+  font-size: 0.85rem;
+  font-weight: 600;
+}
+
+.env-add-btn {
+  padding: 0.3rem 0.6rem;
+  background: #21262d;
+  border: 1px solid #30363d;
+  color: #58a6ff;
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 0.8rem;
+}
+
+.env-add-btn:hover {
+  background: #30363d;
+}
+
+.env-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.env-item {
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+}
+
+.env-key {
+  width: 150px;
+  padding: 0.4rem 0.6rem;
+  background: #0d1117;
+  border: 1px solid #30363d;
+  border-radius: 4px;
+  color: #ffa657;
+  font-family: 'JetBrains Mono', 'Fira Code', monospace;
+  font-size: 0.85rem;
+}
+
+.env-value {
+  flex: 1;
+  padding: 0.4rem 0.6rem;
+  background: #0d1117;
+  border: 1px solid #30363d;
+  border-radius: 4px;
+  color: #e6edf3;
+  font-family: 'JetBrains Mono', 'Fira Code', monospace;
+  font-size: 0.85rem;
+}
+
+.env-key:focus,
+.env-value:focus {
+  outline: none;
+  border-color: #58a6ff;
+}
+
+.env-remove {
+  padding: 0.3rem 0.5rem;
+  background: none;
+  border: none;
+  color: #8b949e;
+  cursor: pointer;
+  font-size: 1.1rem;
+}
+
+.env-remove:hover {
+  color: #f85149;
+}
+
+.env-hint {
+  margin-top: 0.5rem;
+  font-size: 0.75rem;
+  color: #8b949e;
+}
+
+/* Request Builder */
+.request-builder {
+  padding: 1rem 1.5rem;
+  background: #161b22;
+  border-bottom: 1px solid #30363d;
+}
+
+.request-row {
+  display: flex;
+  gap: 0.75rem;
+}
+
+.method-select {
+  padding: 0.6rem 1rem;
+  background: #0d1117;
+  border: 2px solid;
+  border-radius: 6px;
+  color: #e6edf3;
+  font-weight: 700;
+  font-size: 0.9rem;
+  cursor: pointer;
+  min-width: 110px;
+}
+
+.method-select:focus {
+  outline: none;
+}
+
+.url-input {
+  flex: 1;
+  padding: 0.6rem 1rem;
+  background: #0d1117;
+  border: 1px solid #30363d;
+  border-radius: 6px;
+  color: #e6edf3;
+  font-family: 'JetBrains Mono', 'Fira Code', monospace;
+  font-size: 0.9rem;
+}
+
+.url-input:focus {
+  outline: none;
+  border-color: #58a6ff;
+}
+
+.send-btn {
+  padding: 0.6rem 1.5rem;
+  background: linear-gradient(135deg, #238636, #2ea043);
+  border: none;
+  border-radius: 6px;
+  color: #fff;
+  font-weight: 600;
+  font-size: 0.9rem;
+  cursor: pointer;
+  transition: all 0.15s;
+}
+
+.send-btn:hover:not(:disabled) {
+  background: linear-gradient(135deg, #2ea043, #3fb950);
+}
+
+.send-btn:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+/* Main Body */
+.playground-body {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+/* Tabs */
+.tabs {
+  display: flex;
+  gap: 0;
+  padding: 0 1.5rem;
+  background: #161b22;
+  border-bottom: 1px solid #30363d;
+}
+
+.tab {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.75rem 1.25rem;
+  background: none;
+  border: none;
+  border-bottom: 2px solid transparent;
+  color: #8b949e;
+  font-size: 0.9rem;
+  cursor: pointer;
+  transition: all 0.15s;
+}
+
+.tab:hover {
+  color: #e6edf3;
+}
+
+.tab.active {
+  color: #58a6ff;
+  border-bottom-color: #58a6ff;
+}
+
+.tab-count {
+  font-size: 0.75rem;
+  padding: 0.1rem 0.4rem;
+  background: #30363d;
+  border-radius: 10px;
+}
+
+.tab-status {
+  font-size: 0.7rem;
+  font-weight: 600;
+  padding: 0.15rem 0.4rem;
+  border-radius: 4px;
+  color: #fff;
+}
+
+/* Tab Content */
+.tab-content {
+  flex: 1;
+  overflow: auto;
+  padding: 1rem 1.5rem;
+}
+
+/* Headers Editor */
+.headers-editor {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.header-row {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.header-checkbox {
+  width: 18px;
+  height: 18px;
+  cursor: pointer;
+}
+
+.header-key {
+  width: 200px;
+  padding: 0.5rem 0.75rem;
+  background: #161b22;
+  border: 1px solid #30363d;
+  border-radius: 4px;
+  color: #ffa657;
+  font-family: 'JetBrains Mono', 'Fira Code', monospace;
+  font-size: 0.85rem;
+}
+
+.header-value {
+  flex: 1;
+  padding: 0.5rem 0.75rem;
+  background: #161b22;
+  border: 1px solid #30363d;
+  border-radius: 4px;
+  color: #e6edf3;
+  font-family: 'JetBrains Mono', 'Fira Code', monospace;
+  font-size: 0.85rem;
+}
+
+.header-key:focus,
+.header-value:focus {
+  outline: none;
+  border-color: #58a6ff;
+}
+
+.header-remove {
+  padding: 0.3rem 0.5rem;
+  background: none;
+  border: none;
+  color: #8b949e;
+  cursor: pointer;
+  font-size: 1.2rem;
+}
+
+.header-remove:hover {
+  color: #f85149;
+}
+
+.add-header-btn {
+  align-self: flex-start;
+  padding: 0.5rem 1rem;
+  background: #21262d;
+  border: 1px dashed #30363d;
+  border-radius: 6px;
+  color: #58a6ff;
+  cursor: pointer;
+  font-size: 0.85rem;
+  margin-top: 0.5rem;
+}
+
+.add-header-btn:hover {
+  background: #30363d;
+}
+
+/* Body Editor */
+.body-editor {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+}
+
+.body-toolbar {
+  display: flex;
+  gap: 0.5rem;
+  margin-bottom: 0.75rem;
+}
+
+.format-btn {
+  padding: 0.4rem 0.75rem;
+  background: #21262d;
+  border: 1px solid #30363d;
+  border-radius: 4px;
+  color: #e6edf3;
+  cursor: pointer;
+  font-size: 0.8rem;
+}
+
+.format-btn:hover {
+  background: #30363d;
+}
+
+.body-textarea {
+  flex: 1;
+  min-height: 300px;
+  padding: 1rem;
+  background: #161b22;
+  border: 1px solid #30363d;
+  border-radius: 6px;
+  color: #e6edf3;
+  font-family: 'JetBrains Mono', 'Fira Code', monospace;
+  font-size: 0.85rem;
+  line-height: 1.5;
+  resize: vertical;
+}
+
+.body-textarea:focus {
+  outline: none;
+  border-color: #58a6ff;
+}
+
+/* Response Viewer */
+.response-viewer {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.response-metrics {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.metric {
+  padding: 0.35rem 0.75rem;
+  border-radius: 4px;
+  font-size: 0.85rem;
+  font-weight: 600;
+  font-family: 'JetBrains Mono', 'Fira Code', monospace;
+}
+
+.metric.status {
+  color: #fff;
+}
+
+.metric.time {
+  background: #21262d;
+  color: #58a6ff;
+}
+
+.metric.size {
+  background: #21262d;
+  color: #8b949e;
+}
+
+.copy-btn {
+  padding: 0.35rem 0.75rem;
+  background: #21262d;
+  border: 1px solid #30363d;
+  border-radius: 4px;
+  color: #e6edf3;
+  cursor: pointer;
+  font-size: 0.8rem;
+  margin-left: auto;
+}
+
+.copy-btn:hover {
+  background: #30363d;
+}
+
+.response-error {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 1rem;
+  background: #f8514922;
+  border: 1px solid #f85149;
+  border-radius: 6px;
+  color: #f85149;
+}
+
+.error-icon {
+  font-size: 1.2rem;
+}
+
+.response-headers {
+  background: #161b22;
+  border: 1px solid #30363d;
+  border-radius: 6px;
+}
+
+.response-headers summary {
+  padding: 0.75rem 1rem;
+  cursor: pointer;
+  font-size: 0.85rem;
+  color: #8b949e;
+}
+
+.response-headers summary:hover {
+  color: #e6edf3;
+}
+
+.headers-list {
+  padding: 0 1rem 1rem;
+}
+
+.response-header-item {
+  display: flex;
+  gap: 0.5rem;
+  padding: 0.25rem 0;
+  font-size: 0.8rem;
+  font-family: 'JetBrains Mono', 'Fira Code', monospace;
+}
+
+.rh-key {
+  color: #ffa657;
+}
+
+.rh-value {
+  color: #8b949e;
+}
+
+.response-body {
+  margin: 0;
+  padding: 1rem;
+  background: #161b22;
+  border: 1px solid #30363d;
+  border-radius: 6px;
+  font-family: 'JetBrains Mono', 'Fira Code', monospace;
+  font-size: 0.85rem;
+  line-height: 1.5;
+  overflow: auto;
+  max-height: 500px;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.response-empty,
+.response-loading {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 3rem;
+  color: #8b949e;
+}
+
+.empty-icon {
+  font-size: 3rem;
+  margin-bottom: 1rem;
+}
+
+.loading-spinner {
+  width: 40px;
+  height: 40px;
+  border: 3px solid #21262d;
+  border-top-color: #58a6ff;
+  border-radius: 50%;
+  animation: spin 1s linear infinite;
+  margin-bottom: 1rem;
+}
+
+@keyframes spin {
+  to { transform: rotate(360deg); }
+}
+
+/* History Viewer */
+.history-viewer {
+  display: flex;
+  flex-direction: column;
+}
+
+.history-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 1rem;
+  font-size: 0.85rem;
+  color: #8b949e;
+}
+
+.clear-history-btn {
+  padding: 0.35rem 0.75rem;
+  background: #f8514922;
+  border: 1px solid #f85149;
+  border-radius: 4px;
+  color: #f85149;
+  cursor: pointer;
+  font-size: 0.8rem;
+}
+
+.clear-history-btn:hover {
+  background: #f8514944;
+}
+
+.history-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.history-item {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.75rem 1rem;
+  background: #161b22;
+  border: 1px solid #30363d;
+  border-radius: 6px;
+  cursor: pointer;
+  transition: all 0.15s;
+}
+
+.history-item:hover {
+  border-color: #58a6ff;
+  background: #21262d;
+}
+
+.history-method {
+  font-size: 0.75rem;
+  font-weight: 700;
+  font-family: 'JetBrains Mono', 'Fira Code', monospace;
+  min-width: 50px;
+}
+
+.history-url {
+  flex: 1;
+  font-size: 0.85rem;
+  font-family: 'JetBrains Mono', 'Fira Code', monospace;
+  color: #e6edf3;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.history-status {
+  font-size: 0.7rem;
+  font-weight: 600;
+  padding: 0.2rem 0.5rem;
+  border-radius: 4px;
+  color: #fff;
+}
+
+.history-time {
+  font-size: 0.8rem;
+  font-family: 'JetBrains Mono', 'Fira Code', monospace;
+  color: #58a6ff;
+  min-width: 50px;
+  text-align: right;
+}
+
+.history-ago {
+  font-size: 0.75rem;
+  color: #6b7280;
+  min-width: 60px;
+  text-align: right;
+}
+
+.history-empty {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 3rem;
+  color: #8b949e;
+}
+
+/* Responsive */
+@media (max-width: 768px) {
+  .request-row {
+    flex-direction: column;
+  }
+
+  .method-select {
+    width: 100%;
+  }
+
+  .header-row {
+    flex-wrap: wrap;
+  }
+
+  .header-key {
+    width: 100%;
+  }
+
+  .templates-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .history-item {
+    flex-wrap: wrap;
+  }
+
+  .history-url {
+    width: 100%;
+    order: 10;
+    margin-top: 0.5rem;
+  }
+}
+
+/* Scrollbar */
+.tab-content::-webkit-scrollbar,
+.response-body::-webkit-scrollbar {
+  width: 8px;
+}
+
+.tab-content::-webkit-scrollbar-track,
+.response-body::-webkit-scrollbar-track {
+  background: #0d1117;
+}
+
+.tab-content::-webkit-scrollbar-thumb,
+.response-body::-webkit-scrollbar-thumb {
+  background: #30363d;
+  border-radius: 4px;
+}
+
+.tab-content::-webkit-scrollbar-thumb:hover,
+.response-body::-webkit-scrollbar-thumb:hover {
+  background: #484f58;
+}

--- a/web/src/pages/ApiPlayground.tsx
+++ b/web/src/pages/ApiPlayground.tsx
@@ -1,0 +1,637 @@
+/**
+ * API Playground - Interactive API testing tool
+ *
+ * Features:
+ * - Request builder with method, URL, headers, body
+ * - Response viewer with syntax highlighting
+ * - Request history saved to localStorage
+ * - Pre-built API endpoint templates
+ * - Environment variables
+ * - Response metrics (status, time, size)
+ */
+
+import { useState, useEffect, useCallback } from 'react';
+import './ApiPlayground.css';
+
+type HttpMethod = 'GET' | 'POST' | 'PUT' | 'DELETE' | 'PATCH';
+
+interface Header {
+  key: string;
+  value: string;
+  enabled: boolean;
+}
+
+interface HistoryItem {
+  id: string;
+  timestamp: number;
+  method: HttpMethod;
+  url: string;
+  status: number;
+  time: number;
+}
+
+interface EnvVariable {
+  key: string;
+  value: string;
+}
+
+interface ApiTemplate {
+  name: string;
+  method: HttpMethod;
+  path: string;
+  headers?: Header[];
+  body?: string;
+  description: string;
+}
+
+const STORAGE_KEY = 'api_playground_history';
+const ENV_STORAGE_KEY = 'api_playground_env';
+
+const DEFAULT_BASE_URL = 'http://localhost:8000';
+
+const METHOD_COLORS: Record<HttpMethod, string> = {
+  GET: '#22c55e',
+  POST: '#3b82f6',
+  PUT: '#f97316',
+  DELETE: '#ef4444',
+  PATCH: '#a855f7',
+};
+
+// Pre-built API templates
+const API_TEMPLATES: ApiTemplate[] = [
+  { name: 'Health Check', method: 'GET', path: '/api/health', description: 'Basic health check' },
+  { name: 'System Status', method: 'GET', path: '/api/status', description: 'Full system status' },
+  { name: 'Cache Stats', method: 'GET', path: '/api/cache/stats', description: 'Redis cache statistics' },
+  { name: 'Cache Keys', method: 'GET', path: '/api/cache/keys?pattern=*', description: 'List cache keys' },
+  { name: 'DB Tables', method: 'GET', path: '/api/db/tables', description: 'List database tables' },
+  { name: 'Leaderboard', method: 'GET', path: '/api/leaderboard?limit=10', description: 'Top scores' },
+  { name: 'Login', method: 'POST', path: '/api/auth/login', description: 'Authenticate user', body: JSON.stringify({ username: 'demo', password: 'DemoPass123' }, null, 2) },
+  { name: 'Register', method: 'POST', path: '/api/auth/register', description: 'Create account', body: JSON.stringify({ username: '', email: '', password: '' }, null, 2) },
+  { name: 'Daily Challenge', method: 'GET', path: '/api/daily', description: 'Today\'s challenge' },
+  { name: 'Achievements', method: 'GET', path: '/api/achievements', description: 'All achievements' },
+];
+
+export function ApiPlayground() {
+  // Request state
+  const [method, setMethod] = useState<HttpMethod>('GET');
+  const [url, setUrl] = useState(`${DEFAULT_BASE_URL}/api/health`);
+  const [headers, setHeaders] = useState<Header[]>([
+    { key: 'Content-Type', value: 'application/json', enabled: true },
+  ]);
+  const [body, setBody] = useState('');
+
+  // Response state
+  const [response, setResponse] = useState<string | null>(null);
+  const [responseStatus, setResponseStatus] = useState<number | null>(null);
+  const [responseTime, setResponseTime] = useState<number | null>(null);
+  const [responseSize, setResponseSize] = useState<number | null>(null);
+  const [responseHeaders, setResponseHeaders] = useState<Record<string, string>>({});
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  // History & env state
+  const [history, setHistory] = useState<HistoryItem[]>([]);
+  const [envVars, setEnvVars] = useState<EnvVariable[]>([
+    { key: 'BASE_URL', value: DEFAULT_BASE_URL },
+  ]);
+  const [showEnvPanel, setShowEnvPanel] = useState(false);
+  const [showTemplates, setShowTemplates] = useState(false);
+  const [activeTab, setActiveTab] = useState<'headers' | 'body' | 'response' | 'history'>('response');
+
+  // Load history and env from localStorage
+  useEffect(() => {
+    try {
+      const savedHistory = localStorage.getItem(STORAGE_KEY);
+      if (savedHistory) setHistory(JSON.parse(savedHistory));
+
+      const savedEnv = localStorage.getItem(ENV_STORAGE_KEY);
+      if (savedEnv) setEnvVars(JSON.parse(savedEnv));
+    } catch (e) {
+      console.warn('Failed to load saved data:', e);
+    }
+  }, []);
+
+  // Save history to localStorage
+  useEffect(() => {
+    try {
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(history.slice(0, 50)));
+    } catch (e) {
+      console.warn('Failed to save history:', e);
+    }
+  }, [history]);
+
+  // Save env to localStorage
+  useEffect(() => {
+    try {
+      localStorage.setItem(ENV_STORAGE_KEY, JSON.stringify(envVars));
+    } catch (e) {
+      console.warn('Failed to save env:', e);
+    }
+  }, [envVars]);
+
+  // Replace env variables in string
+  const replaceEnvVars = useCallback((str: string): string => {
+    let result = str;
+    envVars.forEach(({ key, value }) => {
+      result = result.replace(new RegExp(`\\{\\{${key}\\}\\}`, 'g'), value);
+    });
+    return result;
+  }, [envVars]);
+
+  // Send request
+  const sendRequest = async () => {
+    setIsLoading(true);
+    setError(null);
+    setResponse(null);
+    setResponseStatus(null);
+    setResponseTime(null);
+    setResponseSize(null);
+    setResponseHeaders({});
+
+    const finalUrl = replaceEnvVars(url);
+    const startTime = performance.now();
+
+    try {
+      const enabledHeaders = headers
+        .filter(h => h.enabled && h.key.trim())
+        .reduce((acc, h) => ({ ...acc, [h.key]: replaceEnvVars(h.value) }), {} as Record<string, string>);
+
+      const options: RequestInit = {
+        method,
+        headers: enabledHeaders,
+      };
+
+      if (['POST', 'PUT', 'PATCH'].includes(method) && body.trim()) {
+        options.body = replaceEnvVars(body);
+      }
+
+      const res = await fetch(finalUrl, options);
+      const endTime = performance.now();
+      const elapsed = Math.round(endTime - startTime);
+
+      // Get response text
+      const text = await res.text();
+      const size = new Blob([text]).size;
+
+      // Try to format as JSON
+      let formattedResponse = text;
+      try {
+        const json = JSON.parse(text);
+        formattedResponse = JSON.stringify(json, null, 2);
+      } catch {
+        // Not JSON, keep as-is
+      }
+
+      // Extract response headers
+      const resHeaders: Record<string, string> = {};
+      res.headers.forEach((value, key) => {
+        resHeaders[key] = value;
+      });
+
+      setResponse(formattedResponse);
+      setResponseStatus(res.status);
+      setResponseTime(elapsed);
+      setResponseSize(size);
+      setResponseHeaders(resHeaders);
+      setActiveTab('response');
+
+      // Add to history
+      const historyItem: HistoryItem = {
+        id: Date.now().toString(),
+        timestamp: Date.now(),
+        method,
+        url: finalUrl,
+        status: res.status,
+        time: elapsed,
+      };
+      setHistory(prev => [historyItem, ...prev.slice(0, 49)]);
+
+    } catch (e) {
+      const endTime = performance.now();
+      setError(e instanceof Error ? e.message : 'Request failed');
+      setResponseTime(Math.round(endTime - startTime));
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  // Load template
+  const loadTemplate = (template: ApiTemplate) => {
+    const baseUrl = envVars.find(v => v.key === 'BASE_URL')?.value || DEFAULT_BASE_URL;
+    setMethod(template.method);
+    setUrl(`${baseUrl}${template.path}`);
+    if (template.body) {
+      setBody(template.body);
+      setActiveTab('body');
+    } else {
+      setBody('');
+    }
+    if (template.headers) {
+      setHeaders(template.headers);
+    }
+    setShowTemplates(false);
+  };
+
+  // Load from history
+  const loadFromHistory = (item: HistoryItem) => {
+    setUrl(item.url);
+    setMethod(item.method);
+    setActiveTab('response');
+  };
+
+  // Clear history
+  const clearHistory = () => {
+    setHistory([]);
+    localStorage.removeItem(STORAGE_KEY);
+  };
+
+  // Add header
+  const addHeader = () => {
+    setHeaders([...headers, { key: '', value: '', enabled: true }]);
+  };
+
+  // Update header
+  const updateHeader = (index: number, field: keyof Header, value: string | boolean) => {
+    const updated = [...headers];
+    updated[index] = { ...updated[index], [field]: value };
+    setHeaders(updated);
+  };
+
+  // Remove header
+  const removeHeader = (index: number) => {
+    setHeaders(headers.filter((_, i) => i !== index));
+  };
+
+  // Add env variable
+  const addEnvVar = () => {
+    setEnvVars([...envVars, { key: '', value: '' }]);
+  };
+
+  // Update env variable
+  const updateEnvVar = (index: number, field: keyof EnvVariable, value: string) => {
+    const updated = [...envVars];
+    updated[index] = { ...updated[index], [field]: value };
+    setEnvVars(updated);
+  };
+
+  // Remove env variable
+  const removeEnvVar = (index: number) => {
+    setEnvVars(envVars.filter((_, i) => i !== index));
+  };
+
+  // Copy response to clipboard
+  const copyResponse = () => {
+    if (response) {
+      navigator.clipboard.writeText(response);
+    }
+  };
+
+  // Format body as JSON
+  const formatBody = () => {
+    try {
+      const parsed = JSON.parse(body);
+      setBody(JSON.stringify(parsed, null, 2));
+    } catch {
+      // Not valid JSON
+    }
+  };
+
+  // Get status color
+  const getStatusColor = (status: number): string => {
+    if (status >= 200 && status < 300) return '#22c55e';
+    if (status >= 300 && status < 400) return '#3b82f6';
+    if (status >= 400 && status < 500) return '#f97316';
+    return '#ef4444';
+  };
+
+  // Format time ago
+  const formatTimeAgo = (timestamp: number): string => {
+    const seconds = Math.floor((Date.now() - timestamp) / 1000);
+    if (seconds < 60) return `${seconds}s ago`;
+    const minutes = Math.floor(seconds / 60);
+    if (minutes < 60) return `${minutes}m ago`;
+    const hours = Math.floor(minutes / 60);
+    if (hours < 24) return `${hours}h ago`;
+    return `${Math.floor(hours / 24)}d ago`;
+  };
+
+  return (
+    <div className="api-playground">
+      {/* Header */}
+      <header className="playground-header">
+        <div className="header-left">
+          <h1>API Playground</h1>
+          <span className="header-badge">DEV TOOL</span>
+        </div>
+        <div className="header-actions">
+          <button
+            className={`action-btn ${showTemplates ? 'active' : ''}`}
+            onClick={() => setShowTemplates(!showTemplates)}
+          >
+            📋 Templates
+          </button>
+          <button
+            className={`action-btn ${showEnvPanel ? 'active' : ''}`}
+            onClick={() => setShowEnvPanel(!showEnvPanel)}
+          >
+            ⚙️ Environment
+          </button>
+        </div>
+      </header>
+
+      {/* Templates Panel */}
+      {showTemplates && (
+        <div className="templates-panel">
+          <div className="templates-grid">
+            {API_TEMPLATES.map((template, i) => (
+              <button
+                key={i}
+                className="template-card"
+                onClick={() => loadTemplate(template)}
+              >
+                <span
+                  className="template-method"
+                  style={{ color: METHOD_COLORS[template.method] }}
+                >
+                  {template.method}
+                </span>
+                <span className="template-name">{template.name}</span>
+                <span className="template-desc">{template.description}</span>
+              </button>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* Environment Panel */}
+      {showEnvPanel && (
+        <div className="env-panel">
+          <div className="env-header">
+            <span>Environment Variables</span>
+            <button className="env-add-btn" onClick={addEnvVar}>+ Add</button>
+          </div>
+          <div className="env-list">
+            {envVars.map((v, i) => (
+              <div key={i} className="env-item">
+                <input
+                  type="text"
+                  value={v.key}
+                  onChange={(e) => updateEnvVar(i, 'key', e.target.value)}
+                  placeholder="KEY"
+                  className="env-key"
+                />
+                <input
+                  type="text"
+                  value={v.value}
+                  onChange={(e) => updateEnvVar(i, 'value', e.target.value)}
+                  placeholder="value"
+                  className="env-value"
+                />
+                <button className="env-remove" onClick={() => removeEnvVar(i)}>×</button>
+              </div>
+            ))}
+          </div>
+          <div className="env-hint">Use {`{{KEY}}`} in URL, headers, or body</div>
+        </div>
+      )}
+
+      {/* Request Builder */}
+      <div className="request-builder">
+        <div className="request-row">
+          <select
+            value={method}
+            onChange={(e) => setMethod(e.target.value as HttpMethod)}
+            className="method-select"
+            style={{ borderColor: METHOD_COLORS[method] }}
+          >
+            {Object.keys(METHOD_COLORS).map((m) => (
+              <option key={m} value={m}>{m}</option>
+            ))}
+          </select>
+          <input
+            type="text"
+            value={url}
+            onChange={(e) => setUrl(e.target.value)}
+            placeholder="Enter request URL"
+            className="url-input"
+          />
+          <button
+            className="send-btn"
+            onClick={sendRequest}
+            disabled={isLoading}
+          >
+            {isLoading ? 'Sending...' : 'Send'}
+          </button>
+        </div>
+      </div>
+
+      {/* Main Content */}
+      <div className="playground-body">
+        {/* Tabs */}
+        <div className="tabs">
+          <button
+            className={`tab ${activeTab === 'headers' ? 'active' : ''}`}
+            onClick={() => setActiveTab('headers')}
+          >
+            Headers
+            <span className="tab-count">{headers.filter(h => h.enabled).length}</span>
+          </button>
+          <button
+            className={`tab ${activeTab === 'body' ? 'active' : ''}`}
+            onClick={() => setActiveTab('body')}
+          >
+            Body
+          </button>
+          <button
+            className={`tab ${activeTab === 'response' ? 'active' : ''}`}
+            onClick={() => setActiveTab('response')}
+          >
+            Response
+            {responseStatus && (
+              <span
+                className="tab-status"
+                style={{ backgroundColor: getStatusColor(responseStatus) }}
+              >
+                {responseStatus}
+              </span>
+            )}
+          </button>
+          <button
+            className={`tab ${activeTab === 'history' ? 'active' : ''}`}
+            onClick={() => setActiveTab('history')}
+          >
+            History
+            <span className="tab-count">{history.length}</span>
+          </button>
+        </div>
+
+        {/* Tab Content */}
+        <div className="tab-content">
+          {/* Headers Tab */}
+          {activeTab === 'headers' && (
+            <div className="headers-editor">
+              {headers.map((h, i) => (
+                <div key={i} className="header-row">
+                  <input
+                    type="checkbox"
+                    checked={h.enabled}
+                    onChange={(e) => updateHeader(i, 'enabled', e.target.checked)}
+                    className="header-checkbox"
+                  />
+                  <input
+                    type="text"
+                    value={h.key}
+                    onChange={(e) => updateHeader(i, 'key', e.target.value)}
+                    placeholder="Header name"
+                    className="header-key"
+                  />
+                  <input
+                    type="text"
+                    value={h.value}
+                    onChange={(e) => updateHeader(i, 'value', e.target.value)}
+                    placeholder="Value"
+                    className="header-value"
+                  />
+                  <button className="header-remove" onClick={() => removeHeader(i)}>×</button>
+                </div>
+              ))}
+              <button className="add-header-btn" onClick={addHeader}>+ Add Header</button>
+            </div>
+          )}
+
+          {/* Body Tab */}
+          {activeTab === 'body' && (
+            <div className="body-editor">
+              <div className="body-toolbar">
+                <button onClick={formatBody} className="format-btn">Format JSON</button>
+              </div>
+              <textarea
+                value={body}
+                onChange={(e) => setBody(e.target.value)}
+                placeholder="Request body (JSON)"
+                className="body-textarea"
+                spellCheck={false}
+              />
+            </div>
+          )}
+
+          {/* Response Tab */}
+          {activeTab === 'response' && (
+            <div className="response-viewer">
+              {/* Response Metrics */}
+              {(responseStatus || error) && (
+                <div className="response-metrics">
+                  {responseStatus && (
+                    <span
+                      className="metric status"
+                      style={{ backgroundColor: getStatusColor(responseStatus) }}
+                    >
+                      {responseStatus}
+                    </span>
+                  )}
+                  {responseTime !== null && (
+                    <span className="metric time">{responseTime}ms</span>
+                  )}
+                  {responseSize !== null && (
+                    <span className="metric size">{responseSize} bytes</span>
+                  )}
+                  {response && (
+                    <button className="copy-btn" onClick={copyResponse}>
+                      📋 Copy
+                    </button>
+                  )}
+                </div>
+              )}
+
+              {/* Error Display */}
+              {error && (
+                <div className="response-error">
+                  <span className="error-icon">⚠</span>
+                  {error}
+                </div>
+              )}
+
+              {/* Response Headers */}
+              {Object.keys(responseHeaders).length > 0 && (
+                <details className="response-headers">
+                  <summary>Response Headers ({Object.keys(responseHeaders).length})</summary>
+                  <div className="headers-list">
+                    {Object.entries(responseHeaders).map(([key, value]) => (
+                      <div key={key} className="response-header-item">
+                        <span className="rh-key">{key}:</span>
+                        <span className="rh-value">{value}</span>
+                      </div>
+                    ))}
+                  </div>
+                </details>
+              )}
+
+              {/* Response Body */}
+              {response ? (
+                <pre className="response-body">{response}</pre>
+              ) : !error && !isLoading ? (
+                <div className="response-empty">
+                  <span className="empty-icon">📡</span>
+                  <p>Send a request to see the response</p>
+                </div>
+              ) : isLoading ? (
+                <div className="response-loading">
+                  <div className="loading-spinner" />
+                  <p>Sending request...</p>
+                </div>
+              ) : null}
+            </div>
+          )}
+
+          {/* History Tab */}
+          {activeTab === 'history' && (
+            <div className="history-viewer">
+              {history.length > 0 ? (
+                <>
+                  <div className="history-header">
+                    <span>{history.length} requests</span>
+                    <button className="clear-history-btn" onClick={clearHistory}>
+                      Clear All
+                    </button>
+                  </div>
+                  <div className="history-list">
+                    {history.map((item) => (
+                      <div
+                        key={item.id}
+                        className="history-item"
+                        onClick={() => loadFromHistory(item)}
+                      >
+                        <span
+                          className="history-method"
+                          style={{ color: METHOD_COLORS[item.method] }}
+                        >
+                          {item.method}
+                        </span>
+                        <span className="history-url">{item.url}</span>
+                        <span
+                          className="history-status"
+                          style={{ backgroundColor: getStatusColor(item.status) }}
+                        >
+                          {item.status}
+                        </span>
+                        <span className="history-time">{item.time}ms</span>
+                        <span className="history-ago">{formatTimeAgo(item.timestamp)}</span>
+                      </div>
+                    ))}
+                  </div>
+                </>
+              ) : (
+                <div className="history-empty">
+                  <span className="empty-icon">📜</span>
+                  <p>No request history yet</p>
+                </div>
+              )}
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default ApiPlayground;

--- a/web/src/pages/index.ts
+++ b/web/src/pages/index.ts
@@ -20,3 +20,4 @@ export { DatabaseExplorer } from './DatabaseExplorer';
 export { CacheInspector } from './CacheInspector';
 export { AudioJukebox } from './AudioJukebox';
 export { SystemStatus } from './SystemStatus';
+export { ApiPlayground } from './ApiPlayground';


### PR DESCRIPTION
## Summary
Custom API Playground with Postman/Insomnia-style interface, embedded in the app's design system.

## Features
- **Request Builder**: Method selector, URL input, headers editor, body editor
- **Response Viewer**: Formatted JSON, status code, response time, size
- **Request History**: Last 50 requests saved to localStorage
- **API Templates**: 10 pre-built templates for quick testing (health, auth, cache, etc.)
- **Environment Variables**: `{{BASE_URL}}` substitution in URL/headers/body
- **IDE Theme**: Dark mode with monospace fonts, color-coded methods

## Test plan
- [ ] Navigate to /api-playground
- [ ] Click a template (e.g., "Health Check") and hit Send
- [ ] Verify response displays with status, time, size
- [ ] Test POST with Login template
- [ ] Add custom headers and verify they're sent
- [ ] Check history tab shows past requests
- [ ] Test environment variable substitution
- [ ] Clear history and verify it's empty

🤖 Generated with [Claude Code](https://claude.com/claude-code)