### PR TITLE
feat(dev-tools): add Performance Profiler with request timing

### DIFF
--- a/server/app/api/profiler.py
+++ b/server/app/api/profiler.py
@@ -1,0 +1,414 @@
+"""
+Performance Profiler API - Request timing and performance metrics.
+
+Features:
+- Middleware captures request/response timing
+- Stores performance data in ring buffer
+- Identifies slow requests
+- Provides aggregated statistics by endpoint
+- Tracks response sizes and status codes
+"""
+
+import time
+import statistics
+from datetime import datetime, timedelta
+from collections import deque
+from typing import Optional
+from enum import Enum
+
+from fastapi import APIRouter, Depends, Request, Query
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.types import ASGIApp
+from pydantic import BaseModel
+
+from ..api.dbexplorer import require_debug
+
+router = APIRouter(prefix="/api/profiler", tags=["profiler"])
+
+# Ring buffer for storing request metrics (last 500 requests)
+MAX_METRICS_ENTRIES = 500
+metrics_buffer: deque = deque(maxlen=MAX_METRICS_ENTRIES)
+
+# Slow request threshold in milliseconds
+SLOW_REQUEST_THRESHOLD_MS = 500
+
+# Global request counter
+_request_id_counter = 0
+
+
+class RequestMetric(BaseModel):
+    """A single request performance metric."""
+    id: int
+    timestamp: str
+    method: str
+    path: str
+    full_path: str
+    status_code: int
+    duration_ms: float
+    response_size: Optional[int] = None
+    client_ip: Optional[str] = None
+    user_agent: Optional[str] = None
+    is_slow: bool = False
+
+
+class EndpointStats(BaseModel):
+    """Aggregated statistics for an endpoint."""
+    path: str
+    method: str
+    count: int
+    avg_ms: float
+    min_ms: float
+    max_ms: float
+    p50_ms: float
+    p95_ms: float
+    p99_ms: float
+    slow_count: int
+    error_count: int
+
+
+class OverallStats(BaseModel):
+    """Overall performance statistics."""
+    total_requests: int
+    avg_duration_ms: float
+    slow_requests: int
+    error_requests: int
+    requests_per_minute: float
+    by_status: dict[str, int]
+    by_method: dict[str, int]
+
+
+class ProfilingMiddleware(BaseHTTPMiddleware):
+    """Middleware to capture request performance metrics."""
+
+    def __init__(self, app: ASGIApp, enabled: bool = True):
+        super().__init__(app)
+        self.enabled = enabled
+
+    async def dispatch(self, request: Request, call_next):
+        if not self.enabled:
+            return await call_next(request)
+
+        # Skip profiling the profiler endpoints to avoid recursion
+        if request.url.path.startswith('/api/profiler'):
+            return await call_next(request)
+
+        global _request_id_counter
+        _request_id_counter += 1
+        request_id = _request_id_counter
+
+        start_time = time.perf_counter()
+
+        # Process request
+        response = await call_next(request)
+
+        # Calculate duration
+        duration = (time.perf_counter() - start_time) * 1000  # Convert to ms
+
+        # Get response size if available
+        response_size = None
+        if hasattr(response, 'headers'):
+            content_length = response.headers.get('content-length')
+            if content_length:
+                response_size = int(content_length)
+
+        # Determine if slow
+        is_slow = duration >= SLOW_REQUEST_THRESHOLD_MS
+
+        # Create metric entry
+        metric = RequestMetric(
+            id=request_id,
+            timestamp=datetime.utcnow().isoformat() + "Z",
+            method=request.method,
+            path=request.url.path,
+            full_path=str(request.url),
+            status_code=response.status_code,
+            duration_ms=round(duration, 2),
+            response_size=response_size,
+            client_ip=request.client.host if request.client else None,
+            user_agent=request.headers.get('user-agent'),
+            is_slow=is_slow,
+        )
+
+        metrics_buffer.append(metric)
+
+        return response
+
+
+def get_profiling_middleware(enabled: bool = True):
+    """Factory to create profiling middleware."""
+    return lambda app: ProfilingMiddleware(app, enabled=enabled)
+
+
+@router.get("/requests")
+async def get_requests(
+    _: None = Depends(require_debug),
+    limit: int = Query(100, ge=1, le=500),
+    offset: int = Query(0, ge=0),
+    method: Optional[str] = None,
+    path: Optional[str] = None,
+    slow_only: bool = False,
+    errors_only: bool = False,
+    min_duration: Optional[float] = None,
+):
+    """
+    Get recent request metrics.
+
+    Supports filtering by:
+    - method: HTTP method (GET, POST, etc.)
+    - path: URL path contains
+    - slow_only: Only slow requests
+    - errors_only: Only error responses (4xx, 5xx)
+    - min_duration: Minimum duration in ms
+    """
+    all_metrics = list(metrics_buffer)
+
+    # Apply filters
+    filtered = all_metrics
+
+    if method:
+        filtered = [m for m in filtered if m.method == method.upper()]
+
+    if path:
+        filtered = [m for m in filtered if path.lower() in m.path.lower()]
+
+    if slow_only:
+        filtered = [m for m in filtered if m.is_slow]
+
+    if errors_only:
+        filtered = [m for m in filtered if m.status_code >= 400]
+
+    if min_duration is not None:
+        filtered = [m for m in filtered if m.duration_ms >= min_duration]
+
+    # Reverse to show newest first
+    filtered = list(reversed(filtered))
+    total = len(filtered)
+    paginated = filtered[offset:offset + limit]
+
+    return {
+        "requests": [m.model_dump() for m in paginated],
+        "total": total,
+        "slow_threshold_ms": SLOW_REQUEST_THRESHOLD_MS,
+    }
+
+
+@router.get("/stats")
+async def get_stats(_: None = Depends(require_debug)):
+    """Get overall performance statistics."""
+    all_metrics = list(metrics_buffer)
+
+    if not all_metrics:
+        return OverallStats(
+            total_requests=0,
+            avg_duration_ms=0,
+            slow_requests=0,
+            error_requests=0,
+            requests_per_minute=0,
+            by_status={},
+            by_method={},
+        )
+
+    durations = [m.duration_ms for m in all_metrics]
+    slow_count = len([m for m in all_metrics if m.is_slow])
+    error_count = len([m for m in all_metrics if m.status_code >= 400])
+
+    # Count by status code
+    by_status: dict[str, int] = {}
+    for m in all_metrics:
+        status_group = f"{m.status_code // 100}xx"
+        by_status[status_group] = by_status.get(status_group, 0) + 1
+
+    # Count by method
+    by_method: dict[str, int] = {}
+    for m in all_metrics:
+        by_method[m.method] = by_method.get(m.method, 0) + 1
+
+    # Calculate requests per minute (based on time span of data)
+    if len(all_metrics) >= 2:
+        try:
+            first_time = datetime.fromisoformat(all_metrics[0].timestamp.replace('Z', ''))
+            last_time = datetime.fromisoformat(all_metrics[-1].timestamp.replace('Z', ''))
+            time_span_minutes = (last_time - first_time).total_seconds() / 60
+            if time_span_minutes > 0:
+                rpm = len(all_metrics) / time_span_minutes
+            else:
+                rpm = 0
+        except:
+            rpm = 0
+    else:
+        rpm = 0
+
+    return OverallStats(
+        total_requests=len(all_metrics),
+        avg_duration_ms=round(statistics.mean(durations), 2),
+        slow_requests=slow_count,
+        error_requests=error_count,
+        requests_per_minute=round(rpm, 2),
+        by_status=by_status,
+        by_method=by_method,
+    )
+
+
+@router.get("/endpoints")
+async def get_endpoint_stats(
+    _: None = Depends(require_debug),
+    sort_by: str = Query("count", regex="^(count|avg_ms|max_ms|slow_count)$"),
+):
+    """Get aggregated statistics by endpoint."""
+    all_metrics = list(metrics_buffer)
+
+    # Group by endpoint (method + path)
+    endpoints: dict[str, list[RequestMetric]] = {}
+    for m in all_metrics:
+        key = f"{m.method} {m.path}"
+        if key not in endpoints:
+            endpoints[key] = []
+        endpoints[key].append(m)
+
+    # Calculate stats for each endpoint
+    stats_list: list[EndpointStats] = []
+    for key, metrics in endpoints.items():
+        method, path = key.split(' ', 1)
+        durations = [m.duration_ms for m in metrics]
+        sorted_durations = sorted(durations)
+
+        def percentile(data: list, p: float) -> float:
+            k = (len(data) - 1) * p / 100
+            f = int(k)
+            c = f + 1 if f + 1 < len(data) else f
+            return data[f] + (k - f) * (data[c] - data[f]) if c != f else data[f]
+
+        stats = EndpointStats(
+            path=path,
+            method=method,
+            count=len(metrics),
+            avg_ms=round(statistics.mean(durations), 2),
+            min_ms=round(min(durations), 2),
+            max_ms=round(max(durations), 2),
+            p50_ms=round(percentile(sorted_durations, 50), 2),
+            p95_ms=round(percentile(sorted_durations, 95), 2),
+            p99_ms=round(percentile(sorted_durations, 99), 2),
+            slow_count=len([m for m in metrics if m.is_slow]),
+            error_count=len([m for m in metrics if m.status_code >= 400]),
+        )
+        stats_list.append(stats)
+
+    # Sort
+    sort_key = {
+        "count": lambda x: x.count,
+        "avg_ms": lambda x: x.avg_ms,
+        "max_ms": lambda x: x.max_ms,
+        "slow_count": lambda x: x.slow_count,
+    }.get(sort_by, lambda x: x.count)
+
+    stats_list.sort(key=sort_key, reverse=True)
+
+    return {
+        "endpoints": [s.model_dump() for s in stats_list],
+        "total_endpoints": len(stats_list),
+    }
+
+
+@router.get("/slow")
+async def get_slow_requests(
+    _: None = Depends(require_debug),
+    limit: int = Query(20, ge=1, le=100),
+):
+    """Get slowest requests."""
+    all_metrics = list(metrics_buffer)
+
+    # Sort by duration descending
+    sorted_metrics = sorted(all_metrics, key=lambda m: m.duration_ms, reverse=True)
+
+    return {
+        "requests": [m.model_dump() for m in sorted_metrics[:limit]],
+        "threshold_ms": SLOW_REQUEST_THRESHOLD_MS,
+    }
+
+
+@router.get("/timeline")
+async def get_timeline(
+    _: None = Depends(require_debug),
+    minutes: int = Query(10, ge=1, le=60),
+    bucket_seconds: int = Query(30, ge=10, le=300),
+):
+    """Get request timeline data for charting."""
+    all_metrics = list(metrics_buffer)
+
+    if not all_metrics:
+        return {"buckets": [], "bucket_seconds": bucket_seconds}
+
+    now = datetime.utcnow()
+    cutoff = now - timedelta(minutes=minutes)
+
+    # Filter to time window
+    recent = []
+    for m in all_metrics:
+        try:
+            ts = datetime.fromisoformat(m.timestamp.replace('Z', ''))
+            if ts >= cutoff:
+                recent.append((ts, m))
+        except:
+            pass
+
+    if not recent:
+        return {"buckets": [], "bucket_seconds": bucket_seconds}
+
+    # Create time buckets
+    buckets: list[dict] = []
+    bucket_start = cutoff
+    while bucket_start < now:
+        bucket_end = bucket_start + timedelta(seconds=bucket_seconds)
+
+        bucket_metrics = [m for ts, m in recent if bucket_start <= ts < bucket_end]
+
+        if bucket_metrics:
+            durations = [m.duration_ms for m in bucket_metrics]
+            bucket_data = {
+                "time": bucket_start.isoformat() + "Z",
+                "count": len(bucket_metrics),
+                "avg_ms": round(statistics.mean(durations), 2),
+                "max_ms": round(max(durations), 2),
+                "errors": len([m for m in bucket_metrics if m.status_code >= 400]),
+            }
+        else:
+            bucket_data = {
+                "time": bucket_start.isoformat() + "Z",
+                "count": 0,
+                "avg_ms": 0,
+                "max_ms": 0,
+                "errors": 0,
+            }
+
+        buckets.append(bucket_data)
+        bucket_start = bucket_end
+
+    return {
+        "buckets": buckets,
+        "bucket_seconds": bucket_seconds,
+        "minutes": minutes,
+    }
+
+
+@router.delete("")
+async def clear_metrics(_: None = Depends(require_debug)):
+    """Clear all performance metrics."""
+    metrics_buffer.clear()
+    return {"status": "cleared", "message": "Metrics buffer cleared"}
+
+
+@router.patch("/threshold")
+async def set_threshold(
+    threshold_ms: int = Query(..., ge=100, le=5000),
+    _: None = Depends(require_debug),
+):
+    """Set the slow request threshold."""
+    global SLOW_REQUEST_THRESHOLD_MS
+    SLOW_REQUEST_THRESHOLD_MS = threshold_ms
+    return {"status": "updated", "threshold_ms": threshold_ms}
+
+
+@router.get("/threshold")
+async def get_threshold(_: None = Depends(require_debug)):
+    """Get the current slow request threshold."""
+    return {"threshold_ms": SLOW_REQUEST_THRESHOLD_MS}

--- a/server/app/main.py
+++ b/server/app/main.py
@@ -22,6 +22,7 @@ from .api.status import router as status_router
 from .api.buildinfo import router as buildinfo_router
 from .api.logs import router as logs_router
 from .api.errors import router as errors_router, capture_error
+from .api.profiler import router as profiler_router, ProfilingMiddleware
 
 
 @asynccontextmanager
@@ -67,6 +68,10 @@ def create_app() -> FastAPI:
         allow_headers=["*"],
     )
 
+    # Performance profiling middleware (debug mode only)
+    if settings.debug:
+        app.add_middleware(ProfilingMiddleware, enabled=True)
+
     # Include routers
     app.include_router(health_router, prefix="/api", tags=["health"])
     app.include_router(auth_router, prefix="/api")
@@ -85,6 +90,7 @@ def create_app() -> FastAPI:
     app.include_router(buildinfo_router, tags=["dev-tools"])
     app.include_router(logs_router, tags=["dev-tools"])
     app.include_router(errors_router, tags=["dev-tools"])
+    app.include_router(profiler_router, tags=["dev-tools"])
 
     # Add exception handler to capture errors (only in debug mode)
     if settings.debug:

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,6 +1,6 @@
 import { Routes, Route } from 'react-router-dom';
 import { Layout } from './components/Layout';
-import { Home, Login, Register, Play, Features, About, PlayScene, SceneDemo, Leaderboard, Ghosts, Profile, Achievements, Spectate, Friends, Presentation, Roadmap, CodebaseHealth, Changelog, DatabaseExplorer, CacheInspector, AudioJukebox, SystemStatus, ApiPlayground, WebSocketMonitor, BuildInfo, LogViewer, ErrorTracker } from './pages';
+import { Home, Login, Register, Play, Features, About, PlayScene, SceneDemo, Leaderboard, Ghosts, Profile, Achievements, Spectate, Friends, Presentation, Roadmap, CodebaseHealth, Changelog, DatabaseExplorer, CacheInspector, AudioJukebox, SystemStatus, ApiPlayground, WebSocketMonitor, BuildInfo, LogViewer, ErrorTracker, PerformanceProfiler } from './pages';
 import { FirstPersonDemo } from './pages/FirstPersonDemo';
 import { FirstPersonTestPage } from './pages/FirstPersonTestPage';
 import { Debug3DPage } from './pages/Debug3DPage';
@@ -42,6 +42,7 @@ function App() {
         <Route path="build-info" element={<BuildInfo />} />
         <Route path="log-viewer" element={<LogViewer />} />
         <Route path="error-tracker" element={<ErrorTracker />} />
+        <Route path="profiler" element={<PerformanceProfiler />} />
       </Route>
     </Routes>
   );

--- a/web/src/components/Layout.tsx
+++ b/web/src/components/Layout.tsx
@@ -160,6 +160,10 @@ export function Layout() {
                     <span className="menu-icon">🐛</span>
                     Error Tracker
                   </Link>
+                  <Link to="/profiler" onClick={closeDropdown}>
+                    <span className="menu-icon">⏱️</span>
+                    Profiler
+                  </Link>
                   <Link to="/codebase-health" onClick={closeDropdown}>
                     <span className="menu-icon">🩺</span>
                     Codebase Health

--- a/web/src/pages/PerformanceProfiler.css
+++ b/web/src/pages/PerformanceProfiler.css
@@ -1,0 +1,588 @@
+/**
+ * Performance Profiler Styles - Metrics/Dashboard theme
+ */
+
+.performance-profiler {
+  min-height: 100vh;
+  background: #0d1117;
+  color: #e6edf3;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+}
+
+/* Loading State */
+.profiler-loading {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  min-height: 60vh;
+  gap: 1rem;
+}
+
+.loading-spinner {
+  width: 40px;
+  height: 40px;
+  border: 3px solid #21262d;
+  border-top-color: #3b82f6;
+  border-radius: 50%;
+  animation: spin 1s linear infinite;
+}
+
+@keyframes spin {
+  to { transform: rotate(360deg); }
+}
+
+/* Header */
+.profiler-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 1rem 1.5rem;
+  background: #161b22;
+  border-bottom: 1px solid #30363d;
+}
+
+.profiler-header .header-left {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+}
+
+.profiler-header h1 {
+  margin: 0;
+  font-size: 1.25rem;
+  font-weight: 600;
+}
+
+.header-badge {
+  font-size: 0.75rem;
+  font-weight: 600;
+  padding: 0.25rem 0.75rem;
+  background: #3b82f622;
+  color: #3b82f6;
+  border-radius: 12px;
+}
+
+.clear-btn {
+  padding: 0.5rem 1rem;
+  background: transparent;
+  border: 1px solid #30363d;
+  border-radius: 6px;
+  color: #8b949e;
+  cursor: pointer;
+  transition: all 0.15s;
+}
+
+.clear-btn:hover {
+  background: #21262d;
+  color: #e6edf3;
+}
+
+/* Stats Row */
+.stats-row {
+  display: flex;
+  gap: 1rem;
+  padding: 1rem 1.5rem;
+  background: #161b22;
+  border-bottom: 1px solid #21262d;
+  overflow-x: auto;
+}
+
+.stat-card {
+  flex: 1;
+  min-width: 100px;
+  background: #0d1117;
+  border: 1px solid #30363d;
+  border-radius: 8px;
+  padding: 0.75rem 1rem;
+  text-align: center;
+}
+
+.stat-card.stat-warning {
+  border-color: #d2992255;
+}
+
+.stat-card.stat-warning .stat-value {
+  color: #d29922;
+}
+
+.stat-card.stat-error {
+  border-color: #f8514955;
+}
+
+.stat-card.stat-error .stat-value {
+  color: #f85149;
+}
+
+.stat-value {
+  font-size: 1.5rem;
+  font-weight: 700;
+  color: #e6edf3;
+}
+
+.stat-label {
+  font-size: 0.7rem;
+  color: #8b949e;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  margin-top: 0.25rem;
+}
+
+/* Timeline Section */
+.timeline-section {
+  padding: 1rem 1.5rem;
+  background: #161b22;
+  border-bottom: 1px solid #21262d;
+}
+
+.section-title {
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: #8b949e;
+  margin: 0 0 0.75rem 0;
+}
+
+.timeline-chart {
+  display: flex;
+  align-items: flex-end;
+  gap: 2px;
+  height: 80px;
+  padding-bottom: 20px;
+  position: relative;
+}
+
+.timeline-bar-container {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  height: 100%;
+  position: relative;
+}
+
+.timeline-bar {
+  width: 100%;
+  background: linear-gradient(to top, #3b82f6, #60a5fa);
+  border-radius: 2px 2px 0 0;
+  transition: height 0.3s ease;
+  position: relative;
+  cursor: pointer;
+  min-height: 2px;
+}
+
+.timeline-bar:hover {
+  background: linear-gradient(to top, #2563eb, #3b82f6);
+}
+
+.timeline-bar.has-errors {
+  background: linear-gradient(to top, #f85149, #ff7b72);
+}
+
+.error-indicator {
+  position: absolute;
+  top: -4px;
+  left: 50%;
+  transform: translateX(-50%);
+  width: 6px;
+  height: 6px;
+  background: #f85149;
+  border-radius: 50%;
+}
+
+.timeline-label {
+  position: absolute;
+  bottom: -18px;
+  font-size: 0.65rem;
+  color: #6b7280;
+  white-space: nowrap;
+}
+
+/* View Toggle */
+.view-toggle {
+  display: flex;
+  gap: 0;
+  padding: 0 1.5rem;
+  background: #161b22;
+  border-bottom: 1px solid #21262d;
+}
+
+.view-toggle button {
+  padding: 0.75rem 1.5rem;
+  background: transparent;
+  border: none;
+  border-bottom: 2px solid transparent;
+  color: #8b949e;
+  font-size: 0.9rem;
+  cursor: pointer;
+  transition: all 0.15s;
+}
+
+.view-toggle button:hover {
+  color: #e6edf3;
+}
+
+.view-toggle button.active {
+  color: #3b82f6;
+  border-bottom-color: #3b82f6;
+}
+
+/* Toolbar */
+.profiler-toolbar {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.75rem 1.5rem;
+  background: #0d1117;
+  border-bottom: 1px solid #21262d;
+  flex-wrap: wrap;
+}
+
+.filter-select {
+  padding: 0.5rem 0.75rem;
+  background: #161b22;
+  border: 1px solid #30363d;
+  border-radius: 6px;
+  color: #e6edf3;
+  font-size: 0.85rem;
+  cursor: pointer;
+}
+
+.filter-select:focus {
+  outline: none;
+  border-color: #3b82f6;
+}
+
+.filter-input {
+  padding: 0.5rem 0.75rem;
+  background: #161b22;
+  border: 1px solid #30363d;
+  border-radius: 6px;
+  color: #e6edf3;
+  font-size: 0.85rem;
+  min-width: 180px;
+}
+
+.filter-input:focus {
+  outline: none;
+  border-color: #3b82f6;
+}
+
+.filter-input::placeholder {
+  color: #6b7280;
+}
+
+.checkbox-filter {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.85rem;
+  color: #8b949e;
+  cursor: pointer;
+}
+
+/* Request List */
+.request-list {
+  padding: 0;
+}
+
+.no-data {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  min-height: 200px;
+  color: #6b7280;
+}
+
+.no-data .hint {
+  font-size: 0.85rem;
+  color: #4b5563;
+}
+
+/* Request Table */
+.request-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.85rem;
+}
+
+.request-table th {
+  padding: 0.75rem 1rem;
+  text-align: left;
+  background: #161b22;
+  color: #8b949e;
+  font-weight: 600;
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  border-bottom: 1px solid #21262d;
+  position: sticky;
+  top: 0;
+}
+
+.request-table td {
+  padding: 0.6rem 1rem;
+  border-bottom: 1px solid #21262d;
+  vertical-align: middle;
+}
+
+.request-table tr:hover {
+  background: #161b22;
+}
+
+.request-table tr.slow-row {
+  background: #d2992210;
+}
+
+.col-time {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.8rem;
+  color: #8b949e;
+  white-space: nowrap;
+}
+
+.method-badge {
+  display: inline-block;
+  padding: 0.2rem 0.5rem;
+  border-radius: 4px;
+  font-size: 0.7rem;
+  font-weight: 700;
+  color: white;
+}
+
+.method-badge.small {
+  padding: 0.15rem 0.35rem;
+  font-size: 0.6rem;
+}
+
+.col-path {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.8rem;
+  max-width: 300px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.status-badge {
+  display: inline-block;
+  padding: 0.15rem 0.4rem;
+  border-radius: 4px;
+  font-size: 0.75rem;
+  font-weight: 600;
+}
+
+.status-2xx {
+  background: #22c55e22;
+  color: #22c55e;
+}
+
+.status-3xx {
+  background: #3b82f622;
+  color: #3b82f6;
+}
+
+.status-4xx {
+  background: #d2992222;
+  color: #d29922;
+}
+
+.status-5xx {
+  background: #f8514922;
+  color: #f85149;
+}
+
+.col-duration {
+  font-family: 'JetBrains Mono', monospace;
+  font-weight: 600;
+  white-space: nowrap;
+}
+
+.duration-fast {
+  color: #22c55e;
+}
+
+.duration-medium {
+  color: #d29922;
+}
+
+.duration-slow {
+  color: #f85149;
+}
+
+.slow-indicator {
+  margin-left: 0.25rem;
+}
+
+.col-size {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.8rem;
+  color: #8b949e;
+}
+
+/* Endpoints Table */
+.endpoints-section {
+  padding: 0;
+}
+
+.endpoints-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.85rem;
+}
+
+.endpoints-table th {
+  padding: 0.75rem 1rem;
+  text-align: left;
+  background: #161b22;
+  color: #8b949e;
+  font-weight: 600;
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  border-bottom: 1px solid #21262d;
+}
+
+.endpoints-table td {
+  padding: 0.6rem 1rem;
+  border-bottom: 1px solid #21262d;
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.8rem;
+}
+
+.endpoints-table tr:hover {
+  background: #161b22;
+}
+
+.col-endpoint {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.endpoint-path {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.has-slow {
+  color: #d29922;
+}
+
+.has-errors {
+  color: #f85149;
+}
+
+/* Distribution Section */
+.distribution-section {
+  padding: 1.5rem;
+}
+
+.distribution-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+  gap: 1rem;
+}
+
+.distribution-card {
+  background: #161b22;
+  border: 1px solid #30363d;
+  border-radius: 8px;
+  padding: 1rem;
+}
+
+.distribution-card h3 {
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: #8b949e;
+  margin: 0 0 0.75rem 0;
+}
+
+.distribution-bars {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.dist-item {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.dist-label {
+  font-size: 0.75rem;
+  font-weight: 600;
+  width: 60px;
+}
+
+.dist-label.status-2 { color: #22c55e; }
+.dist-label.status-3 { color: #3b82f6; }
+.dist-label.status-4 { color: #d29922; }
+.dist-label.status-5 { color: #f85149; }
+
+.dist-bar {
+  flex: 1;
+  height: 8px;
+  background: #21262d;
+  border-radius: 4px;
+  overflow: hidden;
+}
+
+.dist-fill {
+  height: 100%;
+  border-radius: 4px;
+  transition: width 0.3s ease;
+}
+
+.status-fill-2 { background: #22c55e; }
+.status-fill-3 { background: #3b82f6; }
+.status-fill-4 { background: #d29922; }
+.status-fill-5 { background: #f85149; }
+
+.dist-count {
+  font-size: 0.75rem;
+  color: #8b949e;
+  width: 40px;
+  text-align: right;
+  font-family: 'JetBrains Mono', monospace;
+}
+
+/* Responsive */
+@media (max-width: 768px) {
+  .stats-row {
+    flex-wrap: nowrap;
+    overflow-x: auto;
+    padding-bottom: 0.5rem;
+  }
+
+  .stat-card {
+    min-width: 80px;
+  }
+
+  .profiler-toolbar {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .filter-input {
+    min-width: auto;
+  }
+
+  .col-path {
+    max-width: 150px;
+  }
+
+  .request-table,
+  .endpoints-table {
+    font-size: 0.75rem;
+  }
+
+  .request-table th,
+  .request-table td,
+  .endpoints-table th,
+  .endpoints-table td {
+    padding: 0.5rem;
+  }
+}

--- a/web/src/pages/PerformanceProfiler.tsx
+++ b/web/src/pages/PerformanceProfiler.tsx
@@ -1,0 +1,506 @@
+/**
+ * Performance Profiler - Request timing and metrics dashboard
+ *
+ * Features:
+ * - Real-time request timing visualization
+ * - Endpoint statistics with percentiles
+ * - Slow request identification
+ * - Timeline chart of request volume
+ * - Filter by method, path, slow requests
+ */
+
+import { useState, useEffect, useCallback } from 'react';
+import './PerformanceProfiler.css';
+
+const API_BASE = 'http://localhost:8000/api/profiler';
+
+interface RequestMetric {
+  id: number;
+  timestamp: string;
+  method: string;
+  path: string;
+  full_path: string;
+  status_code: number;
+  duration_ms: number;
+  response_size?: number;
+  client_ip?: string;
+  user_agent?: string;
+  is_slow: boolean;
+}
+
+interface OverallStats {
+  total_requests: number;
+  avg_duration_ms: number;
+  slow_requests: number;
+  error_requests: number;
+  requests_per_minute: number;
+  by_status: Record<string, number>;
+  by_method: Record<string, number>;
+}
+
+interface EndpointStats {
+  path: string;
+  method: string;
+  count: number;
+  avg_ms: number;
+  min_ms: number;
+  max_ms: number;
+  p50_ms: number;
+  p95_ms: number;
+  p99_ms: number;
+  slow_count: number;
+  error_count: number;
+}
+
+interface TimelineBucket {
+  time: string;
+  count: number;
+  avg_ms: number;
+  max_ms: number;
+  errors: number;
+}
+
+const METHOD_COLORS: Record<string, string> = {
+  GET: '#22c55e',
+  POST: '#3b82f6',
+  PUT: '#eab308',
+  PATCH: '#f97316',
+  DELETE: '#ef4444',
+  OPTIONS: '#8b5cf6',
+};
+
+export function PerformanceProfiler() {
+  const [requests, setRequests] = useState<RequestMetric[]>([]);
+  const [stats, setStats] = useState<OverallStats | null>(null);
+  const [endpoints, setEndpoints] = useState<EndpointStats[]>([]);
+  const [timeline, setTimeline] = useState<TimelineBucket[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [slowThreshold, setSlowThreshold] = useState(500);
+
+  // Filters
+  const [methodFilter, setMethodFilter] = useState('');
+  const [pathFilter, setPathFilter] = useState('');
+  const [slowOnly, setSlowOnly] = useState(false);
+  const [errorsOnly, setErrorsOnly] = useState(false);
+
+  // View mode
+  const [view, setView] = useState<'requests' | 'endpoints'>('requests');
+
+  // Fetch requests
+  const fetchRequests = useCallback(async () => {
+    try {
+      const params = new URLSearchParams({ limit: '100' });
+      if (methodFilter) params.append('method', methodFilter);
+      if (pathFilter) params.append('path', pathFilter);
+      if (slowOnly) params.append('slow_only', 'true');
+      if (errorsOnly) params.append('errors_only', 'true');
+
+      const res = await fetch(`${API_BASE}/requests?${params}`);
+      if (res.ok) {
+        const data = await res.json();
+        setRequests(data.requests);
+        setSlowThreshold(data.slow_threshold_ms);
+      }
+    } catch {
+      // Silently fail
+    }
+  }, [methodFilter, pathFilter, slowOnly, errorsOnly]);
+
+  // Fetch stats
+  const fetchStats = useCallback(async () => {
+    try {
+      const res = await fetch(`${API_BASE}/stats`);
+      if (res.ok) {
+        const data = await res.json();
+        setStats(data);
+      }
+    } catch {
+      // Silently fail
+    }
+  }, []);
+
+  // Fetch endpoints
+  const fetchEndpoints = useCallback(async () => {
+    try {
+      const res = await fetch(`${API_BASE}/endpoints?sort_by=avg_ms`);
+      if (res.ok) {
+        const data = await res.json();
+        setEndpoints(data.endpoints);
+      }
+    } catch {
+      // Silently fail
+    }
+  }, []);
+
+  // Fetch timeline
+  const fetchTimeline = useCallback(async () => {
+    try {
+      const res = await fetch(`${API_BASE}/timeline?minutes=10&bucket_seconds=30`);
+      if (res.ok) {
+        const data = await res.json();
+        setTimeline(data.buckets);
+      }
+    } catch {
+      // Silently fail
+    }
+  }, []);
+
+  // Initial fetch
+  useEffect(() => {
+    const loadData = async () => {
+      setLoading(true);
+      await Promise.all([fetchRequests(), fetchStats(), fetchEndpoints(), fetchTimeline()]);
+      setLoading(false);
+    };
+    loadData();
+
+    // Auto-refresh every 5 seconds
+    const interval = setInterval(() => {
+      fetchRequests();
+      fetchStats();
+      fetchEndpoints();
+      fetchTimeline();
+    }, 5000);
+
+    return () => clearInterval(interval);
+  }, [fetchRequests, fetchStats, fetchEndpoints, fetchTimeline]);
+
+  // Clear metrics
+  const clearMetrics = async () => {
+    try {
+      await fetch(API_BASE, { method: 'DELETE' });
+      setRequests([]);
+      fetchStats();
+      fetchEndpoints();
+      fetchTimeline();
+    } catch {
+      // Silently fail
+    }
+  };
+
+  // Format duration with color
+  const getDurationClass = (ms: number) => {
+    if (ms >= slowThreshold) return 'duration-slow';
+    if (ms >= slowThreshold * 0.5) return 'duration-medium';
+    return 'duration-fast';
+  };
+
+  // Format timestamp
+  const formatTime = (timestamp: string) => {
+    try {
+      const date = new Date(timestamp);
+      return date.toLocaleTimeString('en-US', {
+        hour12: false,
+        hour: '2-digit',
+        minute: '2-digit',
+        second: '2-digit',
+      });
+    } catch {
+      return timestamp;
+    }
+  };
+
+  // Get status class
+  const getStatusClass = (status: number) => {
+    if (status >= 500) return 'status-5xx';
+    if (status >= 400) return 'status-4xx';
+    if (status >= 300) return 'status-3xx';
+    return 'status-2xx';
+  };
+
+  // Get max value for timeline scaling
+  const timelineMax = Math.max(...timeline.map(b => b.avg_ms), 1);
+
+  if (loading) {
+    return (
+      <div className="performance-profiler">
+        <div className="profiler-loading">
+          <div className="loading-spinner" />
+          <p>Loading performance data...</p>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="performance-profiler">
+      {/* Header */}
+      <header className="profiler-header">
+        <div className="header-left">
+          <h1>Performance Profiler</h1>
+          <span className="header-badge">{slowThreshold}ms threshold</span>
+        </div>
+        <div className="header-right">
+          <button onClick={clearMetrics} className="clear-btn">Clear</button>
+        </div>
+      </header>
+
+      {/* Stats Cards */}
+      {stats && (
+        <div className="stats-row">
+          <div className="stat-card">
+            <div className="stat-value">{stats.total_requests}</div>
+            <div className="stat-label">Total Requests</div>
+          </div>
+          <div className="stat-card">
+            <div className="stat-value">{stats.avg_duration_ms.toFixed(0)}ms</div>
+            <div className="stat-label">Avg Duration</div>
+          </div>
+          <div className="stat-card stat-warning">
+            <div className="stat-value">{stats.slow_requests}</div>
+            <div className="stat-label">Slow Requests</div>
+          </div>
+          <div className="stat-card stat-error">
+            <div className="stat-value">{stats.error_requests}</div>
+            <div className="stat-label">Errors</div>
+          </div>
+          <div className="stat-card">
+            <div className="stat-value">{stats.requests_per_minute.toFixed(1)}</div>
+            <div className="stat-label">Req/min</div>
+          </div>
+        </div>
+      )}
+
+      {/* Timeline Chart */}
+      <div className="timeline-section">
+        <h2 className="section-title">Request Timeline (Last 10 min)</h2>
+        <div className="timeline-chart">
+          {timeline.map((bucket, i) => (
+            <div key={i} className="timeline-bar-container">
+              <div
+                className={`timeline-bar ${bucket.errors > 0 ? 'has-errors' : ''}`}
+                style={{
+                  height: `${Math.max(5, (bucket.avg_ms / timelineMax) * 100)}%`,
+                }}
+                title={`${formatTime(bucket.time)}\n${bucket.count} requests\n${bucket.avg_ms.toFixed(0)}ms avg\n${bucket.errors} errors`}
+              >
+                {bucket.errors > 0 && <div className="error-indicator" />}
+              </div>
+              {i % 4 === 0 && (
+                <span className="timeline-label">{formatTime(bucket.time)}</span>
+              )}
+            </div>
+          ))}
+        </div>
+      </div>
+
+      {/* View Toggle */}
+      <div className="view-toggle">
+        <button
+          className={view === 'requests' ? 'active' : ''}
+          onClick={() => setView('requests')}
+        >
+          Recent Requests
+        </button>
+        <button
+          className={view === 'endpoints' ? 'active' : ''}
+          onClick={() => setView('endpoints')}
+        >
+          Endpoint Stats
+        </button>
+      </div>
+
+      {/* Requests View */}
+      {view === 'requests' && (
+        <>
+          {/* Toolbar */}
+          <div className="profiler-toolbar">
+            <select
+              value={methodFilter}
+              onChange={(e) => setMethodFilter(e.target.value)}
+              className="filter-select"
+            >
+              <option value="">All Methods</option>
+              <option value="GET">GET</option>
+              <option value="POST">POST</option>
+              <option value="PUT">PUT</option>
+              <option value="PATCH">PATCH</option>
+              <option value="DELETE">DELETE</option>
+            </select>
+
+            <input
+              type="text"
+              value={pathFilter}
+              onChange={(e) => setPathFilter(e.target.value)}
+              placeholder="Filter by path..."
+              className="filter-input"
+            />
+
+            <label className="checkbox-filter">
+              <input
+                type="checkbox"
+                checked={slowOnly}
+                onChange={(e) => setSlowOnly(e.target.checked)}
+              />
+              Slow only
+            </label>
+
+            <label className="checkbox-filter">
+              <input
+                type="checkbox"
+                checked={errorsOnly}
+                onChange={(e) => setErrorsOnly(e.target.checked)}
+              />
+              Errors only
+            </label>
+          </div>
+
+          {/* Request List */}
+          <div className="request-list">
+            {requests.length === 0 ? (
+              <div className="no-data">
+                <p>No requests captured yet</p>
+                <p className="hint">Make some API calls to see performance data</p>
+              </div>
+            ) : (
+              <table className="request-table">
+                <thead>
+                  <tr>
+                    <th>Time</th>
+                    <th>Method</th>
+                    <th>Path</th>
+                    <th>Status</th>
+                    <th>Duration</th>
+                    <th>Size</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {requests.map((req) => (
+                    <tr key={req.id} className={req.is_slow ? 'slow-row' : ''}>
+                      <td className="col-time">{formatTime(req.timestamp)}</td>
+                      <td>
+                        <span
+                          className="method-badge"
+                          style={{ background: METHOD_COLORS[req.method] || '#6b7280' }}
+                        >
+                          {req.method}
+                        </span>
+                      </td>
+                      <td className="col-path" title={req.full_path}>
+                        {req.path}
+                      </td>
+                      <td>
+                        <span className={`status-badge ${getStatusClass(req.status_code)}`}>
+                          {req.status_code}
+                        </span>
+                      </td>
+                      <td className={`col-duration ${getDurationClass(req.duration_ms)}`}>
+                        {req.duration_ms.toFixed(0)}ms
+                        {req.is_slow && <span className="slow-indicator">🐢</span>}
+                      </td>
+                      <td className="col-size">
+                        {req.response_size ? `${(req.response_size / 1024).toFixed(1)}KB` : '-'}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            )}
+          </div>
+        </>
+      )}
+
+      {/* Endpoints View */}
+      {view === 'endpoints' && (
+        <div className="endpoints-section">
+          {endpoints.length === 0 ? (
+            <div className="no-data">
+              <p>No endpoint data yet</p>
+            </div>
+          ) : (
+            <table className="endpoints-table">
+              <thead>
+                <tr>
+                  <th>Endpoint</th>
+                  <th>Requests</th>
+                  <th>Avg</th>
+                  <th>P50</th>
+                  <th>P95</th>
+                  <th>P99</th>
+                  <th>Max</th>
+                  <th>Slow</th>
+                  <th>Errors</th>
+                </tr>
+              </thead>
+              <tbody>
+                {endpoints.map((ep, i) => (
+                  <tr key={i}>
+                    <td className="col-endpoint">
+                      <span
+                        className="method-badge small"
+                        style={{ background: METHOD_COLORS[ep.method] || '#6b7280' }}
+                      >
+                        {ep.method}
+                      </span>
+                      <span className="endpoint-path">{ep.path}</span>
+                    </td>
+                    <td>{ep.count}</td>
+                    <td className={getDurationClass(ep.avg_ms)}>{ep.avg_ms.toFixed(0)}ms</td>
+                    <td>{ep.p50_ms.toFixed(0)}ms</td>
+                    <td className={getDurationClass(ep.p95_ms)}>{ep.p95_ms.toFixed(0)}ms</td>
+                    <td className={getDurationClass(ep.p99_ms)}>{ep.p99_ms.toFixed(0)}ms</td>
+                    <td className={getDurationClass(ep.max_ms)}>{ep.max_ms.toFixed(0)}ms</td>
+                    <td className={ep.slow_count > 0 ? 'has-slow' : ''}>{ep.slow_count}</td>
+                    <td className={ep.error_count > 0 ? 'has-errors' : ''}>{ep.error_count}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          )}
+        </div>
+      )}
+
+      {/* Method Distribution */}
+      {stats && Object.keys(stats.by_method).length > 0 && (
+        <div className="distribution-section">
+          <h2 className="section-title">Request Distribution</h2>
+          <div className="distribution-grid">
+            <div className="distribution-card">
+              <h3>By Method</h3>
+              <div className="distribution-bars">
+                {Object.entries(stats.by_method).map(([method, count]) => (
+                  <div key={method} className="dist-item">
+                    <span className="dist-label" style={{ color: METHOD_COLORS[method] }}>
+                      {method}
+                    </span>
+                    <div className="dist-bar">
+                      <div
+                        className="dist-fill"
+                        style={{
+                          width: `${(count / stats.total_requests) * 100}%`,
+                          background: METHOD_COLORS[method],
+                        }}
+                      />
+                    </div>
+                    <span className="dist-count">{count}</span>
+                  </div>
+                ))}
+              </div>
+            </div>
+            <div className="distribution-card">
+              <h3>By Status</h3>
+              <div className="distribution-bars">
+                {Object.entries(stats.by_status).map(([status, count]) => (
+                  <div key={status} className="dist-item">
+                    <span className={`dist-label status-${status.replace('xx', '')}`}>
+                      {status}
+                    </span>
+                    <div className="dist-bar">
+                      <div
+                        className={`dist-fill status-fill-${status.replace('xx', '')}`}
+                        style={{ width: `${(count / stats.total_requests) * 100}%` }}
+                      />
+                    </div>
+                    <span className="dist-count">{count}</span>
+                  </div>
+                ))}
+              </div>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default PerformanceProfiler;

--- a/web/src/pages/index.ts
+++ b/web/src/pages/index.ts
@@ -25,3 +25,4 @@ export { WebSocketMonitor } from './WebSocketMonitor';
 export { BuildInfo } from './BuildInfo';
 export { LogViewer } from './LogViewer';
 export { ErrorTracker } from './ErrorTracker';
+export { PerformanceProfiler } from './PerformanceProfiler';


### PR DESCRIPTION
## Summary
- Add performance profiling middleware that captures all request timing
- Ring buffer stores last 500 request metrics
- Overall stats dashboard: total requests, avg duration, slow count, req/min
- Timeline chart showing request volume and latency over last 10 minutes
- Two view modes: Recent Requests table and Endpoint Statistics
- Endpoint stats include P50/P95/P99 latency percentiles
- Filter requests by method, path, slow-only, errors-only
- Method and status code distribution visualizations
- Configurable slow request threshold (default 500ms)
- Auto-refresh every 5 seconds

## Test plan
- [ ] Navigate to Dev Tools → Profiler
- [ ] Verify stats cards show request metrics
- [ ] Make API calls and verify timeline updates
- [ ] Check Recent Requests table populates
- [ ] Switch to Endpoint Stats view
- [ ] Test filters (method, slow only, errors only)
- [ ] Verify slow requests highlighted with turtle icon
- [ ] Test Clear button

🤖 Generated with [Claude Code](https://claude.com/claude-code)