### PR TITLE
feat(dev-tools): add Error Tracker for exception monitoring

### DIFF
--- a/server/app/api/errors.py
+++ b/server/app/api/errors.py
@@ -1,0 +1,373 @@
+"""
+Error Tracker API - Captures and displays application errors.
+
+Features:
+- Captures unhandled exceptions with full stack traces
+- Stores errors in a ring buffer (last 100 errors)
+- Groups similar errors by fingerprint
+- Provides error statistics and trends
+"""
+
+import sys
+import traceback
+import hashlib
+from datetime import datetime
+from collections import deque
+from typing import Optional
+from enum import Enum
+
+from fastapi import APIRouter, Depends, Request, Query
+from fastapi.responses import JSONResponse
+from pydantic import BaseModel
+
+from ..api.dbexplorer import require_debug
+
+router = APIRouter(prefix="/api/errors", tags=["errors"])
+
+# Ring buffer for storing errors (last 100 entries)
+MAX_ERROR_ENTRIES = 100
+error_buffer: deque = deque(maxlen=MAX_ERROR_ENTRIES)
+
+# Error counts by fingerprint for grouping
+error_counts: dict[str, int] = {}
+
+# Global error counter
+_error_id_counter = 0
+
+
+class ErrorSeverity(str, Enum):
+    LOW = "low"
+    MEDIUM = "medium"
+    HIGH = "high"
+    CRITICAL = "critical"
+
+
+class ErrorEntry(BaseModel):
+    """A captured error entry."""
+    id: int
+    timestamp: str
+    error_type: str
+    message: str
+    stack_trace: str
+    fingerprint: str
+    request_path: Optional[str] = None
+    request_method: Optional[str] = None
+    request_params: Optional[dict] = None
+    user_agent: Optional[str] = None
+    client_ip: Optional[str] = None
+    severity: ErrorSeverity = ErrorSeverity.MEDIUM
+    count: int = 1
+    resolved: bool = False
+    notes: Optional[str] = None
+
+
+class ErrorsResponse(BaseModel):
+    """Response containing error entries."""
+    entries: list[ErrorEntry]
+    total: int
+    unresolved: int
+    by_type: dict[str, int]
+
+
+class ErrorStats(BaseModel):
+    """Error statistics."""
+    total_errors: int
+    unique_errors: int
+    unresolved: int
+    by_severity: dict[str, int]
+    by_type: dict[str, int]
+    recent_24h: int
+
+
+def generate_fingerprint(error_type: str, message: str, stack_trace: str) -> str:
+    """Generate a fingerprint for grouping similar errors."""
+    # Use error type and first few lines of stack trace for fingerprinting
+    trace_lines = stack_trace.split('\n')[:5]
+    content = f"{error_type}:{message}:{':'.join(trace_lines)}"
+    return hashlib.md5(content.encode()).hexdigest()[:12]
+
+
+def determine_severity(error_type: str, message: str) -> ErrorSeverity:
+    """Determine error severity based on type and message."""
+    critical_types = ['SystemExit', 'KeyboardInterrupt', 'MemoryError', 'RecursionError']
+    high_types = ['DatabaseError', 'ConnectionError', 'AuthenticationError', 'PermissionError']
+    low_types = ['ValidationError', 'ValueError', 'KeyError', 'IndexError']
+
+    if error_type in critical_types:
+        return ErrorSeverity.CRITICAL
+    elif error_type in high_types or 'database' in message.lower() or 'connection' in message.lower():
+        return ErrorSeverity.HIGH
+    elif error_type in low_types:
+        return ErrorSeverity.LOW
+    return ErrorSeverity.MEDIUM
+
+
+def capture_error(
+    exc: Exception,
+    request: Optional[Request] = None,
+) -> ErrorEntry:
+    """Capture an exception and store it in the error buffer."""
+    global _error_id_counter
+    _error_id_counter += 1
+
+    # Get exception details
+    error_type = type(exc).__name__
+    message = str(exc)
+
+    # Get full stack trace
+    tb = traceback.format_exception(type(exc), exc, exc.__traceback__)
+    stack_trace = ''.join(tb)
+
+    # Generate fingerprint for grouping
+    fingerprint = generate_fingerprint(error_type, message, stack_trace)
+
+    # Update counts
+    error_counts[fingerprint] = error_counts.get(fingerprint, 0) + 1
+
+    # Determine severity
+    severity = determine_severity(error_type, message)
+
+    # Extract request info if available
+    request_path = None
+    request_method = None
+    request_params = None
+    user_agent = None
+    client_ip = None
+
+    if request:
+        request_path = str(request.url.path)
+        request_method = request.method
+        request_params = dict(request.query_params) if request.query_params else None
+        user_agent = request.headers.get('user-agent')
+        client_ip = request.client.host if request.client else None
+
+    entry = ErrorEntry(
+        id=_error_id_counter,
+        timestamp=datetime.utcnow().isoformat() + "Z",
+        error_type=error_type,
+        message=message,
+        stack_trace=stack_trace,
+        fingerprint=fingerprint,
+        request_path=request_path,
+        request_method=request_method,
+        request_params=request_params,
+        user_agent=user_agent,
+        client_ip=client_ip,
+        severity=severity,
+        count=error_counts[fingerprint],
+    )
+
+    error_buffer.append(entry)
+    return entry
+
+
+def get_exception_handler(app):
+    """Create an exception handler that captures errors."""
+    async def exception_handler(request: Request, exc: Exception):
+        # Capture the error
+        capture_error(exc, request)
+
+        # Return a generic error response
+        return JSONResponse(
+            status_code=500,
+            content={
+                "detail": "Internal server error",
+                "error_type": type(exc).__name__,
+            }
+        )
+    return exception_handler
+
+
+@router.get("", response_model=ErrorsResponse)
+async def get_errors(
+    _: None = Depends(require_debug),
+    limit: int = Query(50, ge=1, le=100),
+    offset: int = Query(0, ge=0),
+    severity: Optional[ErrorSeverity] = None,
+    error_type: Optional[str] = None,
+    unresolved_only: bool = False,
+    search: Optional[str] = None,
+):
+    """
+    Get captured application errors.
+
+    Supports filtering by:
+    - severity: Filter by severity level
+    - error_type: Filter by exception type
+    - unresolved_only: Show only unresolved errors
+    - search: Search in error messages
+    """
+    all_entries = list(error_buffer)
+
+    # Apply filters
+    filtered = all_entries
+
+    if severity:
+        filtered = [e for e in filtered if e.severity == severity]
+
+    if error_type:
+        filtered = [e for e in filtered if error_type.lower() in e.error_type.lower()]
+
+    if unresolved_only:
+        filtered = [e for e in filtered if not e.resolved]
+
+    if search:
+        search_lower = search.lower()
+        filtered = [
+            e for e in filtered
+            if search_lower in e.message.lower() or search_lower in e.error_type.lower()
+        ]
+
+    # Calculate stats
+    by_type: dict[str, int] = {}
+    for entry in all_entries:
+        by_type[entry.error_type] = by_type.get(entry.error_type, 0) + 1
+
+    unresolved = len([e for e in all_entries if not e.resolved])
+
+    # Reverse to show newest first
+    filtered = list(reversed(filtered))
+    total = len(filtered)
+    paginated = filtered[offset:offset + limit]
+
+    return ErrorsResponse(
+        entries=paginated,
+        total=total,
+        unresolved=unresolved,
+        by_type=by_type,
+    )
+
+
+@router.get("/stats", response_model=ErrorStats)
+async def get_error_stats(_: None = Depends(require_debug)):
+    """Get error statistics."""
+    all_entries = list(error_buffer)
+
+    by_severity: dict[str, int] = {
+        "low": 0,
+        "medium": 0,
+        "high": 0,
+        "critical": 0,
+    }
+
+    by_type: dict[str, int] = {}
+    fingerprints = set()
+    recent_24h = 0
+    now = datetime.utcnow()
+
+    for entry in all_entries:
+        by_severity[entry.severity.value] += 1
+        by_type[entry.error_type] = by_type.get(entry.error_type, 0) + 1
+        fingerprints.add(entry.fingerprint)
+
+        # Check if within last 24 hours
+        try:
+            entry_time = datetime.fromisoformat(entry.timestamp.replace('Z', '+00:00').replace('+00:00', ''))
+            if (now - entry_time).total_seconds() < 86400:
+                recent_24h += 1
+        except:
+            pass
+
+    unresolved = len([e for e in all_entries if not e.resolved])
+
+    return ErrorStats(
+        total_errors=len(all_entries),
+        unique_errors=len(fingerprints),
+        unresolved=unresolved,
+        by_severity=by_severity,
+        by_type=by_type,
+        recent_24h=recent_24h,
+    )
+
+
+@router.get("/types")
+async def get_error_types(_: None = Depends(require_debug)):
+    """Get list of error types."""
+    all_entries = list(error_buffer)
+
+    types: dict[str, int] = {}
+    for entry in all_entries:
+        types[entry.error_type] = types.get(entry.error_type, 0) + 1
+
+    sorted_types = sorted(types.items(), key=lambda x: x[1], reverse=True)
+
+    return {
+        "types": [{"name": name, "count": count} for name, count in sorted_types],
+    }
+
+
+@router.get("/{error_id}")
+async def get_error_detail(
+    error_id: int,
+    _: None = Depends(require_debug),
+):
+    """Get detailed information about a specific error."""
+    for entry in error_buffer:
+        if entry.id == error_id:
+            return entry
+
+    return JSONResponse(status_code=404, content={"detail": "Error not found"})
+
+
+@router.patch("/{error_id}/resolve")
+async def resolve_error(
+    error_id: int,
+    _: None = Depends(require_debug),
+):
+    """Mark an error as resolved."""
+    for entry in error_buffer:
+        if entry.id == error_id:
+            entry.resolved = True
+            return {"status": "resolved", "id": error_id}
+
+    return JSONResponse(status_code=404, content={"detail": "Error not found"})
+
+
+@router.patch("/{error_id}/unresolve")
+async def unresolve_error(
+    error_id: int,
+    _: None = Depends(require_debug),
+):
+    """Mark an error as unresolved."""
+    for entry in error_buffer:
+        if entry.id == error_id:
+            entry.resolved = False
+            return {"status": "unresolved", "id": error_id}
+
+    return JSONResponse(status_code=404, content={"detail": "Error not found"})
+
+
+@router.delete("")
+async def clear_errors(_: None = Depends(require_debug)):
+    """Clear all captured errors."""
+    error_buffer.clear()
+    error_counts.clear()
+    return {"status": "cleared", "message": "Error buffer cleared"}
+
+
+@router.post("/test")
+async def create_test_error(
+    _: None = Depends(require_debug),
+    error_type: str = "TestError",
+    message: str = "This is a test error",
+):
+    """Create a test error for debugging."""
+    # Create a custom exception
+    class TestException(Exception):
+        pass
+
+    try:
+        raise TestException(message)
+    except TestException as e:
+        entry = capture_error(e)
+        # Override the error type name
+        entry.error_type = error_type
+        return {"status": "created", "error_id": entry.id, "fingerprint": entry.fingerprint}
+
+
+@router.post("/test/real")
+async def trigger_real_error(_: None = Depends(require_debug)):
+    """Trigger a real error to test error capturing."""
+    # This will raise a real exception that gets captured
+    result = 1 / 0  # ZeroDivisionError
+    return {"result": result}

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,6 +1,6 @@
 import { Routes, Route } from 'react-router-dom';
 import { Layout } from './components/Layout';
-import { Home, Login, Register, Play, Features, About, PlayScene, SceneDemo, Leaderboard, Ghosts, Profile, Achievements, Spectate, Friends, Presentation, Roadmap, CodebaseHealth, Changelog, DatabaseExplorer, CacheInspector, AudioJukebox, SystemStatus, ApiPlayground, WebSocketMonitor, BuildInfo, LogViewer } from './pages';
+import { Home, Login, Register, Play, Features, About, PlayScene, SceneDemo, Leaderboard, Ghosts, Profile, Achievements, Spectate, Friends, Presentation, Roadmap, CodebaseHealth, Changelog, DatabaseExplorer, CacheInspector, AudioJukebox, SystemStatus, ApiPlayground, WebSocketMonitor, BuildInfo, LogViewer, ErrorTracker } from './pages';
 import { FirstPersonDemo } from './pages/FirstPersonDemo';
 import { FirstPersonTestPage } from './pages/FirstPersonTestPage';
 import { Debug3DPage } from './pages/Debug3DPage';
@@ -41,6 +41,7 @@ function App() {
         <Route path="ws-monitor" element={<WebSocketMonitor />} />
         <Route path="build-info" element={<BuildInfo />} />
         <Route path="log-viewer" element={<LogViewer />} />
+        <Route path="error-tracker" element={<ErrorTracker />} />
       </Route>
     </Routes>
   );

--- a/web/src/components/Layout.tsx
+++ b/web/src/components/Layout.tsx
@@ -156,6 +156,10 @@ export function Layout() {
                     <span className="menu-icon">📜</span>
                     Log Viewer
                   </Link>
+                  <Link to="/error-tracker" onClick={closeDropdown}>
+                    <span className="menu-icon">🐛</span>
+                    Error Tracker
+                  </Link>
                   <Link to="/codebase-health" onClick={closeDropdown}>
                     <span className="menu-icon">🩺</span>
                     Codebase Health

--- a/web/src/pages/ErrorTracker.css
+++ b/web/src/pages/ErrorTracker.css
@@ -1,0 +1,600 @@
+/**
+ * Error Tracker Styles - Alert/Monitoring theme
+ */
+
+.error-tracker {
+  min-height: 100vh;
+  background: #0d1117;
+  color: #e6edf3;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+}
+
+/* Loading State */
+.error-loading {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  min-height: 60vh;
+  gap: 1rem;
+}
+
+.loading-spinner {
+  width: 40px;
+  height: 40px;
+  border: 3px solid #21262d;
+  border-top-color: #f85149;
+  border-radius: 50%;
+  animation: spin 1s linear infinite;
+}
+
+@keyframes spin {
+  to { transform: rotate(360deg); }
+}
+
+/* Header */
+.error-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 1rem 1.5rem;
+  background: #161b22;
+  border-bottom: 1px solid #30363d;
+}
+
+.error-header .header-left {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+}
+
+.error-header h1 {
+  margin: 0;
+  font-size: 1.25rem;
+  font-weight: 600;
+}
+
+.header-badge {
+  font-size: 0.75rem;
+  font-weight: 600;
+  padding: 0.25rem 0.75rem;
+  background: #f8514922;
+  color: #f85149;
+  border-radius: 12px;
+}
+
+.refresh-btn {
+  padding: 0.5rem 1rem;
+  background: #21262d;
+  border: 1px solid #30363d;
+  border-radius: 6px;
+  color: #e6edf3;
+  cursor: pointer;
+  transition: all 0.15s;
+}
+
+.refresh-btn:hover {
+  background: #30363d;
+}
+
+/* Stats Grid */
+.stats-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  gap: 1rem;
+  padding: 1.5rem;
+  background: #161b22;
+  border-bottom: 1px solid #21262d;
+}
+
+.stat-card {
+  background: #0d1117;
+  border: 1px solid #30363d;
+  border-radius: 8px;
+  padding: 1rem;
+  text-align: center;
+}
+
+.stat-card.stat-warning {
+  border-color: #f8514955;
+  background: #f8514910;
+}
+
+.stat-value {
+  font-size: 1.75rem;
+  font-weight: 700;
+  color: #e6edf3;
+}
+
+.stat-card.stat-warning .stat-value {
+  color: #f85149;
+}
+
+.stat-label {
+  font-size: 0.75rem;
+  color: #8b949e;
+  margin-top: 0.25rem;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+
+/* Severity Breakdown */
+.stat-card.severity-breakdown {
+  grid-column: span 2;
+  text-align: left;
+}
+
+.severity-bars {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.severity-bar-item {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.sev-label {
+  font-size: 0.65rem;
+  font-weight: 600;
+  width: 60px;
+  text-transform: uppercase;
+}
+
+.sev-bar {
+  flex: 1;
+  height: 8px;
+  background: #21262d;
+  border-radius: 4px;
+  overflow: hidden;
+}
+
+.sev-fill {
+  height: 100%;
+  border-radius: 4px;
+  transition: width 0.3s ease;
+}
+
+.sev-count {
+  font-size: 0.75rem;
+  color: #8b949e;
+  width: 30px;
+  text-align: right;
+}
+
+/* Toolbar */
+.error-toolbar {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1rem;
+  padding: 0.75rem 1.5rem;
+  background: #161b22;
+  border-bottom: 1px solid #21262d;
+  flex-wrap: wrap;
+}
+
+.toolbar-left,
+.toolbar-right {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.filter-select {
+  padding: 0.5rem 0.75rem;
+  background: #0d1117;
+  border: 1px solid #30363d;
+  border-radius: 6px;
+  color: #e6edf3;
+  font-size: 0.85rem;
+  cursor: pointer;
+}
+
+.filter-select:focus {
+  outline: none;
+  border-color: #58a6ff;
+}
+
+.checkbox-filter {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.85rem;
+  color: #8b949e;
+  cursor: pointer;
+}
+
+.checkbox-filter input {
+  cursor: pointer;
+}
+
+.search-input {
+  padding: 0.5rem 0.75rem;
+  background: #0d1117;
+  border: 1px solid #30363d;
+  border-radius: 6px;
+  color: #e6edf3;
+  font-size: 0.85rem;
+  min-width: 180px;
+}
+
+.search-input:focus {
+  outline: none;
+  border-color: #58a6ff;
+}
+
+.search-input::placeholder {
+  color: #6b7280;
+}
+
+/* Test Buttons */
+.test-buttons {
+  display: flex;
+  gap: 0.25rem;
+}
+
+.test-btn {
+  padding: 0.35rem 0.5rem;
+  background: #21262d;
+  border: 1px solid #30363d;
+  border-radius: 4px;
+  color: #8b949e;
+  font-size: 0.7rem;
+  cursor: pointer;
+  transition: all 0.15s;
+}
+
+.test-btn:hover {
+  background: #30363d;
+  color: #e6edf3;
+}
+
+.test-btn.test-real {
+  background: #f8514922;
+  border-color: #f8514955;
+  color: #f85149;
+}
+
+.test-btn.test-real:hover {
+  background: #f8514933;
+}
+
+.clear-btn {
+  padding: 0.5rem 0.75rem;
+  background: transparent;
+  border: 1px solid #f8514955;
+  border-radius: 6px;
+  color: #f85149;
+  font-size: 0.85rem;
+  cursor: pointer;
+  transition: all 0.15s;
+}
+
+.clear-btn:hover {
+  background: #f8514922;
+}
+
+/* Error Banner */
+.error-banner {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 0.75rem 1.5rem;
+  background: #f8514922;
+  border-bottom: 1px solid #f8514955;
+  color: #f85149;
+}
+
+.error-banner button {
+  padding: 0.25rem 0.75rem;
+  background: transparent;
+  border: 1px solid #f85149;
+  border-radius: 4px;
+  color: #f85149;
+  cursor: pointer;
+}
+
+/* Error List */
+.error-list {
+  padding: 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.no-errors {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  min-height: 300px;
+  color: #6b7280;
+}
+
+.no-errors-icon {
+  font-size: 3rem;
+  color: #22c55e;
+  margin-bottom: 1rem;
+}
+
+.no-errors .hint {
+  font-size: 0.85rem;
+  color: #4b5563;
+}
+
+/* Error Item */
+.error-item {
+  background: #161b22;
+  border: 1px solid #30363d;
+  border-left: 4px solid #f85149;
+  border-radius: 8px;
+  overflow: hidden;
+  transition: all 0.15s;
+}
+
+.error-item.resolved {
+  opacity: 0.6;
+}
+
+.error-item-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 0.75rem 1rem;
+  cursor: pointer;
+  transition: background 0.15s;
+}
+
+.error-item-header:hover {
+  background: #21262d;
+}
+
+.error-main {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.error-severity {
+  font-size: 0.65rem;
+  font-weight: 700;
+  padding: 0.2rem 0.5rem;
+  border-radius: 4px;
+  text-transform: uppercase;
+}
+
+.error-type {
+  font-weight: 600;
+  color: #e6edf3;
+}
+
+.error-count {
+  font-size: 0.75rem;
+  color: #8b949e;
+  background: #21262d;
+  padding: 0.15rem 0.4rem;
+  border-radius: 4px;
+}
+
+.resolved-badge {
+  font-size: 0.65rem;
+  font-weight: 600;
+  padding: 0.2rem 0.5rem;
+  background: #22c55e22;
+  color: #22c55e;
+  border-radius: 4px;
+}
+
+.error-meta {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+}
+
+.error-time {
+  font-size: 0.8rem;
+  color: #8b949e;
+}
+
+.expand-icon {
+  color: #6b7280;
+  font-size: 0.75rem;
+}
+
+/* Error Message */
+.error-message {
+  padding: 0 1rem 0.75rem;
+  font-size: 0.9rem;
+  color: #b0b0b0;
+  font-family: 'JetBrains Mono', 'Fira Code', monospace;
+}
+
+/* Request Info */
+.error-request {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0 1rem 0.75rem;
+  font-size: 0.8rem;
+}
+
+.request-method {
+  font-weight: 600;
+  color: #58a6ff;
+  background: #58a6ff22;
+  padding: 0.15rem 0.4rem;
+  border-radius: 3px;
+}
+
+.request-path {
+  color: #8b949e;
+  font-family: 'JetBrains Mono', monospace;
+}
+
+/* Error Details */
+.error-details {
+  border-top: 1px solid #21262d;
+  padding: 1rem;
+  background: #0d1117;
+}
+
+.stack-trace-section {
+  margin-bottom: 1rem;
+}
+
+.section-header {
+  font-size: 0.75rem;
+  font-weight: 600;
+  color: #8b949e;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  margin-bottom: 0.5rem;
+}
+
+.stack-trace {
+  background: #161b22;
+  border: 1px solid #21262d;
+  border-radius: 6px;
+  padding: 1rem;
+  font-size: 0.75rem;
+  font-family: 'JetBrains Mono', 'Fira Code', monospace;
+  color: #f85149;
+  overflow-x: auto;
+  white-space: pre;
+  max-height: 300px;
+  overflow-y: auto;
+  margin: 0;
+}
+
+/* Error Info Grid */
+.error-info-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 0.75rem;
+  margin-bottom: 1rem;
+}
+
+.info-item {
+  background: #161b22;
+  border: 1px solid #21262d;
+  border-radius: 6px;
+  padding: 0.75rem;
+}
+
+.info-item.full-width {
+  grid-column: 1 / -1;
+}
+
+.info-label {
+  display: block;
+  font-size: 0.7rem;
+  font-weight: 600;
+  color: #8b949e;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  margin-bottom: 0.25rem;
+}
+
+.info-value {
+  font-size: 0.85rem;
+  color: #e6edf3;
+  word-break: break-all;
+}
+
+code.info-value {
+  font-family: 'JetBrains Mono', monospace;
+  background: #21262d;
+  padding: 0.15rem 0.4rem;
+  border-radius: 3px;
+}
+
+/* Error Actions */
+.error-actions {
+  display: flex;
+  gap: 0.75rem;
+  padding-top: 0.75rem;
+  border-top: 1px solid #21262d;
+}
+
+.action-btn {
+  padding: 0.5rem 1rem;
+  background: #21262d;
+  border: 1px solid #30363d;
+  border-radius: 6px;
+  color: #e6edf3;
+  font-size: 0.85rem;
+  cursor: pointer;
+  transition: all 0.15s;
+}
+
+.action-btn:hover {
+  background: #30363d;
+}
+
+.action-btn.resolve {
+  background: #22c55e22;
+  border-color: #22c55e55;
+  color: #22c55e;
+}
+
+.action-btn.resolve:hover {
+  background: #22c55e33;
+}
+
+.action-btn.unresolve {
+  background: #d2992222;
+  border-color: #d2992255;
+  color: #d29922;
+}
+
+.action-btn.unresolve:hover {
+  background: #d2992233;
+}
+
+/* Scrollbar */
+.stack-trace::-webkit-scrollbar {
+  width: 8px;
+  height: 8px;
+}
+
+.stack-trace::-webkit-scrollbar-track {
+  background: #0d1117;
+}
+
+.stack-trace::-webkit-scrollbar-thumb {
+  background: #30363d;
+  border-radius: 4px;
+}
+
+.stack-trace::-webkit-scrollbar-thumb:hover {
+  background: #484f58;
+}
+
+/* Responsive */
+@media (max-width: 768px) {
+  .stats-grid {
+    grid-template-columns: repeat(2, 1fr);
+  }
+
+  .stat-card.severity-breakdown {
+    grid-column: span 2;
+  }
+
+  .error-toolbar {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .toolbar-left,
+  .toolbar-right {
+    justify-content: flex-start;
+  }
+
+  .error-info-grid {
+    grid-template-columns: 1fr;
+  }
+}

--- a/web/src/pages/ErrorTracker.tsx
+++ b/web/src/pages/ErrorTracker.tsx
@@ -1,0 +1,495 @@
+/**
+ * Error Tracker - Application error monitoring dashboard
+ *
+ * Features:
+ * - View captured exceptions with stack traces
+ * - Filter by severity, error type, resolved status
+ * - Mark errors as resolved/unresolved
+ * - Error statistics and trends
+ * - Expandable stack trace view
+ * - Test error generation
+ */
+
+import { useState, useEffect, useCallback } from 'react';
+import './ErrorTracker.css';
+
+const API_BASE = 'http://localhost:8000/api/errors';
+
+interface ErrorEntry {
+  id: number;
+  timestamp: string;
+  error_type: string;
+  message: string;
+  stack_trace: string;
+  fingerprint: string;
+  request_path?: string;
+  request_method?: string;
+  request_params?: Record<string, string>;
+  user_agent?: string;
+  client_ip?: string;
+  severity: 'low' | 'medium' | 'high' | 'critical';
+  count: number;
+  resolved: boolean;
+  notes?: string;
+}
+
+interface ErrorStats {
+  total_errors: number;
+  unique_errors: number;
+  unresolved: number;
+  by_severity: Record<string, number>;
+  by_type: Record<string, number>;
+  recent_24h: number;
+}
+
+interface ErrorType {
+  name: string;
+  count: number;
+}
+
+const SEVERITY_COLORS: Record<string, string> = {
+  low: '#8b949e',
+  medium: '#d29922',
+  high: '#f85149',
+  critical: '#ff7b72',
+};
+
+const SEVERITY_BG: Record<string, string> = {
+  low: '#8b949e15',
+  medium: '#d2992220',
+  high: '#f8514925',
+  critical: '#ff7b7230',
+};
+
+export function ErrorTracker() {
+  const [errors, setErrors] = useState<ErrorEntry[]>([]);
+  const [stats, setStats] = useState<ErrorStats | null>(null);
+  const [errorTypes, setErrorTypes] = useState<ErrorType[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  // Filters
+  const [severityFilter, setSeverityFilter] = useState<string>('');
+  const [typeFilter, setTypeFilter] = useState<string>('');
+  const [unresolvedOnly, setUnresolvedOnly] = useState(false);
+  const [searchTerm, setSearchTerm] = useState('');
+
+  // Expanded errors
+  const [expandedErrors, setExpandedErrors] = useState<Set<number>>(new Set());
+
+  // Fetch errors
+  const fetchErrors = useCallback(async () => {
+    try {
+      const params = new URLSearchParams();
+      if (severityFilter) params.append('severity', severityFilter);
+      if (typeFilter) params.append('error_type', typeFilter);
+      if (unresolvedOnly) params.append('unresolved_only', 'true');
+      if (searchTerm) params.append('search', searchTerm);
+
+      const res = await fetch(`${API_BASE}?${params}`);
+      if (!res.ok) throw new Error('Failed to fetch errors');
+      const data = await res.json();
+      setErrors(data.entries);
+      setError(null);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Failed to fetch errors');
+    }
+  }, [severityFilter, typeFilter, unresolvedOnly, searchTerm]);
+
+  // Fetch stats
+  const fetchStats = useCallback(async () => {
+    try {
+      const res = await fetch(`${API_BASE}/stats`);
+      if (res.ok) {
+        const data = await res.json();
+        setStats(data);
+      }
+    } catch {
+      // Silently fail
+    }
+  }, []);
+
+  // Fetch error types
+  const fetchTypes = useCallback(async () => {
+    try {
+      const res = await fetch(`${API_BASE}/types`);
+      if (res.ok) {
+        const data = await res.json();
+        setErrorTypes(data.types);
+      }
+    } catch {
+      // Silently fail
+    }
+  }, []);
+
+  // Initial fetch
+  useEffect(() => {
+    const loadData = async () => {
+      setLoading(true);
+      await Promise.all([fetchErrors(), fetchStats(), fetchTypes()]);
+      setLoading(false);
+    };
+    loadData();
+  }, [fetchErrors, fetchStats, fetchTypes]);
+
+  // Refetch on filter change
+  useEffect(() => {
+    fetchErrors();
+  }, [fetchErrors]);
+
+  // Toggle error expansion
+  const toggleExpanded = (id: number) => {
+    setExpandedErrors((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) {
+        next.delete(id);
+      } else {
+        next.add(id);
+      }
+      return next;
+    });
+  };
+
+  // Resolve/unresolve error
+  const toggleResolved = async (id: number, currentlyResolved: boolean) => {
+    try {
+      const endpoint = currentlyResolved ? 'unresolve' : 'resolve';
+      const res = await fetch(`${API_BASE}/${id}/${endpoint}`, { method: 'PATCH' });
+      if (res.ok) {
+        setErrors((prev) =>
+          prev.map((e) => (e.id === id ? { ...e, resolved: !currentlyResolved } : e))
+        );
+        fetchStats();
+      }
+    } catch {
+      // Silently fail
+    }
+  };
+
+  // Create test error
+  const createTestError = async (type: string) => {
+    try {
+      await fetch(`${API_BASE}/test?error_type=${type}&message=Test ${type} from Error Tracker`, {
+        method: 'POST',
+      });
+      fetchErrors();
+      fetchStats();
+      fetchTypes();
+    } catch {
+      // Silently fail
+    }
+  };
+
+  // Trigger real error
+  const triggerRealError = async () => {
+    try {
+      await fetch(`${API_BASE}/test/real`, { method: 'POST' });
+    } catch {
+      // Expected to fail
+    }
+    setTimeout(() => {
+      fetchErrors();
+      fetchStats();
+      fetchTypes();
+    }, 500);
+  };
+
+  // Clear all errors
+  const clearErrors = async () => {
+    try {
+      await fetch(API_BASE, { method: 'DELETE' });
+      setErrors([]);
+      fetchStats();
+      fetchTypes();
+    } catch {
+      // Silently fail
+    }
+  };
+
+  // Format timestamp
+  const formatTime = (timestamp: string) => {
+    try {
+      const date = new Date(timestamp);
+      return date.toLocaleString();
+    } catch {
+      return timestamp;
+    }
+  };
+
+  // Format relative time
+  const formatRelativeTime = (timestamp: string) => {
+    try {
+      const date = new Date(timestamp);
+      const now = new Date();
+      const diff = now.getTime() - date.getTime();
+      const minutes = Math.floor(diff / 60000);
+      const hours = Math.floor(minutes / 60);
+      const days = Math.floor(hours / 24);
+
+      if (days > 0) return `${days}d ago`;
+      if (hours > 0) return `${hours}h ago`;
+      if (minutes > 0) return `${minutes}m ago`;
+      return 'just now';
+    } catch {
+      return '';
+    }
+  };
+
+  if (loading) {
+    return (
+      <div className="error-tracker">
+        <div className="error-loading">
+          <div className="loading-spinner" />
+          <p>Loading error data...</p>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="error-tracker">
+      {/* Header */}
+      <header className="error-header">
+        <div className="header-left">
+          <h1>Error Tracker</h1>
+          <span className="header-badge">
+            {stats?.unresolved || 0} unresolved
+          </span>
+        </div>
+        <div className="header-right">
+          <button onClick={() => fetchErrors()} className="refresh-btn">
+            Refresh
+          </button>
+        </div>
+      </header>
+
+      {/* Stats Cards */}
+      {stats && (
+        <div className="stats-grid">
+          <div className="stat-card">
+            <div className="stat-value">{stats.total_errors}</div>
+            <div className="stat-label">Total Errors</div>
+          </div>
+          <div className="stat-card">
+            <div className="stat-value">{stats.unique_errors}</div>
+            <div className="stat-label">Unique Errors</div>
+          </div>
+          <div className="stat-card stat-warning">
+            <div className="stat-value">{stats.unresolved}</div>
+            <div className="stat-label">Unresolved</div>
+          </div>
+          <div className="stat-card">
+            <div className="stat-value">{stats.recent_24h}</div>
+            <div className="stat-label">Last 24h</div>
+          </div>
+          <div className="stat-card severity-breakdown">
+            <div className="severity-bars">
+              {Object.entries(stats.by_severity).map(([sev, count]) => (
+                <div key={sev} className="severity-bar-item">
+                  <span className="sev-label" style={{ color: SEVERITY_COLORS[sev] }}>
+                    {sev.toUpperCase()}
+                  </span>
+                  <div className="sev-bar">
+                    <div
+                      className="sev-fill"
+                      style={{
+                        width: `${stats.total_errors ? (count / stats.total_errors) * 100 : 0}%`,
+                        background: SEVERITY_COLORS[sev],
+                      }}
+                    />
+                  </div>
+                  <span className="sev-count">{count}</span>
+                </div>
+              ))}
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* Toolbar */}
+      <div className="error-toolbar">
+        <div className="toolbar-left">
+          <select
+            value={severityFilter}
+            onChange={(e) => setSeverityFilter(e.target.value)}
+            className="filter-select"
+          >
+            <option value="">All Severities</option>
+            <option value="low">Low</option>
+            <option value="medium">Medium</option>
+            <option value="high">High</option>
+            <option value="critical">Critical</option>
+          </select>
+
+          <select
+            value={typeFilter}
+            onChange={(e) => setTypeFilter(e.target.value)}
+            className="filter-select"
+          >
+            <option value="">All Types</option>
+            {errorTypes.map((t) => (
+              <option key={t.name} value={t.name}>
+                {t.name} ({t.count})
+              </option>
+            ))}
+          </select>
+
+          <label className="checkbox-filter">
+            <input
+              type="checkbox"
+              checked={unresolvedOnly}
+              onChange={(e) => setUnresolvedOnly(e.target.checked)}
+            />
+            Unresolved only
+          </label>
+
+          <input
+            type="text"
+            value={searchTerm}
+            onChange={(e) => setSearchTerm(e.target.value)}
+            placeholder="Search errors..."
+            className="search-input"
+          />
+        </div>
+
+        <div className="toolbar-right">
+          <div className="test-buttons">
+            <button onClick={() => createTestError('ValueError')} className="test-btn">
+              + ValueError
+            </button>
+            <button onClick={() => createTestError('TypeError')} className="test-btn">
+              + TypeError
+            </button>
+            <button onClick={triggerRealError} className="test-btn test-real">
+              + Real Error
+            </button>
+          </div>
+          <button onClick={clearErrors} className="clear-btn">
+            Clear All
+          </button>
+        </div>
+      </div>
+
+      {/* Error Display */}
+      {error && (
+        <div className="error-banner">
+          <span>{error}</span>
+          <button onClick={() => fetchErrors()}>Retry</button>
+        </div>
+      )}
+
+      {/* Error List */}
+      <div className="error-list">
+        {errors.length === 0 ? (
+          <div className="no-errors">
+            <div className="no-errors-icon">✓</div>
+            <p>No errors captured</p>
+            <p className="hint">Errors will appear here when they occur</p>
+          </div>
+        ) : (
+          errors.map((err) => (
+            <div
+              key={err.id}
+              className={`error-item ${err.resolved ? 'resolved' : ''}`}
+              style={{ borderLeftColor: SEVERITY_COLORS[err.severity] }}
+            >
+              {/* Error Header */}
+              <div className="error-item-header" onClick={() => toggleExpanded(err.id)}>
+                <div className="error-main">
+                  <span
+                    className="error-severity"
+                    style={{
+                      color: SEVERITY_COLORS[err.severity],
+                      background: SEVERITY_BG[err.severity],
+                    }}
+                  >
+                    {err.severity.toUpperCase()}
+                  </span>
+                  <span className="error-type">{err.error_type}</span>
+                  {err.count > 1 && (
+                    <span className="error-count">×{err.count}</span>
+                  )}
+                  {err.resolved && (
+                    <span className="resolved-badge">Resolved</span>
+                  )}
+                </div>
+                <div className="error-meta">
+                  <span className="error-time" title={formatTime(err.timestamp)}>
+                    {formatRelativeTime(err.timestamp)}
+                  </span>
+                  <span className="expand-icon">
+                    {expandedErrors.has(err.id) ? '▼' : '▶'}
+                  </span>
+                </div>
+              </div>
+
+              {/* Error Message */}
+              <div className="error-message">{err.message}</div>
+
+              {/* Request Info (if available) */}
+              {err.request_path && (
+                <div className="error-request">
+                  <span className="request-method">{err.request_method}</span>
+                  <span className="request-path">{err.request_path}</span>
+                </div>
+              )}
+
+              {/* Expanded Details */}
+              {expandedErrors.has(err.id) && (
+                <div className="error-details">
+                  {/* Stack Trace */}
+                  <div className="stack-trace-section">
+                    <div className="section-header">Stack Trace</div>
+                    <pre className="stack-trace">{err.stack_trace}</pre>
+                  </div>
+
+                  {/* Additional Info */}
+                  <div className="error-info-grid">
+                    <div className="info-item">
+                      <span className="info-label">Fingerprint</span>
+                      <code className="info-value">{err.fingerprint}</code>
+                    </div>
+                    <div className="info-item">
+                      <span className="info-label">Timestamp</span>
+                      <span className="info-value">{formatTime(err.timestamp)}</span>
+                    </div>
+                    {err.client_ip && (
+                      <div className="info-item">
+                        <span className="info-label">Client IP</span>
+                        <span className="info-value">{err.client_ip}</span>
+                      </div>
+                    )}
+                    {err.user_agent && (
+                      <div className="info-item full-width">
+                        <span className="info-label">User Agent</span>
+                        <span className="info-value">{err.user_agent}</span>
+                      </div>
+                    )}
+                  </div>
+
+                  {/* Actions */}
+                  <div className="error-actions">
+                    <button
+                      onClick={() => toggleResolved(err.id, err.resolved)}
+                      className={`action-btn ${err.resolved ? 'unresolve' : 'resolve'}`}
+                    >
+                      {err.resolved ? 'Mark Unresolved' : 'Mark Resolved'}
+                    </button>
+                    <button
+                      onClick={() => navigator.clipboard.writeText(err.stack_trace)}
+                      className="action-btn"
+                    >
+                      Copy Stack Trace
+                    </button>
+                  </div>
+                </div>
+              )}
+            </div>
+          ))
+        )}
+      </div>
+    </div>
+  );
+}
+
+export default ErrorTracker;

--- a/web/src/pages/index.ts
+++ b/web/src/pages/index.ts
@@ -24,3 +24,4 @@ export { ApiPlayground } from './ApiPlayground';
 export { WebSocketMonitor } from './WebSocketMonitor';
 export { BuildInfo } from './BuildInfo';
 export { LogViewer } from './LogViewer';
+export { ErrorTracker } from './ErrorTracker';


### PR DESCRIPTION
## Summary
- Add error tracking dashboard for monitoring application exceptions
- Backend captures unhandled exceptions with full stack traces via global exception handler
- Ring buffer stores last 100 errors with fingerprinting for grouping
- Filter by severity (low/medium/high/critical) and error type
- Mark errors as resolved/unresolved for triage workflow
- Statistics dashboard: total errors, unique, unresolved, last 24h
- Severity breakdown visualization with color-coded bars
- Expandable stack trace view with copy functionality
- Test buttons for generating sample errors

## Test plan
- [ ] Navigate to Dev Tools → Error Tracker
- [ ] Click "Real Error" button to trigger a ZeroDivisionError
- [ ] Verify error appears with stack trace
- [ ] Expand error to see full stack trace
- [ ] Test "Mark Resolved" button
- [ ] Test severity and type filters
- [ ] Verify statistics update correctly
- [ ] Test "Copy Stack Trace" button
- [ ] Test "Clear All" button

🤖 Generated with [Claude Code](https://claude.com/claude-code)