### PR TITLE
feat(dev-tools): add Log Viewer with real-time streaming

### DIFF
--- a/server/app/api/logs.py
+++ b/server/app/api/logs.py
@@ -1,0 +1,278 @@
+"""
+Log Viewer API - Real-time application log streaming.
+
+Captures application logs in a ring buffer and provides:
+- REST endpoint to fetch recent logs
+- WebSocket endpoint for real-time streaming
+- Filtering by level, source, and search term
+"""
+
+import logging
+import asyncio
+from datetime import datetime
+from collections import deque
+from typing import Optional
+from enum import Enum
+
+from fastapi import APIRouter, Depends, WebSocket, WebSocketDisconnect, Query
+from pydantic import BaseModel
+
+from ..api.dbexplorer import require_debug
+
+router = APIRouter(prefix="/api/logs", tags=["logs"])
+
+# Ring buffer for storing logs (last 1000 entries)
+MAX_LOG_ENTRIES = 1000
+log_buffer: deque = deque(maxlen=MAX_LOG_ENTRIES)
+
+# Connected WebSocket clients for real-time streaming
+connected_clients: set[WebSocket] = set()
+
+
+class LogLevel(str, Enum):
+    DEBUG = "DEBUG"
+    INFO = "INFO"
+    WARNING = "WARNING"
+    ERROR = "ERROR"
+    CRITICAL = "CRITICAL"
+
+
+class LogEntry(BaseModel):
+    """A single log entry."""
+    id: int
+    timestamp: str
+    level: str
+    logger: str
+    message: str
+    source: Optional[str] = None
+    line: Optional[int] = None
+
+
+class LogsResponse(BaseModel):
+    """Response containing log entries."""
+    entries: list[LogEntry]
+    total: int
+    has_more: bool
+
+
+# Custom log handler that captures logs to our buffer
+class BufferLogHandler(logging.Handler):
+    """Custom handler that writes logs to our ring buffer."""
+
+    _id_counter = 0
+
+    def emit(self, record: logging.LogRecord):
+        try:
+            BufferLogHandler._id_counter += 1
+            entry = LogEntry(
+                id=BufferLogHandler._id_counter,
+                timestamp=datetime.fromtimestamp(record.created).isoformat() + "Z",
+                level=record.levelname,
+                logger=record.name,
+                message=self.format(record),
+                source=record.pathname if hasattr(record, 'pathname') else None,
+                line=record.lineno if hasattr(record, 'lineno') else None,
+            )
+            log_buffer.append(entry)
+
+            # Broadcast to connected WebSocket clients
+            asyncio.create_task(broadcast_log(entry))
+        except Exception:
+            pass  # Don't let logging errors break the app
+
+
+async def broadcast_log(entry: LogEntry):
+    """Broadcast a log entry to all connected WebSocket clients."""
+    if not connected_clients:
+        return
+
+    message = entry.model_dump_json()
+    disconnected = set()
+
+    for client in connected_clients:
+        try:
+            await client.send_text(message)
+        except Exception:
+            disconnected.add(client)
+
+    # Clean up disconnected clients
+    connected_clients.difference_update(disconnected)
+
+
+def setup_log_capture():
+    """Set up log capturing for the application."""
+    handler = BufferLogHandler()
+    handler.setLevel(logging.DEBUG)
+    formatter = logging.Formatter('%(message)s')
+    handler.setFormatter(formatter)
+
+    # Add handler to root logger
+    root_logger = logging.getLogger()
+    root_logger.addHandler(handler)
+
+    # Also capture uvicorn access logs
+    uvicorn_logger = logging.getLogger("uvicorn.access")
+    uvicorn_logger.addHandler(handler)
+
+    # Capture FastAPI logs
+    fastapi_logger = logging.getLogger("fastapi")
+    fastapi_logger.addHandler(handler)
+
+    return handler
+
+
+# Initialize log capture on module load
+_log_handler = setup_log_capture()
+
+
+@router.get("", response_model=LogsResponse)
+async def get_logs(
+    _: None = Depends(require_debug),
+    limit: int = Query(100, ge=1, le=500),
+    offset: int = Query(0, ge=0),
+    level: Optional[LogLevel] = None,
+    logger: Optional[str] = None,
+    search: Optional[str] = None,
+):
+    """
+    Get recent application logs.
+
+    Supports filtering by:
+    - level: Filter by log level (DEBUG, INFO, WARNING, ERROR, CRITICAL)
+    - logger: Filter by logger name (e.g., 'uvicorn.access')
+    - search: Search in log messages
+    """
+    # Convert deque to list for filtering
+    all_entries = list(log_buffer)
+
+    # Apply filters
+    filtered = all_entries
+
+    if level:
+        level_order = ["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"]
+        min_level_idx = level_order.index(level.value)
+        filtered = [
+            e for e in filtered
+            if e.level in level_order[min_level_idx:]
+        ]
+
+    if logger:
+        filtered = [e for e in filtered if logger.lower() in e.logger.lower()]
+
+    if search:
+        search_lower = search.lower()
+        filtered = [
+            e for e in filtered
+            if search_lower in e.message.lower() or search_lower in e.logger.lower()
+        ]
+
+    # Reverse to show newest first
+    filtered = list(reversed(filtered))
+
+    total = len(filtered)
+    paginated = filtered[offset:offset + limit]
+
+    return LogsResponse(
+        entries=paginated,
+        total=total,
+        has_more=(offset + limit) < total,
+    )
+
+
+@router.get("/levels")
+async def get_log_levels(_: None = Depends(require_debug)):
+    """Get available log levels and their counts."""
+    all_entries = list(log_buffer)
+
+    counts = {
+        "DEBUG": 0,
+        "INFO": 0,
+        "WARNING": 0,
+        "ERROR": 0,
+        "CRITICAL": 0,
+    }
+
+    for entry in all_entries:
+        if entry.level in counts:
+            counts[entry.level] += 1
+
+    return {
+        "levels": counts,
+        "total": len(all_entries),
+    }
+
+
+@router.get("/loggers")
+async def get_loggers(_: None = Depends(require_debug)):
+    """Get list of active loggers."""
+    all_entries = list(log_buffer)
+
+    loggers: dict[str, int] = {}
+    for entry in all_entries:
+        loggers[entry.logger] = loggers.get(entry.logger, 0) + 1
+
+    # Sort by count descending
+    sorted_loggers = sorted(loggers.items(), key=lambda x: x[1], reverse=True)
+
+    return {
+        "loggers": [{"name": name, "count": count} for name, count in sorted_loggers],
+    }
+
+
+@router.delete("")
+async def clear_logs(_: None = Depends(require_debug)):
+    """Clear the log buffer."""
+    log_buffer.clear()
+    return {"status": "cleared", "message": "Log buffer cleared"}
+
+
+@router.post("/test")
+async def create_test_log(
+    _: None = Depends(require_debug),
+    level: LogLevel = LogLevel.INFO,
+    message: str = "Test log message",
+):
+    """Create a test log entry for debugging."""
+    logger = logging.getLogger("test.manual")
+    log_func = getattr(logger, level.value.lower())
+    log_func(message)
+    return {"status": "created", "level": level, "message": message}
+
+
+@router.websocket("/stream")
+async def websocket_log_stream(websocket: WebSocket):
+    """
+    WebSocket endpoint for real-time log streaming.
+
+    Clients receive log entries as JSON messages.
+    Send 'ping' to keep connection alive.
+    """
+    await websocket.accept()
+
+    # Check debug mode (simplified check for WebSocket)
+    from ..core.config import settings
+    if not settings.debug:
+        await websocket.close(code=4003, reason="Debug mode required")
+        return
+
+    connected_clients.add(websocket)
+
+    try:
+        # Send recent logs on connect
+        recent_logs = list(log_buffer)[-50:]  # Last 50 entries
+        for entry in recent_logs:
+            await websocket.send_text(entry.model_dump_json())
+
+        # Keep connection alive and handle client messages
+        while True:
+            try:
+                data = await asyncio.wait_for(websocket.receive_text(), timeout=30.0)
+                if data == "ping":
+                    await websocket.send_text('{"type": "pong"}')
+            except asyncio.TimeoutError:
+                # Send keepalive
+                await websocket.send_text('{"type": "keepalive"}')
+    except WebSocketDisconnect:
+        pass
+    finally:
+        connected_clients.discard(websocket)

--- a/server/app/main.py
+++ b/server/app/main.py
@@ -20,6 +20,7 @@ from .api.dbexplorer import router as dbexplorer_router
 from .api.cache import router as cache_router
 from .api.status import router as status_router
 from .api.buildinfo import router as buildinfo_router
+from .api.logs import router as logs_router
 
 
 @asynccontextmanager
@@ -81,6 +82,7 @@ def create_app() -> FastAPI:
     app.include_router(cache_router, tags=["dev-tools"])
     app.include_router(status_router, tags=["dev-tools"])
     app.include_router(buildinfo_router, tags=["dev-tools"])
+    app.include_router(logs_router, tags=["dev-tools"])
 
     return app
 

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,6 +1,6 @@
 import { Routes, Route } from 'react-router-dom';
 import { Layout } from './components/Layout';
-import { Home, Login, Register, Play, Features, About, PlayScene, SceneDemo, Leaderboard, Ghosts, Profile, Achievements, Spectate, Friends, Presentation, Roadmap, CodebaseHealth, Changelog, DatabaseExplorer, CacheInspector, AudioJukebox, SystemStatus, ApiPlayground, WebSocketMonitor, BuildInfo } from './pages';
+import { Home, Login, Register, Play, Features, About, PlayScene, SceneDemo, Leaderboard, Ghosts, Profile, Achievements, Spectate, Friends, Presentation, Roadmap, CodebaseHealth, Changelog, DatabaseExplorer, CacheInspector, AudioJukebox, SystemStatus, ApiPlayground, WebSocketMonitor, BuildInfo, LogViewer } from './pages';
 import { FirstPersonDemo } from './pages/FirstPersonDemo';
 import { FirstPersonTestPage } from './pages/FirstPersonTestPage';
 import { Debug3DPage } from './pages/Debug3DPage';
@@ -40,6 +40,7 @@ function App() {
         <Route path="api-playground" element={<ApiPlayground />} />
         <Route path="ws-monitor" element={<WebSocketMonitor />} />
         <Route path="build-info" element={<BuildInfo />} />
+        <Route path="log-viewer" element={<LogViewer />} />
       </Route>
     </Routes>
   );

--- a/web/src/components/Layout.tsx
+++ b/web/src/components/Layout.tsx
@@ -152,6 +152,10 @@ export function Layout() {
                     <span className="menu-icon">🏗️</span>
                     Build Info
                   </Link>
+                  <Link to="/log-viewer" onClick={closeDropdown}>
+                    <span className="menu-icon">📜</span>
+                    Log Viewer
+                  </Link>
                   <Link to="/codebase-health" onClick={closeDropdown}>
                     <span className="menu-icon">🩺</span>
                     Codebase Health

--- a/web/src/pages/LogViewer.css
+++ b/web/src/pages/LogViewer.css
@@ -1,0 +1,455 @@
+/**
+ * Log Viewer Styles - Terminal/Console theme
+ */
+
+.log-viewer {
+  min-height: 100vh;
+  background: #0d1117;
+  color: #e6edf3;
+  font-family: 'JetBrains Mono', 'Fira Code', 'Consolas', monospace;
+  display: flex;
+  flex-direction: column;
+}
+
+/* Loading State */
+.log-loading {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  min-height: 60vh;
+  gap: 1rem;
+}
+
+.loading-spinner {
+  width: 40px;
+  height: 40px;
+  border: 3px solid #21262d;
+  border-top-color: #58a6ff;
+  border-radius: 50%;
+  animation: spin 1s linear infinite;
+}
+
+@keyframes spin {
+  to { transform: rotate(360deg); }
+}
+
+/* Header */
+.log-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 1rem 1.5rem;
+  background: #161b22;
+  border-bottom: 1px solid #30363d;
+}
+
+.log-header .header-left {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+}
+
+.log-header h1 {
+  margin: 0;
+  font-size: 1.25rem;
+  font-weight: 600;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+}
+
+.connection-status {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.8rem;
+  padding: 0.25rem 0.75rem;
+  border-radius: 12px;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+}
+
+.connection-status.connected {
+  background: #22c55e22;
+  color: #22c55e;
+}
+
+.connection-status.disconnected {
+  background: #f8514922;
+  color: #f85149;
+}
+
+.status-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: currentColor;
+  animation: pulse 2s ease-in-out infinite;
+}
+
+.connection-status.disconnected .status-dot {
+  animation: none;
+}
+
+@keyframes pulse {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.5; }
+}
+
+.log-count {
+  font-size: 0.85rem;
+  color: #8b949e;
+  background: #21262d;
+  padding: 0.25rem 0.75rem;
+  border-radius: 12px;
+}
+
+/* Toolbar */
+.log-toolbar {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1rem;
+  padding: 0.75rem 1.5rem;
+  background: #161b22;
+  border-bottom: 1px solid #21262d;
+  flex-wrap: wrap;
+}
+
+.toolbar-left,
+.toolbar-right {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.level-select,
+.logger-select {
+  padding: 0.5rem 0.75rem;
+  background: #0d1117;
+  border: 1px solid #30363d;
+  border-radius: 6px;
+  color: #e6edf3;
+  font-size: 0.85rem;
+  cursor: pointer;
+  min-width: 140px;
+}
+
+.level-select:focus,
+.logger-select:focus {
+  outline: none;
+  border-color: #58a6ff;
+}
+
+.search-input {
+  padding: 0.5rem 0.75rem;
+  background: #0d1117;
+  border: 1px solid #30363d;
+  border-radius: 6px;
+  color: #e6edf3;
+  font-size: 0.85rem;
+  min-width: 200px;
+}
+
+.search-input:focus {
+  outline: none;
+  border-color: #58a6ff;
+}
+
+.search-input::placeholder {
+  color: #6b7280;
+}
+
+/* Test Buttons */
+.test-buttons {
+  display: flex;
+  gap: 0.25rem;
+}
+
+.test-btn {
+  padding: 0.35rem 0.5rem;
+  border: none;
+  border-radius: 4px;
+  font-size: 0.7rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: all 0.15s;
+}
+
+.test-btn.test-info {
+  background: #58a6ff33;
+  color: #58a6ff;
+}
+
+.test-btn.test-info:hover {
+  background: #58a6ff55;
+}
+
+.test-btn.test-warning {
+  background: #d2992233;
+  color: #d29922;
+}
+
+.test-btn.test-warning:hover {
+  background: #d2992255;
+}
+
+.test-btn.test-error {
+  background: #f8514933;
+  color: #f85149;
+}
+
+.test-btn.test-error:hover {
+  background: #f8514955;
+}
+
+/* Action Buttons */
+.action-btn {
+  padding: 0.5rem 0.75rem;
+  background: #21262d;
+  border: 1px solid #30363d;
+  border-radius: 6px;
+  color: #e6edf3;
+  font-size: 0.85rem;
+  cursor: pointer;
+  transition: all 0.15s;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+}
+
+.action-btn:hover {
+  background: #30363d;
+  border-color: #484f58;
+}
+
+.action-btn.paused {
+  background: #22c55e22;
+  border-color: #22c55e55;
+  color: #22c55e;
+}
+
+.action-btn.danger {
+  color: #f85149;
+}
+
+.action-btn.danger:hover {
+  background: #f8514922;
+  border-color: #f85149;
+}
+
+/* Error Banner */
+.error-banner {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 0.75rem 1.5rem;
+  background: #f8514922;
+  border-bottom: 1px solid #f8514955;
+  color: #f85149;
+  font-size: 0.9rem;
+}
+
+.error-banner button {
+  padding: 0.25rem 0.75rem;
+  background: transparent;
+  border: 1px solid #f85149;
+  border-radius: 4px;
+  color: #f85149;
+  cursor: pointer;
+}
+
+.error-banner button:hover {
+  background: #f8514933;
+}
+
+/* Log Container */
+.log-container {
+  flex: 1;
+  overflow-y: auto;
+  padding: 0;
+  background: #0d1117;
+  min-height: 400px;
+  max-height: calc(100vh - 220px);
+}
+
+.no-logs {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  min-height: 300px;
+  color: #6b7280;
+}
+
+.no-logs .hint {
+  font-size: 0.85rem;
+  color: #4b5563;
+}
+
+/* Log Entries */
+.log-entries {
+  padding: 0.5rem 0;
+}
+
+.log-entry {
+  display: flex;
+  align-items: flex-start;
+  gap: 1rem;
+  padding: 0.35rem 1.5rem;
+  font-size: 0.8rem;
+  line-height: 1.5;
+  border-left: 3px solid transparent;
+  transition: background 0.1s;
+}
+
+.log-entry:hover {
+  background: #161b22;
+}
+
+.log-entry.level-debug {
+  border-left-color: #8b949e;
+}
+
+.log-entry.level-info {
+  border-left-color: #58a6ff;
+}
+
+.log-entry.level-warning {
+  border-left-color: #d29922;
+  background: #d2992208;
+}
+
+.log-entry.level-error {
+  border-left-color: #f85149;
+  background: #f8514910;
+}
+
+.log-entry.level-critical {
+  border-left-color: #ff7b72;
+  background: #ff7b7215;
+}
+
+.log-time {
+  flex-shrink: 0;
+  color: #6b7280;
+  font-size: 0.75rem;
+  min-width: 100px;
+}
+
+.log-level {
+  flex-shrink: 0;
+  font-weight: 600;
+  font-size: 0.7rem;
+  min-width: 70px;
+  text-transform: uppercase;
+}
+
+.log-logger {
+  flex-shrink: 0;
+  color: #a855f7;
+  font-size: 0.75rem;
+  min-width: 150px;
+  max-width: 200px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.log-message {
+  flex: 1;
+  color: #e6edf3;
+  word-break: break-word;
+  white-space: pre-wrap;
+}
+
+/* Footer */
+.log-footer {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 0.75rem 1.5rem;
+  background: #161b22;
+  border-top: 1px solid #30363d;
+  font-size: 0.85rem;
+}
+
+.auto-scroll-toggle {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  cursor: pointer;
+  color: #8b949e;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+}
+
+.auto-scroll-toggle input {
+  cursor: pointer;
+}
+
+.footer-hint {
+  color: #6b7280;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+}
+
+/* Scrollbar */
+.log-container::-webkit-scrollbar {
+  width: 10px;
+}
+
+.log-container::-webkit-scrollbar-track {
+  background: #0d1117;
+}
+
+.log-container::-webkit-scrollbar-thumb {
+  background: #30363d;
+  border-radius: 5px;
+}
+
+.log-container::-webkit-scrollbar-thumb:hover {
+  background: #484f58;
+}
+
+/* Responsive */
+@media (max-width: 900px) {
+  .log-toolbar {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .toolbar-left,
+  .toolbar-right {
+    justify-content: flex-start;
+  }
+
+  .search-input {
+    min-width: 150px;
+    flex: 1;
+  }
+
+  .log-entry {
+    flex-wrap: wrap;
+    gap: 0.5rem;
+  }
+
+  .log-logger {
+    min-width: auto;
+    max-width: none;
+  }
+
+  .log-message {
+    width: 100%;
+    padding-left: 0;
+  }
+}
+
+@media (max-width: 600px) {
+  .test-buttons {
+    display: none;
+  }
+
+  .log-time {
+    min-width: auto;
+  }
+
+  .log-level {
+    min-width: auto;
+  }
+}

--- a/web/src/pages/LogViewer.tsx
+++ b/web/src/pages/LogViewer.tsx
@@ -1,0 +1,404 @@
+/**
+ * Log Viewer - Real-time application log streaming
+ *
+ * Features:
+ * - Real-time WebSocket log streaming
+ * - Filter by log level
+ * - Search in messages
+ * - Auto-scroll with pause
+ * - Log level coloring
+ * - Export logs
+ */
+
+import { useState, useEffect, useRef, useCallback } from 'react';
+import './LogViewer.css';
+
+const API_BASE = 'http://localhost:8000/api/logs';
+const WS_URL = 'ws://localhost:8000/api/logs/stream';
+
+interface LogEntry {
+  id: number;
+  timestamp: string;
+  level: string;
+  logger: string;
+  message: string;
+  source?: string;
+  line?: number;
+}
+
+interface LoggerInfo {
+  name: string;
+  count: number;
+}
+
+type LogLevel = 'DEBUG' | 'INFO' | 'WARNING' | 'ERROR' | 'CRITICAL';
+
+const LEVEL_COLORS: Record<LogLevel, string> = {
+  DEBUG: '#8b949e',
+  INFO: '#58a6ff',
+  WARNING: '#d29922',
+  ERROR: '#f85149',
+  CRITICAL: '#ff7b72',
+};
+
+export function LogViewer() {
+  const [logs, setLogs] = useState<LogEntry[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [connected, setConnected] = useState(false);
+  const [autoScroll, setAutoScroll] = useState(true);
+  const [selectedLevel, setSelectedLevel] = useState<LogLevel | 'ALL'>('ALL');
+  const [selectedLogger, setSelectedLogger] = useState<string>('');
+  const [searchTerm, setSearchTerm] = useState('');
+  const [loggers, setLoggers] = useState<LoggerInfo[]>([]);
+  const [levelCounts, setLevelCounts] = useState<Record<string, number>>({});
+  const [isPaused, setIsPaused] = useState(false);
+
+  const logsEndRef = useRef<HTMLDivElement>(null);
+  const logsContainerRef = useRef<HTMLDivElement>(null);
+  const wsRef = useRef<WebSocket | null>(null);
+
+  // Fetch initial logs
+  const fetchLogs = useCallback(async () => {
+    try {
+      setLoading(true);
+      const params = new URLSearchParams({ limit: '200' });
+      if (selectedLevel !== 'ALL') params.append('level', selectedLevel);
+      if (selectedLogger) params.append('logger', selectedLogger);
+      if (searchTerm) params.append('search', searchTerm);
+
+      const res = await fetch(`${API_BASE}?${params}`);
+      if (!res.ok) throw new Error('Failed to fetch logs');
+      const data = await res.json();
+      setLogs(data.entries.reverse()); // Reverse to show oldest first, newest at bottom
+      setError(null);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Failed to fetch logs');
+    } finally {
+      setLoading(false);
+    }
+  }, [selectedLevel, selectedLogger, searchTerm]);
+
+  // Fetch loggers and level counts
+  const fetchMetadata = useCallback(async () => {
+    try {
+      const [loggersRes, levelsRes] = await Promise.all([
+        fetch(`${API_BASE}/loggers`),
+        fetch(`${API_BASE}/levels`),
+      ]);
+
+      if (loggersRes.ok) {
+        const data = await loggersRes.json();
+        setLoggers(data.loggers);
+      }
+
+      if (levelsRes.ok) {
+        const data = await levelsRes.json();
+        setLevelCounts(data.levels);
+      }
+    } catch {
+      // Silently fail metadata fetch
+    }
+  }, []);
+
+  // WebSocket connection
+  useEffect(() => {
+    if (isPaused) return;
+
+    const ws = new WebSocket(WS_URL);
+    wsRef.current = ws;
+
+    ws.onopen = () => {
+      setConnected(true);
+      setError(null);
+    };
+
+    ws.onmessage = (event) => {
+      try {
+        const data = JSON.parse(event.data);
+        if (data.type === 'pong' || data.type === 'keepalive') return;
+
+        const entry = data as LogEntry;
+
+        // Apply filters
+        if (selectedLevel !== 'ALL') {
+          const levelOrder = ['DEBUG', 'INFO', 'WARNING', 'ERROR', 'CRITICAL'];
+          const minLevel = levelOrder.indexOf(selectedLevel);
+          if (levelOrder.indexOf(entry.level) < minLevel) return;
+        }
+
+        if (selectedLogger && !entry.logger.toLowerCase().includes(selectedLogger.toLowerCase())) {
+          return;
+        }
+
+        if (searchTerm) {
+          const term = searchTerm.toLowerCase();
+          if (!entry.message.toLowerCase().includes(term) &&
+              !entry.logger.toLowerCase().includes(term)) {
+            return;
+          }
+        }
+
+        setLogs((prev) => [...prev.slice(-499), entry]); // Keep last 500
+      } catch {
+        // Invalid JSON, ignore
+      }
+    };
+
+    ws.onerror = () => {
+      setError('WebSocket connection error');
+      setConnected(false);
+    };
+
+    ws.onclose = () => {
+      setConnected(false);
+    };
+
+    // Ping to keep alive
+    const pingInterval = setInterval(() => {
+      if (ws.readyState === WebSocket.OPEN) {
+        ws.send('ping');
+      }
+    }, 25000);
+
+    return () => {
+      clearInterval(pingInterval);
+      ws.close();
+    };
+  }, [isPaused, selectedLevel, selectedLogger, searchTerm]);
+
+  // Initial fetch
+  useEffect(() => {
+    fetchLogs();
+    fetchMetadata();
+  }, [fetchLogs, fetchMetadata]);
+
+  // Auto-scroll
+  useEffect(() => {
+    if (autoScroll && logsEndRef.current) {
+      logsEndRef.current.scrollIntoView({ behavior: 'smooth' });
+    }
+  }, [logs, autoScroll]);
+
+  // Handle scroll to detect manual scrolling
+  const handleScroll = () => {
+    if (!logsContainerRef.current) return;
+    const { scrollTop, scrollHeight, clientHeight } = logsContainerRef.current;
+    const isAtBottom = scrollHeight - scrollTop - clientHeight < 50;
+    setAutoScroll(isAtBottom);
+  };
+
+  const formatTime = (timestamp: string) => {
+    try {
+      const date = new Date(timestamp);
+      return date.toLocaleTimeString('en-US', {
+        hour12: false,
+        hour: '2-digit',
+        minute: '2-digit',
+        second: '2-digit',
+        fractionalSecondDigits: 3,
+      });
+    } catch {
+      return timestamp;
+    }
+  };
+
+  const clearLogs = async () => {
+    try {
+      await fetch(API_BASE, { method: 'DELETE' });
+      setLogs([]);
+    } catch {
+      // Ignore
+    }
+  };
+
+  const createTestLog = async (level: LogLevel) => {
+    try {
+      await fetch(`${API_BASE}/test?level=${level}&message=Test ${level} log from Log Viewer`, {
+        method: 'POST',
+      });
+    } catch {
+      // Ignore
+    }
+  };
+
+  const exportLogs = () => {
+    const content = logs.map((log) =>
+      `[${log.timestamp}] [${log.level.padEnd(8)}] [${log.logger}] ${log.message}`
+    ).join('\n');
+
+    const blob = new Blob([content], { type: 'text/plain' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = `logs-${new Date().toISOString().replace(/[:.]/g, '-')}.txt`;
+    a.click();
+    URL.revokeObjectURL(url);
+  };
+
+  const filteredLogs = logs; // Already filtered by WebSocket/fetch
+
+  if (loading && logs.length === 0) {
+    return (
+      <div className="log-viewer">
+        <div className="log-loading">
+          <div className="loading-spinner" />
+          <p>Connecting to log stream...</p>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="log-viewer">
+      {/* Header */}
+      <header className="log-header">
+        <div className="header-left">
+          <h1>Log Viewer</h1>
+          <div className={`connection-status ${connected ? 'connected' : 'disconnected'}`}>
+            <span className="status-dot" />
+            {connected ? 'Live' : 'Disconnected'}
+          </div>
+        </div>
+        <div className="header-right">
+          <span className="log-count">{logs.length} entries</span>
+        </div>
+      </header>
+
+      {/* Toolbar */}
+      <div className="log-toolbar">
+        <div className="toolbar-left">
+          {/* Level Filter */}
+          <select
+            value={selectedLevel}
+            onChange={(e) => setSelectedLevel(e.target.value as LogLevel | 'ALL')}
+            className="level-select"
+          >
+            <option value="ALL">All Levels</option>
+            <option value="DEBUG">DEBUG ({levelCounts.DEBUG || 0})</option>
+            <option value="INFO">INFO ({levelCounts.INFO || 0})</option>
+            <option value="WARNING">WARNING ({levelCounts.WARNING || 0})</option>
+            <option value="ERROR">ERROR ({levelCounts.ERROR || 0})</option>
+            <option value="CRITICAL">CRITICAL ({levelCounts.CRITICAL || 0})</option>
+          </select>
+
+          {/* Logger Filter */}
+          <select
+            value={selectedLogger}
+            onChange={(e) => setSelectedLogger(e.target.value)}
+            className="logger-select"
+          >
+            <option value="">All Loggers</option>
+            {loggers.map((logger) => (
+              <option key={logger.name} value={logger.name}>
+                {logger.name} ({logger.count})
+              </option>
+            ))}
+          </select>
+
+          {/* Search */}
+          <input
+            type="text"
+            value={searchTerm}
+            onChange={(e) => setSearchTerm(e.target.value)}
+            placeholder="Search logs..."
+            className="search-input"
+          />
+        </div>
+
+        <div className="toolbar-right">
+          {/* Test Log Buttons */}
+          <div className="test-buttons">
+            <button onClick={() => createTestLog('INFO')} className="test-btn test-info">
+              + INFO
+            </button>
+            <button onClick={() => createTestLog('WARNING')} className="test-btn test-warning">
+              + WARN
+            </button>
+            <button onClick={() => createTestLog('ERROR')} className="test-btn test-error">
+              + ERROR
+            </button>
+          </div>
+
+          <button
+            onClick={() => setIsPaused(!isPaused)}
+            className={`action-btn ${isPaused ? 'paused' : ''}`}
+          >
+            {isPaused ? '▶ Resume' : '⏸ Pause'}
+          </button>
+
+          <button onClick={exportLogs} className="action-btn">
+            ⬇ Export
+          </button>
+
+          <button onClick={clearLogs} className="action-btn danger">
+            🗑 Clear
+          </button>
+        </div>
+      </div>
+
+      {/* Error Banner */}
+      {error && (
+        <div className="error-banner">
+          <span>{error}</span>
+          <button onClick={fetchLogs}>Retry</button>
+        </div>
+      )}
+
+      {/* Log Container */}
+      <div
+        className="log-container"
+        ref={logsContainerRef}
+        onScroll={handleScroll}
+      >
+        {filteredLogs.length === 0 ? (
+          <div className="no-logs">
+            <p>No log entries yet</p>
+            <p className="hint">Logs will appear here as they're generated</p>
+          </div>
+        ) : (
+          <div className="log-entries">
+            {filteredLogs.map((log) => (
+              <div
+                key={log.id}
+                className={`log-entry level-${log.level.toLowerCase()}`}
+              >
+                <span className="log-time">{formatTime(log.timestamp)}</span>
+                <span
+                  className="log-level"
+                  style={{ color: LEVEL_COLORS[log.level as LogLevel] }}
+                >
+                  {log.level}
+                </span>
+                <span className="log-logger">{log.logger}</span>
+                <span className="log-message">{log.message}</span>
+              </div>
+            ))}
+            <div ref={logsEndRef} />
+          </div>
+        )}
+      </div>
+
+      {/* Footer */}
+      <div className="log-footer">
+        <div className="footer-left">
+          <label className="auto-scroll-toggle">
+            <input
+              type="checkbox"
+              checked={autoScroll}
+              onChange={(e) => setAutoScroll(e.target.checked)}
+            />
+            Auto-scroll
+          </label>
+        </div>
+        <div className="footer-right">
+          <span className="footer-hint">
+            {isPaused ? 'Stream paused' : 'Streaming live logs'}
+          </span>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default LogViewer;

--- a/web/src/pages/index.ts
+++ b/web/src/pages/index.ts
@@ -23,3 +23,4 @@ export { SystemStatus } from './SystemStatus';
 export { ApiPlayground } from './ApiPlayground';
 export { WebSocketMonitor } from './WebSocketMonitor';
 export { BuildInfo } from './BuildInfo';
+export { LogViewer } from './LogViewer';


### PR DESCRIPTION
## Summary
- Add real-time log viewer with WebSocket streaming
- Backend ring buffer stores last 1000 log entries
- Filter by level (DEBUG/INFO/WARNING/ERROR/CRITICAL)
- Filter by logger name
- Full-text search in messages
- Auto-scroll with pause/resume
- Export logs to text file
- Test log buttons for generating sample entries
- Terminal-style monospace display with color-coded levels

## Test plan
- [ ] Navigate to Dev Tools → Log Viewer
- [ ] Verify "Live" connection indicator appears
- [ ] Click test buttons (INFO/WARN/ERROR) to generate logs
- [ ] Test level filter dropdown
- [ ] Test search functionality
- [ ] Verify auto-scroll toggle works
- [ ] Test pause/resume streaming
- [ ] Test export button downloads log file
- [ ] Test clear button empties the log

🤖 Generated with [Claude Code](https://claude.com/claude-code)