### PR TITLE
feat(dev-tools): add Build Info page

### DIFF
--- a/server/app/api/buildinfo.py
+++ b/server/app/api/buildinfo.py
@@ -1,0 +1,209 @@
+"""
+Build Info API - Provides build and environment information.
+
+Returns git commit info, dependency versions, and environment details.
+"""
+
+import os
+import sys
+import subprocess
+import platform
+from datetime import datetime
+from typing import Optional
+from pathlib import Path
+
+from fastapi import APIRouter, Depends
+from pydantic import BaseModel
+
+from ..core.config import settings
+from ..api.dbexplorer import require_debug
+
+router = APIRouter(prefix="/api/build", tags=["build-info"])
+
+# Cache git info since it won't change during runtime
+_git_info_cache: Optional[dict] = None
+
+
+class GitInfo(BaseModel):
+    """Git repository information."""
+    commit_hash: Optional[str] = None
+    commit_short: Optional[str] = None
+    branch: Optional[str] = None
+    author: Optional[str] = None
+    author_email: Optional[str] = None
+    commit_date: Optional[str] = None
+    commit_message: Optional[str] = None
+    is_dirty: bool = False
+    tags: list[str] = []
+
+
+class PythonInfo(BaseModel):
+    """Python environment information."""
+    version: str
+    implementation: str
+    executable: str
+    packages: list[dict]
+
+
+class EnvironmentInfo(BaseModel):
+    """Environment and system information."""
+    platform: str
+    platform_release: str
+    architecture: str
+    hostname: str
+    working_directory: str
+    debug_mode: bool
+    environment: str
+
+
+class BuildInfoResponse(BaseModel):
+    """Complete build information response."""
+    app_name: str
+    app_version: str
+    build_timestamp: str
+    git: GitInfo
+    python: PythonInfo
+    environment: EnvironmentInfo
+
+
+def run_git_command(args: list[str]) -> Optional[str]:
+    """Run a git command and return output."""
+    try:
+        result = subprocess.run(
+            ["git"] + args,
+            capture_output=True,
+            text=True,
+            timeout=5,
+            cwd=Path(__file__).parent.parent.parent.parent,  # repo root
+        )
+        if result.returncode == 0:
+            return result.stdout.strip()
+    except Exception:
+        pass
+    return None
+
+
+def get_git_info() -> GitInfo:
+    """Gather git repository information."""
+    global _git_info_cache
+
+    if _git_info_cache is not None:
+        return GitInfo(**_git_info_cache)
+
+    info = GitInfo()
+
+    # Commit hash
+    commit_hash = run_git_command(["rev-parse", "HEAD"])
+    if commit_hash:
+        info.commit_hash = commit_hash
+        info.commit_short = commit_hash[:7]
+
+    # Branch name
+    branch = run_git_command(["rev-parse", "--abbrev-ref", "HEAD"])
+    if branch:
+        info.branch = branch
+
+    # Author info
+    author = run_git_command(["log", "-1", "--format=%an"])
+    if author:
+        info.author = author
+
+    author_email = run_git_command(["log", "-1", "--format=%ae"])
+    if author_email:
+        info.author_email = author_email
+
+    # Commit date
+    commit_date = run_git_command(["log", "-1", "--format=%ci"])
+    if commit_date:
+        info.commit_date = commit_date
+
+    # Commit message
+    commit_msg = run_git_command(["log", "-1", "--format=%s"])
+    if commit_msg:
+        info.commit_message = commit_msg
+
+    # Check if dirty
+    status = run_git_command(["status", "--porcelain"])
+    info.is_dirty = bool(status)
+
+    # Tags pointing to current commit
+    tags = run_git_command(["tag", "--points-at", "HEAD"])
+    if tags:
+        info.tags = tags.split("\n")
+
+    # Cache the result
+    _git_info_cache = info.model_dump()
+
+    return info
+
+
+def get_python_info() -> PythonInfo:
+    """Gather Python environment information."""
+    # Get installed packages
+    packages = []
+    try:
+        result = subprocess.run(
+            [sys.executable, "-m", "pip", "list", "--format=json"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        if result.returncode == 0:
+            import json
+            packages = json.loads(result.stdout)
+    except Exception:
+        pass
+
+    return PythonInfo(
+        version=platform.python_version(),
+        implementation=platform.python_implementation(),
+        executable=sys.executable,
+        packages=packages,
+    )
+
+
+def get_environment_info() -> EnvironmentInfo:
+    """Gather environment information."""
+    return EnvironmentInfo(
+        platform=platform.system(),
+        platform_release=platform.release(),
+        architecture=platform.machine(),
+        hostname=platform.node(),
+        working_directory=os.getcwd(),
+        debug_mode=settings.debug,
+        environment="development" if settings.debug else "production",
+    )
+
+
+@router.get("", response_model=BuildInfoResponse)
+async def get_build_info(_: None = Depends(require_debug)):
+    """
+    Get comprehensive build and environment information.
+
+    Only available in debug mode.
+    """
+    return BuildInfoResponse(
+        app_name=settings.app_name,
+        app_version=settings.app_version,
+        build_timestamp=datetime.utcnow().isoformat() + "Z",
+        git=get_git_info(),
+        python=get_python_info(),
+        environment=get_environment_info(),
+    )
+
+
+@router.get("/git")
+async def get_git_only(_: None = Depends(require_debug)):
+    """Get only git information."""
+    return get_git_info()
+
+
+@router.get("/packages")
+async def get_packages(_: None = Depends(require_debug)):
+    """Get installed Python packages."""
+    info = get_python_info()
+    return {
+        "python_version": info.version,
+        "package_count": len(info.packages),
+        "packages": info.packages,
+    }

--- a/server/app/main.py
+++ b/server/app/main.py
@@ -19,6 +19,7 @@ from .api.daily import router as daily_router
 from .api.dbexplorer import router as dbexplorer_router
 from .api.cache import router as cache_router
 from .api.status import router as status_router
+from .api.buildinfo import router as buildinfo_router
 
 
 @asynccontextmanager
@@ -79,6 +80,7 @@ def create_app() -> FastAPI:
     app.include_router(dbexplorer_router, tags=["dev-tools"])
     app.include_router(cache_router, tags=["dev-tools"])
     app.include_router(status_router, tags=["dev-tools"])
+    app.include_router(buildinfo_router, tags=["dev-tools"])
 
     return app
 

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,6 +1,6 @@
 import { Routes, Route } from 'react-router-dom';
 import { Layout } from './components/Layout';
-import { Home, Login, Register, Play, Features, About, PlayScene, SceneDemo, Leaderboard, Ghosts, Profile, Achievements, Spectate, Friends, Presentation, Roadmap, CodebaseHealth, Changelog, DatabaseExplorer, CacheInspector, AudioJukebox, SystemStatus, ApiPlayground, WebSocketMonitor } from './pages';
+import { Home, Login, Register, Play, Features, About, PlayScene, SceneDemo, Leaderboard, Ghosts, Profile, Achievements, Spectate, Friends, Presentation, Roadmap, CodebaseHealth, Changelog, DatabaseExplorer, CacheInspector, AudioJukebox, SystemStatus, ApiPlayground, WebSocketMonitor, BuildInfo } from './pages';
 import { FirstPersonDemo } from './pages/FirstPersonDemo';
 import { FirstPersonTestPage } from './pages/FirstPersonTestPage';
 import { Debug3DPage } from './pages/Debug3DPage';
@@ -39,6 +39,7 @@ function App() {
         <Route path="system-status" element={<SystemStatus />} />
         <Route path="api-playground" element={<ApiPlayground />} />
         <Route path="ws-monitor" element={<WebSocketMonitor />} />
+        <Route path="build-info" element={<BuildInfo />} />
       </Route>
     </Routes>
   );

--- a/web/src/components/Layout.tsx
+++ b/web/src/components/Layout.tsx
@@ -109,6 +109,10 @@ export function Layout() {
                     <span className="menu-icon">🔌</span>
                     WS Monitor
                   </Link>
+                  <Link to="/build-info" onClick={closeDropdown}>
+                    <span className="menu-icon">🏗️</span>
+                    Build Info
+                  </Link>
                 </div>
               )}
             </div>

--- a/web/src/pages/BuildInfo.css
+++ b/web/src/pages/BuildInfo.css
@@ -1,0 +1,455 @@
+/**
+ * Build Info Styles - Developer/Terminal theme
+ */
+
+.build-info {
+  min-height: 100vh;
+  background: #0d1117;
+  color: #e6edf3;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+}
+
+/* Loading & Error States */
+.build-loading,
+.build-error {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  min-height: 60vh;
+  gap: 1rem;
+}
+
+.loading-spinner {
+  width: 50px;
+  height: 50px;
+  border: 3px solid #21262d;
+  border-top-color: #58a6ff;
+  border-radius: 50%;
+  animation: spin 1s linear infinite;
+}
+
+@keyframes spin {
+  to { transform: rotate(360deg); }
+}
+
+.build-error {
+  color: #f85149;
+}
+
+.error-icon {
+  font-size: 3rem;
+}
+
+.retry-btn {
+  padding: 0.5rem 1rem;
+  background: #21262d;
+  border: 1px solid #30363d;
+  border-radius: 6px;
+  color: #e6edf3;
+  cursor: pointer;
+  margin-top: 0.5rem;
+}
+
+.retry-btn:hover {
+  background: #30363d;
+}
+
+/* Header */
+.build-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 1rem 1.5rem;
+  background: #161b22;
+  border-bottom: 1px solid #30363d;
+}
+
+.header-left {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+}
+
+.build-header h1 {
+  margin: 0;
+  font-size: 1.25rem;
+  font-weight: 600;
+}
+
+.header-badge {
+  font-size: 0.65rem;
+  font-weight: 700;
+  letter-spacing: 1px;
+  padding: 0.25rem 0.5rem;
+  background: #a855f722;
+  color: #a855f7;
+  border-radius: 4px;
+}
+
+.app-badge {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.5rem 1rem;
+  background: #0d1117;
+  border: 1px solid #30363d;
+  border-radius: 6px;
+}
+
+.app-name {
+  font-weight: 600;
+}
+
+.app-version {
+  font-family: 'JetBrains Mono', 'Fira Code', monospace;
+  color: #58a6ff;
+}
+
+/* Body */
+.build-body {
+  padding: 1.5rem;
+  max-width: 1200px;
+  margin: 0 auto;
+}
+
+/* Sections */
+.info-section {
+  background: #161b22;
+  border: 1px solid #30363d;
+  border-radius: 8px;
+  margin-bottom: 1.5rem;
+  overflow: hidden;
+}
+
+.section-title {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  margin: 0;
+  padding: 1rem 1.25rem;
+  font-size: 1rem;
+  font-weight: 600;
+  background: #0d1117;
+  border-bottom: 1px solid #30363d;
+}
+
+.section-icon {
+  font-size: 1.1rem;
+}
+
+.dirty-badge {
+  font-size: 0.65rem;
+  font-weight: 700;
+  padding: 0.2rem 0.5rem;
+  background: #f9731633;
+  color: #f97316;
+  border-radius: 4px;
+  margin-left: auto;
+}
+
+.env-badge {
+  font-size: 0.65rem;
+  font-weight: 700;
+  padding: 0.2rem 0.5rem;
+  border-radius: 4px;
+  margin-left: auto;
+}
+
+.env-development {
+  background: #eab30822;
+  color: #eab308;
+}
+
+.env-production {
+  background: #22c55e22;
+  color: #22c55e;
+}
+
+.package-count {
+  font-size: 0.8rem;
+  font-weight: 500;
+  padding: 0.2rem 0.5rem;
+  background: #30363d;
+  border-radius: 10px;
+  margin-left: auto;
+  font-family: 'JetBrains Mono', 'Fira Code', monospace;
+}
+
+/* Info Grid */
+.info-grid {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 0;
+}
+
+.info-row {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  padding: 0.75rem 1.25rem;
+  border-bottom: 1px solid #21262d;
+}
+
+.info-row:nth-child(odd) {
+  border-right: 1px solid #21262d;
+}
+
+.info-row.full-width {
+  grid-column: 1 / -1;
+  border-right: none;
+}
+
+.info-row:last-child,
+.info-row:nth-last-child(2):nth-child(odd) {
+  border-bottom: none;
+}
+
+.info-label {
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  color: #8b949e;
+}
+
+.info-value {
+  font-size: 0.9rem;
+  color: #e6edf3;
+  word-break: break-word;
+}
+
+.info-value.mono {
+  font-family: 'JetBrains Mono', 'Fira Code', monospace;
+  font-size: 0.85rem;
+}
+
+.info-value-group {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+/* Git specific */
+.branch-value {
+  color: #a855f7;
+  font-weight: 600;
+}
+
+.commit-hash {
+  font-family: 'JetBrains Mono', 'Fira Code', monospace;
+  background: #30363d;
+  padding: 0.2rem 0.5rem;
+  border-radius: 4px;
+  cursor: pointer;
+  transition: background 0.15s;
+}
+
+.commit-hash:hover {
+  background: #484f58;
+}
+
+.copied-badge {
+  font-size: 0.7rem;
+  color: #22c55e;
+  animation: fadeIn 0.2s ease;
+}
+
+@keyframes fadeIn {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+
+.commit-message {
+  font-style: italic;
+  color: #8b949e;
+}
+
+.author-email {
+  color: #8b949e;
+  font-size: 0.85rem;
+}
+
+.tags-list {
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
+.tag-badge {
+  font-size: 0.75rem;
+  padding: 0.2rem 0.5rem;
+  background: #22c55e22;
+  color: #22c55e;
+  border-radius: 4px;
+  font-family: 'JetBrains Mono', 'Fira Code', monospace;
+}
+
+/* Path values */
+.path-value {
+  font-size: 0.8rem;
+  background: #0d1117;
+  padding: 0.3rem 0.5rem;
+  border-radius: 4px;
+  overflow-x: auto;
+}
+
+/* Boolean values */
+.bool-true {
+  color: #22c55e;
+}
+
+.bool-false {
+  color: #8b949e;
+}
+
+/* Python version */
+.python-version {
+  color: #3b82f6;
+  font-family: 'JetBrains Mono', 'Fira Code', monospace;
+}
+
+/* Packages Section */
+.packages-toolbar {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  padding: 0.75rem 1.25rem;
+  border-bottom: 1px solid #21262d;
+}
+
+.package-filter {
+  flex: 1;
+  max-width: 300px;
+  padding: 0.5rem 0.75rem;
+  background: #0d1117;
+  border: 1px solid #30363d;
+  border-radius: 6px;
+  color: #e6edf3;
+  font-size: 0.85rem;
+}
+
+.package-filter:focus {
+  outline: none;
+  border-color: #58a6ff;
+}
+
+.filter-count {
+  font-size: 0.8rem;
+  color: #8b949e;
+  font-family: 'JetBrains Mono', 'Fira Code', monospace;
+}
+
+.packages-list {
+  max-height: 400px;
+  overflow-y: auto;
+  padding: 0.5rem;
+}
+
+.package-item {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 0.5rem 0.75rem;
+  border-radius: 4px;
+  transition: background 0.15s;
+}
+
+.package-item:hover {
+  background: #21262d;
+}
+
+.package-name {
+  font-family: 'JetBrains Mono', 'Fira Code', monospace;
+  font-size: 0.85rem;
+}
+
+.package-version {
+  font-family: 'JetBrains Mono', 'Fira Code', monospace;
+  font-size: 0.8rem;
+  color: #8b949e;
+}
+
+.packages-empty {
+  padding: 2rem;
+  text-align: center;
+  color: #6b7280;
+}
+
+/* Build Timestamp */
+.build-timestamp {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  padding: 1rem 1.25rem;
+  background: #161b22;
+  border: 1px solid #30363d;
+  border-radius: 8px;
+  font-size: 0.85rem;
+}
+
+.timestamp-label {
+  color: #8b949e;
+}
+
+.timestamp-value {
+  font-family: 'JetBrains Mono', 'Fira Code', monospace;
+  color: #e6edf3;
+}
+
+.refresh-btn {
+  margin-left: auto;
+  padding: 0.4rem 0.75rem;
+  background: #21262d;
+  border: 1px solid #30363d;
+  border-radius: 6px;
+  color: #e6edf3;
+  font-size: 0.85rem;
+  cursor: pointer;
+  transition: all 0.15s;
+}
+
+.refresh-btn:hover {
+  background: #30363d;
+  border-color: #58a6ff;
+}
+
+/* Scrollbar */
+.packages-list::-webkit-scrollbar {
+  width: 8px;
+}
+
+.packages-list::-webkit-scrollbar-track {
+  background: #0d1117;
+}
+
+.packages-list::-webkit-scrollbar-thumb {
+  background: #30363d;
+  border-radius: 4px;
+}
+
+.packages-list::-webkit-scrollbar-thumb:hover {
+  background: #484f58;
+}
+
+/* Responsive */
+@media (max-width: 768px) {
+  .info-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .info-row:nth-child(odd) {
+    border-right: none;
+  }
+
+  .build-timestamp {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 0.5rem;
+  }
+
+  .refresh-btn {
+    margin-left: 0;
+    width: 100%;
+  }
+}

--- a/web/src/pages/BuildInfo.tsx
+++ b/web/src/pages/BuildInfo.tsx
@@ -1,0 +1,325 @@
+/**
+ * Build Info - Development build and environment information
+ *
+ * Features:
+ * - Git commit info (hash, branch, author, message)
+ * - Python environment details
+ * - Installed packages with versions
+ * - Environment configuration
+ * - Copy-to-clipboard functionality
+ */
+
+import { useState, useEffect } from 'react';
+import './BuildInfo.css';
+
+const API_BASE = 'http://localhost:8000/api/build';
+
+interface GitInfo {
+  commit_hash: string | null;
+  commit_short: string | null;
+  branch: string | null;
+  author: string | null;
+  author_email: string | null;
+  commit_date: string | null;
+  commit_message: string | null;
+  is_dirty: boolean;
+  tags: string[];
+}
+
+interface PythonInfo {
+  version: string;
+  implementation: string;
+  executable: string;
+  packages: Array<{ name: string; version: string }>;
+}
+
+interface EnvironmentInfo {
+  platform: string;
+  platform_release: string;
+  architecture: string;
+  hostname: string;
+  working_directory: string;
+  debug_mode: boolean;
+  environment: string;
+}
+
+interface BuildInfoResponse {
+  app_name: string;
+  app_version: string;
+  build_timestamp: string;
+  git: GitInfo;
+  python: PythonInfo;
+  environment: EnvironmentInfo;
+}
+
+export function BuildInfo() {
+  const [info, setInfo] = useState<BuildInfoResponse | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [packageFilter, setPackageFilter] = useState('');
+  const [copiedField, setCopiedField] = useState<string | null>(null);
+
+  useEffect(() => {
+    fetchBuildInfo();
+  }, []);
+
+  const fetchBuildInfo = async () => {
+    try {
+      setLoading(true);
+      const res = await fetch(API_BASE);
+      if (!res.ok) {
+        const err = await res.json();
+        throw new Error(err.detail || 'Failed to fetch build info');
+      }
+      const data = await res.json();
+      setInfo(data);
+      setError(null);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Failed to fetch build info');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const copyToClipboard = (text: string, field: string) => {
+    navigator.clipboard.writeText(text);
+    setCopiedField(field);
+    setTimeout(() => setCopiedField(null), 2000);
+  };
+
+  const formatDate = (dateStr: string): string => {
+    try {
+      const date = new Date(dateStr);
+      return date.toLocaleString();
+    } catch {
+      return dateStr;
+    }
+  };
+
+  const filteredPackages = info?.python.packages.filter((pkg) =>
+    pkg.name.toLowerCase().includes(packageFilter.toLowerCase())
+  ) || [];
+
+  if (loading) {
+    return (
+      <div className="build-info">
+        <div className="build-loading">
+          <div className="loading-spinner" />
+          <p>Loading build information...</p>
+        </div>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="build-info">
+        <div className="build-error">
+          <span className="error-icon">⚠</span>
+          <p>{error}</p>
+          <button onClick={fetchBuildInfo} className="retry-btn">Retry</button>
+        </div>
+      </div>
+    );
+  }
+
+  if (!info) return null;
+
+  return (
+    <div className="build-info">
+      {/* Header */}
+      <header className="build-header">
+        <div className="header-left">
+          <h1>Build Info</h1>
+          <span className="header-badge">DEV</span>
+        </div>
+        <div className="header-right">
+          <div className="app-badge">
+            <span className="app-name">{info.app_name}</span>
+            <span className="app-version">v{info.app_version}</span>
+          </div>
+        </div>
+      </header>
+
+      <div className="build-body">
+        {/* Git Section */}
+        <section className="info-section git-section">
+          <h2 className="section-title">
+            <span className="section-icon">⎇</span>
+            Git Information
+            {info.git.is_dirty && <span className="dirty-badge">DIRTY</span>}
+          </h2>
+
+          <div className="info-grid">
+            <div className="info-row">
+              <span className="info-label">Branch</span>
+              <span className="info-value branch-value">
+                {info.git.branch || 'unknown'}
+              </span>
+            </div>
+
+            <div className="info-row">
+              <span className="info-label">Commit</span>
+              <div className="info-value-group">
+                <code
+                  className="commit-hash"
+                  onClick={() => info.git.commit_hash && copyToClipboard(info.git.commit_hash, 'commit')}
+                  title="Click to copy full hash"
+                >
+                  {info.git.commit_short || 'unknown'}
+                </code>
+                {copiedField === 'commit' && <span className="copied-badge">Copied!</span>}
+              </div>
+            </div>
+
+            <div className="info-row full-width">
+              <span className="info-label">Message</span>
+              <span className="info-value commit-message">
+                {info.git.commit_message || 'No message'}
+              </span>
+            </div>
+
+            <div className="info-row">
+              <span className="info-label">Author</span>
+              <span className="info-value">
+                {info.git.author || 'unknown'}
+                {info.git.author_email && (
+                  <span className="author-email"> &lt;{info.git.author_email}&gt;</span>
+                )}
+              </span>
+            </div>
+
+            <div className="info-row">
+              <span className="info-label">Date</span>
+              <span className="info-value">
+                {info.git.commit_date ? formatDate(info.git.commit_date) : 'unknown'}
+              </span>
+            </div>
+
+            {info.git.tags.length > 0 && (
+              <div className="info-row">
+                <span className="info-label">Tags</span>
+                <div className="tags-list">
+                  {info.git.tags.map((tag) => (
+                    <span key={tag} className="tag-badge">{tag}</span>
+                  ))}
+                </div>
+              </div>
+            )}
+          </div>
+        </section>
+
+        {/* Environment Section */}
+        <section className="info-section env-section">
+          <h2 className="section-title">
+            <span className="section-icon">⚙</span>
+            Environment
+            <span className={`env-badge env-${info.environment.environment}`}>
+              {info.environment.environment}
+            </span>
+          </h2>
+
+          <div className="info-grid">
+            <div className="info-row">
+              <span className="info-label">Platform</span>
+              <span className="info-value">
+                {info.environment.platform} {info.environment.platform_release}
+              </span>
+            </div>
+
+            <div className="info-row">
+              <span className="info-label">Architecture</span>
+              <span className="info-value">{info.environment.architecture}</span>
+            </div>
+
+            <div className="info-row">
+              <span className="info-label">Hostname</span>
+              <span className="info-value mono">{info.environment.hostname}</span>
+            </div>
+
+            <div className="info-row full-width">
+              <span className="info-label">Working Dir</span>
+              <span className="info-value mono path-value">
+                {info.environment.working_directory}
+              </span>
+            </div>
+
+            <div className="info-row">
+              <span className="info-label">Debug Mode</span>
+              <span className={`info-value bool-${info.environment.debug_mode}`}>
+                {info.environment.debug_mode ? 'Enabled' : 'Disabled'}
+              </span>
+            </div>
+          </div>
+        </section>
+
+        {/* Python Section */}
+        <section className="info-section python-section">
+          <h2 className="section-title">
+            <span className="section-icon">🐍</span>
+            Python Environment
+          </h2>
+
+          <div className="info-grid">
+            <div className="info-row">
+              <span className="info-label">Version</span>
+              <span className="info-value python-version">
+                {info.python.implementation} {info.python.version}
+              </span>
+            </div>
+
+            <div className="info-row full-width">
+              <span className="info-label">Executable</span>
+              <span className="info-value mono path-value">
+                {info.python.executable}
+              </span>
+            </div>
+          </div>
+        </section>
+
+        {/* Packages Section */}
+        <section className="info-section packages-section">
+          <h2 className="section-title">
+            <span className="section-icon">📦</span>
+            Installed Packages
+            <span className="package-count">{info.python.packages.length}</span>
+          </h2>
+
+          <div className="packages-toolbar">
+            <input
+              type="text"
+              value={packageFilter}
+              onChange={(e) => setPackageFilter(e.target.value)}
+              placeholder="Filter packages..."
+              className="package-filter"
+            />
+            <span className="filter-count">
+              {filteredPackages.length} / {info.python.packages.length}
+            </span>
+          </div>
+
+          <div className="packages-list">
+            {filteredPackages.map((pkg) => (
+              <div key={pkg.name} className="package-item">
+                <span className="package-name">{pkg.name}</span>
+                <span className="package-version">{pkg.version}</span>
+              </div>
+            ))}
+            {filteredPackages.length === 0 && (
+              <div className="packages-empty">No packages match filter</div>
+            )}
+          </div>
+        </section>
+
+        {/* Build Timestamp */}
+        <div className="build-timestamp">
+          <span className="timestamp-label">Info retrieved at:</span>
+          <span className="timestamp-value">{formatDate(info.build_timestamp)}</span>
+          <button onClick={fetchBuildInfo} className="refresh-btn">↻ Refresh</button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default BuildInfo;

--- a/web/src/pages/index.ts
+++ b/web/src/pages/index.ts
@@ -22,3 +22,4 @@ export { AudioJukebox } from './AudioJukebox';
 export { SystemStatus } from './SystemStatus';
 export { ApiPlayground } from './ApiPlayground';
 export { WebSocketMonitor } from './WebSocketMonitor';
+export { BuildInfo } from './BuildInfo';


### PR DESCRIPTION
## Summary
- Add Build Info dev tool page showing git commit, branch, author, and dirty status
- Display Python environment including version, implementation, and all installed packages with filter search
- Show system environment details: platform, architecture, hostname, working directory, debug mode
- Backend endpoint at `/api/build` with DEBUG mode gating via `require_debug` dependency
- Frontend with developer/terminal theme matching existing dev tools

## Test plan
- [ ] Navigate to Game → Build Info in the nav menu
- [ ] Verify git information displays correctly (branch, commit hash, author)
- [ ] Test copy-to-clipboard on commit hash
- [ ] Verify package list displays and filter works
- [ ] Verify refresh button reloads data
- [ ] Confirm endpoint returns 403 if DEBUG mode is disabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)