### PR TITLE
feat(dev-tools): add Session Inspector

### DIFF
--- a/server/app/api/sessions.py
+++ b/server/app/api/sessions.py
@@ -1,0 +1,477 @@
+"""
+Session Inspector API - Track and manage user sessions.
+
+Features:
+- Track active user sessions with metadata
+- View session details (IP, user agent, login time)
+- Revoke individual sessions
+- Session statistics and activity tracking
+"""
+
+import hashlib
+from datetime import datetime, timedelta
+from collections import deque
+from typing import Optional
+from enum import Enum
+
+from fastapi import APIRouter, Depends, Request, Query
+from pydantic import BaseModel
+from sqlalchemy import select, func
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from ..api.dbexplorer import require_debug
+from ..core.database import get_db
+from ..models.user import User
+
+router = APIRouter(prefix="/api/sessions", tags=["sessions"])
+
+# In-memory session store (in production, use Redis)
+# Maps session_id -> SessionInfo
+active_sessions: dict[str, "SessionInfo"] = {}
+
+# Recent session activity log
+MAX_ACTIVITY_LOG = 200
+activity_log: deque = deque(maxlen=MAX_ACTIVITY_LOG)
+
+
+class SessionStatus(str, Enum):
+    ACTIVE = "active"
+    EXPIRED = "expired"
+    REVOKED = "revoked"
+
+
+class SessionInfo(BaseModel):
+    """Information about an active session."""
+    session_id: str
+    user_id: int
+    username: str
+    display_name: Optional[str] = None
+    created_at: str
+    last_activity: str
+    expires_at: str
+    ip_address: Optional[str] = None
+    user_agent: Optional[str] = None
+    device_type: str = "unknown"
+    browser: str = "unknown"
+    os: str = "unknown"
+    status: SessionStatus = SessionStatus.ACTIVE
+    request_count: int = 0
+
+
+class SessionActivity(BaseModel):
+    """A session activity event."""
+    timestamp: str
+    session_id: str
+    user_id: int
+    username: str
+    event: str
+    ip_address: Optional[str] = None
+    details: Optional[str] = None
+
+
+class SessionStats(BaseModel):
+    """Session statistics."""
+    total_active: int
+    total_today: int
+    unique_users: int
+    by_device: dict[str, int]
+    by_browser: dict[str, int]
+    avg_session_duration_minutes: float
+
+
+def generate_session_id(user_id: int, token: str) -> str:
+    """Generate a unique session ID from user and token."""
+    content = f"{user_id}:{token[:32]}"
+    return hashlib.sha256(content.encode()).hexdigest()[:16]
+
+
+def parse_user_agent(user_agent: str) -> dict:
+    """Parse user agent string to extract device, browser, OS."""
+    ua = user_agent.lower() if user_agent else ""
+
+    # Detect device type
+    if "mobile" in ua or "android" in ua or "iphone" in ua:
+        device = "mobile"
+    elif "tablet" in ua or "ipad" in ua:
+        device = "tablet"
+    else:
+        device = "desktop"
+
+    # Detect browser
+    if "firefox" in ua:
+        browser = "Firefox"
+    elif "edg" in ua:
+        browser = "Edge"
+    elif "chrome" in ua:
+        browser = "Chrome"
+    elif "safari" in ua:
+        browser = "Safari"
+    elif "opera" in ua:
+        browser = "Opera"
+    else:
+        browser = "Other"
+
+    # Detect OS
+    if "windows" in ua:
+        os_name = "Windows"
+    elif "mac" in ua:
+        os_name = "macOS"
+    elif "linux" in ua:
+        os_name = "Linux"
+    elif "android" in ua:
+        os_name = "Android"
+    elif "iphone" in ua or "ipad" in ua:
+        os_name = "iOS"
+    else:
+        os_name = "Other"
+
+    return {"device": device, "browser": browser, "os": os_name}
+
+
+def register_session(
+    user_id: int,
+    username: str,
+    token: str,
+    request: Optional[Request] = None,
+    display_name: Optional[str] = None,
+    expires_minutes: int = 60,
+) -> SessionInfo:
+    """Register a new session when user logs in."""
+    session_id = generate_session_id(user_id, token)
+    now = datetime.utcnow()
+
+    ip_address = None
+    user_agent = None
+    device_info = {"device": "unknown", "browser": "unknown", "os": "unknown"}
+
+    if request:
+        ip_address = request.client.host if request.client else None
+        user_agent = request.headers.get("user-agent", "")
+        device_info = parse_user_agent(user_agent)
+
+    session = SessionInfo(
+        session_id=session_id,
+        user_id=user_id,
+        username=username,
+        display_name=display_name,
+        created_at=now.isoformat() + "Z",
+        last_activity=now.isoformat() + "Z",
+        expires_at=(now + timedelta(minutes=expires_minutes)).isoformat() + "Z",
+        ip_address=ip_address,
+        user_agent=user_agent,
+        device_type=device_info["device"],
+        browser=device_info["browser"],
+        os=device_info["os"],
+        status=SessionStatus.ACTIVE,
+        request_count=1,
+    )
+
+    active_sessions[session_id] = session
+
+    # Log activity
+    log_activity(session_id, user_id, username, "login", ip_address, "Session created")
+
+    return session
+
+
+def update_session_activity(session_id: str):
+    """Update session last activity timestamp."""
+    if session_id in active_sessions:
+        session = active_sessions[session_id]
+        session.last_activity = datetime.utcnow().isoformat() + "Z"
+        session.request_count += 1
+
+
+def revoke_session(session_id: str) -> bool:
+    """Revoke a session."""
+    if session_id in active_sessions:
+        session = active_sessions[session_id]
+        session.status = SessionStatus.REVOKED
+        log_activity(
+            session_id,
+            session.user_id,
+            session.username,
+            "revoked",
+            session.ip_address,
+            "Session revoked"
+        )
+        del active_sessions[session_id]
+        return True
+    return False
+
+
+def log_activity(
+    session_id: str,
+    user_id: int,
+    username: str,
+    event: str,
+    ip_address: Optional[str] = None,
+    details: Optional[str] = None,
+):
+    """Log session activity."""
+    activity = SessionActivity(
+        timestamp=datetime.utcnow().isoformat() + "Z",
+        session_id=session_id,
+        user_id=user_id,
+        username=username,
+        event=event,
+        ip_address=ip_address,
+        details=details,
+    )
+    activity_log.append(activity)
+
+
+def cleanup_expired_sessions():
+    """Remove expired sessions."""
+    now = datetime.utcnow()
+    expired = []
+
+    for session_id, session in active_sessions.items():
+        try:
+            expires_at = datetime.fromisoformat(session.expires_at.replace("Z", ""))
+            if now > expires_at:
+                expired.append(session_id)
+        except:
+            pass
+
+    for session_id in expired:
+        session = active_sessions[session_id]
+        log_activity(
+            session_id,
+            session.user_id,
+            session.username,
+            "expired",
+            session.ip_address,
+            "Session expired"
+        )
+        del active_sessions[session_id]
+
+
+@router.get("")
+async def get_sessions(
+    _: None = Depends(require_debug),
+    user_id: Optional[int] = None,
+    status: Optional[SessionStatus] = None,
+    limit: int = Query(50, ge=1, le=200),
+):
+    """Get all active sessions."""
+    cleanup_expired_sessions()
+
+    sessions = list(active_sessions.values())
+
+    if user_id is not None:
+        sessions = [s for s in sessions if s.user_id == user_id]
+
+    if status:
+        sessions = [s for s in sessions if s.status == status]
+
+    # Sort by last activity descending
+    sessions.sort(key=lambda s: s.last_activity, reverse=True)
+
+    return {
+        "sessions": [s.model_dump() for s in sessions[:limit]],
+        "total": len(sessions),
+    }
+
+
+@router.get("/stats")
+async def get_session_stats(
+    _: None = Depends(require_debug),
+    db: AsyncSession = Depends(get_db),
+):
+    """Get session statistics."""
+    cleanup_expired_sessions()
+
+    sessions = list(active_sessions.values())
+
+    # Count by device
+    by_device: dict[str, int] = {}
+    by_browser: dict[str, int] = {}
+    unique_users = set()
+    total_duration = 0
+
+    for session in sessions:
+        by_device[session.device_type] = by_device.get(session.device_type, 0) + 1
+        by_browser[session.browser] = by_browser.get(session.browser, 0) + 1
+        unique_users.add(session.user_id)
+
+        # Calculate duration
+        try:
+            created = datetime.fromisoformat(session.created_at.replace("Z", ""))
+            last = datetime.fromisoformat(session.last_activity.replace("Z", ""))
+            total_duration += (last - created).total_seconds()
+        except:
+            pass
+
+    avg_duration = (total_duration / len(sessions) / 60) if sessions else 0
+
+    # Get total users from database
+    total_users_result = await db.execute(select(func.count(User.id)))
+    total_users = total_users_result.scalar() or 0
+
+    # Get users active today
+    today_start = datetime.utcnow().replace(hour=0, minute=0, second=0, microsecond=0)
+    active_today_result = await db.execute(
+        select(func.count(User.id)).where(User.last_login >= today_start)
+    )
+    active_today = active_today_result.scalar() or 0
+
+    return SessionStats(
+        total_active=len(sessions),
+        total_today=active_today,
+        unique_users=len(unique_users),
+        by_device=by_device,
+        by_browser=by_browser,
+        avg_session_duration_minutes=round(avg_duration, 1),
+    )
+
+
+@router.get("/activity")
+async def get_activity_log(
+    _: None = Depends(require_debug),
+    event: Optional[str] = None,
+    user_id: Optional[int] = None,
+    limit: int = Query(50, ge=1, le=200),
+):
+    """Get session activity log."""
+    activities = list(activity_log)
+
+    if event:
+        activities = [a for a in activities if a.event == event]
+
+    if user_id is not None:
+        activities = [a for a in activities if a.user_id == user_id]
+
+    # Reverse to show newest first
+    activities = list(reversed(activities))
+
+    return {
+        "activities": [a.model_dump() for a in activities[:limit]],
+        "total": len(activities),
+    }
+
+
+@router.get("/users")
+async def get_users_with_sessions(
+    _: None = Depends(require_debug),
+    db: AsyncSession = Depends(get_db),
+):
+    """Get users with session info."""
+    cleanup_expired_sessions()
+
+    # Get all users with recent activity
+    result = await db.execute(
+        select(User)
+        .where(User.is_active == True)
+        .order_by(User.last_login.desc())
+        .limit(50)
+    )
+    users = result.scalars().all()
+
+    user_sessions = []
+    for user in users:
+        # Find sessions for this user
+        sessions = [s for s in active_sessions.values() if s.user_id == user.id]
+
+        user_sessions.append({
+            "id": user.id,
+            "username": user.username,
+            "display_name": user.display_name,
+            "last_login": user.last_login.isoformat() + "Z" if user.last_login else None,
+            "created_at": user.created_at.isoformat() + "Z" if user.created_at else None,
+            "active_sessions": len(sessions),
+            "sessions": [s.model_dump() for s in sessions],
+        })
+
+    return {
+        "users": user_sessions,
+        "total": len(user_sessions),
+    }
+
+
+@router.get("/{session_id}")
+async def get_session_detail(
+    session_id: str,
+    _: None = Depends(require_debug),
+):
+    """Get detailed information about a session."""
+    if session_id not in active_sessions:
+        return {"error": "Session not found"}
+
+    session = active_sessions[session_id]
+
+    # Get activity for this session
+    session_activity = [
+        a.model_dump() for a in activity_log
+        if a.session_id == session_id
+    ]
+
+    return {
+        "session": session.model_dump(),
+        "activity": list(reversed(session_activity))[-20:],
+    }
+
+
+@router.delete("/{session_id}")
+async def revoke_session_endpoint(
+    session_id: str,
+    _: None = Depends(require_debug),
+):
+    """Revoke a specific session."""
+    if revoke_session(session_id):
+        return {"status": "revoked", "session_id": session_id}
+    return {"error": "Session not found"}
+
+
+@router.delete("/user/{user_id}")
+async def revoke_user_sessions(
+    user_id: int,
+    _: None = Depends(require_debug),
+):
+    """Revoke all sessions for a user."""
+    sessions_to_revoke = [
+        s.session_id for s in active_sessions.values()
+        if s.user_id == user_id
+    ]
+
+    for session_id in sessions_to_revoke:
+        revoke_session(session_id)
+
+    return {
+        "status": "revoked",
+        "user_id": user_id,
+        "sessions_revoked": len(sessions_to_revoke),
+    }
+
+
+@router.delete("")
+async def clear_all_sessions(_: None = Depends(require_debug)):
+    """Clear all sessions (admin only)."""
+    count = len(active_sessions)
+    active_sessions.clear()
+    activity_log.clear()
+    return {"status": "cleared", "sessions_cleared": count}
+
+
+@router.post("/test")
+async def create_test_session(
+    _: None = Depends(require_debug),
+    username: str = "test_user",
+    user_id: int = 999,
+):
+    """Create a test session for debugging."""
+    import secrets
+    token = secrets.token_hex(32)
+
+    session = register_session(
+        user_id=user_id,
+        username=username,
+        token=token,
+        display_name=f"Test User {user_id}",
+        expires_minutes=30,
+    )
+
+    return {
+        "status": "created",
+        "session": session.model_dump(),
+    }

--- a/server/app/main.py
+++ b/server/app/main.py
@@ -23,6 +23,7 @@ from .api.buildinfo import router as buildinfo_router
 from .api.logs import router as logs_router
 from .api.errors import router as errors_router, capture_error
 from .api.profiler import router as profiler_router, ProfilingMiddleware
+from .api.sessions import router as sessions_router
 
 
 @asynccontextmanager
@@ -91,6 +92,7 @@ def create_app() -> FastAPI:
     app.include_router(logs_router, tags=["dev-tools"])
     app.include_router(errors_router, tags=["dev-tools"])
     app.include_router(profiler_router, tags=["dev-tools"])
+    app.include_router(sessions_router, tags=["dev-tools"])
 
     # Add exception handler to capture errors (only in debug mode)
     if settings.debug:

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,6 +1,6 @@
 import { Routes, Route } from 'react-router-dom';
 import { Layout } from './components/Layout';
-import { Home, Login, Register, Play, Features, About, PlayScene, SceneDemo, Leaderboard, Ghosts, Profile, Achievements, Spectate, Friends, Presentation, Roadmap, CodebaseHealth, Changelog, DatabaseExplorer, CacheInspector, AudioJukebox, SystemStatus, ApiPlayground, WebSocketMonitor, BuildInfo, LogViewer, ErrorTracker, PerformanceProfiler } from './pages';
+import { Home, Login, Register, Play, Features, About, PlayScene, SceneDemo, Leaderboard, Ghosts, Profile, Achievements, Spectate, Friends, Presentation, Roadmap, CodebaseHealth, Changelog, DatabaseExplorer, CacheInspector, AudioJukebox, SystemStatus, ApiPlayground, WebSocketMonitor, BuildInfo, LogViewer, ErrorTracker, PerformanceProfiler, SessionInspector } from './pages';
 import { FirstPersonDemo } from './pages/FirstPersonDemo';
 import { FirstPersonTestPage } from './pages/FirstPersonTestPage';
 import { Debug3DPage } from './pages/Debug3DPage';
@@ -43,6 +43,7 @@ function App() {
         <Route path="log-viewer" element={<LogViewer />} />
         <Route path="error-tracker" element={<ErrorTracker />} />
         <Route path="profiler" element={<PerformanceProfiler />} />
+        <Route path="session-inspector" element={<SessionInspector />} />
       </Route>
     </Routes>
   );

--- a/web/src/components/Layout.tsx
+++ b/web/src/components/Layout.tsx
@@ -164,6 +164,10 @@ export function Layout() {
                     <span className="menu-icon">⏱️</span>
                     Profiler
                   </Link>
+                  <Link to="/session-inspector" onClick={closeDropdown}>
+                    <span className="menu-icon">👤</span>
+                    Sessions
+                  </Link>
                   <Link to="/codebase-health" onClick={closeDropdown}>
                     <span className="menu-icon">🩺</span>
                     Codebase Health

--- a/web/src/pages/SessionInspector.css
+++ b/web/src/pages/SessionInspector.css
@@ -1,0 +1,551 @@
+/**
+ * Session Inspector Styles - User/Security theme
+ */
+
+.session-inspector {
+  min-height: 100vh;
+  background: #0d1117;
+  color: #e6edf3;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+}
+
+/* Loading State */
+.session-loading {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  min-height: 60vh;
+  gap: 1rem;
+}
+
+.loading-spinner {
+  width: 40px;
+  height: 40px;
+  border: 3px solid #21262d;
+  border-top-color: #a855f7;
+  border-radius: 50%;
+  animation: spin 1s linear infinite;
+}
+
+@keyframes spin {
+  to { transform: rotate(360deg); }
+}
+
+/* Header */
+.session-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 1rem 1.5rem;
+  background: #161b22;
+  border-bottom: 1px solid #30363d;
+}
+
+.session-header .header-left {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+}
+
+.session-header h1 {
+  margin: 0;
+  font-size: 1.25rem;
+  font-weight: 600;
+}
+
+.header-badge {
+  font-size: 0.75rem;
+  font-weight: 600;
+  padding: 0.25rem 0.75rem;
+  background: #a855f722;
+  color: #a855f7;
+  border-radius: 12px;
+}
+
+.header-right {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.test-btn {
+  padding: 0.5rem 1rem;
+  background: #21262d;
+  border: 1px solid #30363d;
+  border-radius: 6px;
+  color: #e6edf3;
+  cursor: pointer;
+  transition: all 0.15s;
+}
+
+.test-btn:hover {
+  background: #30363d;
+}
+
+.clear-btn {
+  padding: 0.5rem 1rem;
+  background: transparent;
+  border: 1px solid #f8514955;
+  border-radius: 6px;
+  color: #f85149;
+  cursor: pointer;
+  transition: all 0.15s;
+}
+
+.clear-btn:hover {
+  background: #f8514922;
+}
+
+/* Stats Row */
+.stats-row {
+  display: flex;
+  gap: 1rem;
+  padding: 1rem 1.5rem;
+  background: #161b22;
+  border-bottom: 1px solid #21262d;
+  overflow-x: auto;
+}
+
+.stat-card {
+  flex: 1;
+  min-width: 100px;
+  background: #0d1117;
+  border: 1px solid #30363d;
+  border-radius: 8px;
+  padding: 0.75rem 1rem;
+  text-align: center;
+}
+
+.stat-value {
+  font-size: 1.5rem;
+  font-weight: 700;
+  color: #e6edf3;
+}
+
+.stat-label {
+  font-size: 0.7rem;
+  color: #8b949e;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  margin-top: 0.25rem;
+}
+
+/* Device Breakdown */
+.stat-card.device-breakdown {
+  min-width: 140px;
+}
+
+.device-items {
+  display: flex;
+  justify-content: center;
+  gap: 1rem;
+}
+
+.device-item {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.25rem;
+}
+
+.device-icon {
+  font-size: 1.25rem;
+}
+
+.device-count {
+  font-size: 0.9rem;
+  font-weight: 600;
+  color: #e6edf3;
+}
+
+/* View Toggle */
+.view-toggle {
+  display: flex;
+  gap: 0;
+  padding: 0 1.5rem;
+  background: #161b22;
+  border-bottom: 1px solid #21262d;
+}
+
+.view-toggle button {
+  padding: 0.75rem 1.5rem;
+  background: transparent;
+  border: none;
+  border-bottom: 2px solid transparent;
+  color: #8b949e;
+  font-size: 0.9rem;
+  cursor: pointer;
+  transition: all 0.15s;
+}
+
+.view-toggle button:hover {
+  color: #e6edf3;
+}
+
+.view-toggle button.active {
+  color: #a855f7;
+  border-bottom-color: #a855f7;
+}
+
+/* No Data */
+.no-data {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  min-height: 300px;
+  color: #6b7280;
+}
+
+.no-data-icon {
+  font-size: 3rem;
+  margin-bottom: 1rem;
+}
+
+.no-data .hint {
+  font-size: 0.85rem;
+  color: #4b5563;
+}
+
+/* Sessions List */
+.sessions-list {
+  padding: 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.session-card {
+  background: #161b22;
+  border: 1px solid #30363d;
+  border-radius: 8px;
+  overflow: hidden;
+  transition: all 0.15s;
+}
+
+.session-card:hover {
+  border-color: #484f58;
+}
+
+.session-card.expanded {
+  border-color: #a855f7;
+}
+
+.session-header-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 1rem;
+  cursor: pointer;
+  transition: background 0.15s;
+}
+
+.session-header-row:hover {
+  background: #21262d;
+}
+
+.session-main {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.session-main .device-icon {
+  font-size: 1.5rem;
+}
+
+.session-info {
+  display: flex;
+  flex-direction: column;
+}
+
+.session-username {
+  font-weight: 600;
+  color: #e6edf3;
+}
+
+.session-meta {
+  font-size: 0.8rem;
+  color: #8b949e;
+}
+
+.session-stats {
+  display: flex;
+  align-items: center;
+  gap: 1.5rem;
+}
+
+.session-requests,
+.session-duration,
+.session-time {
+  font-size: 0.85rem;
+  color: #8b949e;
+}
+
+.session-requests {
+  background: #21262d;
+  padding: 0.2rem 0.5rem;
+  border-radius: 4px;
+}
+
+.expand-icon {
+  color: #6b7280;
+  font-size: 0.75rem;
+}
+
+/* Session Details */
+.session-details {
+  border-top: 1px solid #21262d;
+  padding: 1rem;
+  background: #0d1117;
+}
+
+.detail-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 0.75rem;
+  margin-bottom: 1rem;
+}
+
+.detail-item {
+  background: #161b22;
+  border: 1px solid #21262d;
+  border-radius: 6px;
+  padding: 0.75rem;
+}
+
+.detail-item.full-width {
+  grid-column: 1 / -1;
+}
+
+.detail-label {
+  display: block;
+  font-size: 0.7rem;
+  font-weight: 600;
+  color: #8b949e;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  margin-bottom: 0.25rem;
+}
+
+.detail-value {
+  font-size: 0.85rem;
+  color: #e6edf3;
+  word-break: break-all;
+}
+
+.detail-value.small {
+  font-size: 0.75rem;
+}
+
+code.detail-value {
+  font-family: 'JetBrains Mono', monospace;
+  background: #21262d;
+  padding: 0.15rem 0.4rem;
+  border-radius: 3px;
+}
+
+.status-badge {
+  display: inline-block;
+  padding: 0.15rem 0.5rem;
+  border-radius: 4px;
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+}
+
+.status-active {
+  background: #22c55e22;
+  color: #22c55e;
+}
+
+.status-expired {
+  background: #d2992222;
+  color: #d29922;
+}
+
+.status-revoked {
+  background: #f8514922;
+  color: #f85149;
+}
+
+.session-actions {
+  padding-top: 0.75rem;
+  border-top: 1px solid #21262d;
+}
+
+.revoke-btn {
+  padding: 0.5rem 1rem;
+  background: #f8514922;
+  border: 1px solid #f8514955;
+  border-radius: 6px;
+  color: #f85149;
+  cursor: pointer;
+  transition: all 0.15s;
+}
+
+.revoke-btn:hover {
+  background: #f8514933;
+}
+
+/* Users Table */
+.users-list {
+  padding: 1.5rem;
+}
+
+.users-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.9rem;
+}
+
+.users-table th {
+  padding: 0.75rem 1rem;
+  text-align: left;
+  background: #161b22;
+  color: #8b949e;
+  font-weight: 600;
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  border-bottom: 1px solid #21262d;
+}
+
+.users-table td {
+  padding: 0.75rem 1rem;
+  border-bottom: 1px solid #21262d;
+}
+
+.users-table tr:hover {
+  background: #161b22;
+}
+
+.col-user {
+  display: flex;
+  flex-direction: column;
+}
+
+.user-name {
+  font-weight: 600;
+  color: #e6edf3;
+}
+
+.user-username {
+  font-size: 0.8rem;
+  color: #8b949e;
+}
+
+.sessions-count {
+  display: inline-block;
+  padding: 0.15rem 0.5rem;
+  background: #21262d;
+  border-radius: 10px;
+  font-size: 0.85rem;
+}
+
+.sessions-count.has-sessions {
+  background: #a855f722;
+  color: #a855f7;
+}
+
+.col-date {
+  color: #8b949e;
+  font-size: 0.85rem;
+}
+
+/* Activity Timeline */
+.activity-list {
+  padding: 1.5rem;
+}
+
+.activity-timeline {
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+}
+
+.activity-item {
+  display: flex;
+  gap: 1rem;
+  padding: 0.75rem 0;
+  border-bottom: 1px solid #21262d;
+}
+
+.activity-dot {
+  flex-shrink: 0;
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  margin-top: 0.35rem;
+}
+
+.activity-content {
+  flex: 1;
+}
+
+.activity-header {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  margin-bottom: 0.25rem;
+}
+
+.activity-event {
+  font-size: 0.7rem;
+  font-weight: 700;
+  letter-spacing: 0.5px;
+}
+
+.activity-user {
+  font-weight: 600;
+  color: #e6edf3;
+}
+
+.activity-time {
+  font-size: 0.8rem;
+  color: #6b7280;
+  margin-left: auto;
+}
+
+.activity-details {
+  display: flex;
+  gap: 1rem;
+  font-size: 0.8rem;
+  color: #8b949e;
+}
+
+.activity-ip {
+  font-family: 'JetBrains Mono', monospace;
+}
+
+/* Responsive */
+@media (max-width: 768px) {
+  .stats-row {
+    flex-wrap: nowrap;
+    overflow-x: auto;
+  }
+
+  .session-header-row {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 0.75rem;
+  }
+
+  .session-stats {
+    flex-wrap: wrap;
+    gap: 0.75rem;
+  }
+
+  .detail-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .users-table {
+    font-size: 0.8rem;
+  }
+
+  .users-table th,
+  .users-table td {
+    padding: 0.5rem;
+  }
+}

--- a/web/src/pages/SessionInspector.tsx
+++ b/web/src/pages/SessionInspector.tsx
@@ -1,0 +1,510 @@
+/**
+ * Session Inspector - View and manage user sessions
+ *
+ * Features:
+ * - View all active sessions
+ * - Session details (IP, device, browser, OS)
+ * - Session activity log
+ * - Revoke individual sessions
+ * - Session statistics
+ */
+
+import { useState, useEffect, useCallback } from 'react';
+import './SessionInspector.css';
+
+const API_BASE = 'http://localhost:8000/api/sessions';
+
+interface SessionInfo {
+  session_id: string;
+  user_id: number;
+  username: string;
+  display_name?: string;
+  created_at: string;
+  last_activity: string;
+  expires_at: string;
+  ip_address?: string;
+  user_agent?: string;
+  device_type: string;
+  browser: string;
+  os: string;
+  status: string;
+  request_count: number;
+}
+
+interface SessionActivity {
+  timestamp: string;
+  session_id: string;
+  user_id: number;
+  username: string;
+  event: string;
+  ip_address?: string;
+  details?: string;
+}
+
+interface SessionStats {
+  total_active: number;
+  total_today: number;
+  unique_users: number;
+  by_device: Record<string, number>;
+  by_browser: Record<string, number>;
+  avg_session_duration_minutes: number;
+}
+
+interface UserWithSessions {
+  id: number;
+  username: string;
+  display_name?: string;
+  last_login?: string;
+  created_at?: string;
+  active_sessions: number;
+  sessions: SessionInfo[];
+}
+
+const DEVICE_ICONS: Record<string, string> = {
+  desktop: '🖥️',
+  mobile: '📱',
+  tablet: '📱',
+  unknown: '❓',
+};
+
+const EVENT_COLORS: Record<string, string> = {
+  login: '#22c55e',
+  logout: '#8b949e',
+  expired: '#d29922',
+  revoked: '#f85149',
+};
+
+export function SessionInspector() {
+  const [sessions, setSessions] = useState<SessionInfo[]>([]);
+  const [activities, setActivities] = useState<SessionActivity[]>([]);
+  const [stats, setStats] = useState<SessionStats | null>(null);
+  const [users, setUsers] = useState<UserWithSessions[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  // View mode
+  const [view, setView] = useState<'sessions' | 'users' | 'activity'>('sessions');
+
+  // Expanded session
+  const [expandedSession, setExpandedSession] = useState<string | null>(null);
+
+  // Fetch sessions
+  const fetchSessions = useCallback(async () => {
+    try {
+      const res = await fetch(`${API_BASE}`);
+      if (res.ok) {
+        const data = await res.json();
+        setSessions(data.sessions);
+      }
+    } catch {
+      // Silently fail
+    }
+  }, []);
+
+  // Fetch stats
+  const fetchStats = useCallback(async () => {
+    try {
+      const res = await fetch(`${API_BASE}/stats`);
+      if (res.ok) {
+        const data = await res.json();
+        setStats(data);
+      }
+    } catch {
+      // Silently fail
+    }
+  }, []);
+
+  // Fetch activities
+  const fetchActivities = useCallback(async () => {
+    try {
+      const res = await fetch(`${API_BASE}/activity?limit=50`);
+      if (res.ok) {
+        const data = await res.json();
+        setActivities(data.activities);
+      }
+    } catch {
+      // Silently fail
+    }
+  }, []);
+
+  // Fetch users with sessions
+  const fetchUsers = useCallback(async () => {
+    try {
+      const res = await fetch(`${API_BASE}/users`);
+      if (res.ok) {
+        const data = await res.json();
+        setUsers(data.users);
+      }
+    } catch {
+      // Silently fail
+    }
+  }, []);
+
+  // Initial fetch
+  useEffect(() => {
+    const loadData = async () => {
+      setLoading(true);
+      await Promise.all([fetchSessions(), fetchStats(), fetchActivities(), fetchUsers()]);
+      setLoading(false);
+    };
+    loadData();
+
+    // Auto-refresh every 10 seconds
+    const interval = setInterval(() => {
+      fetchSessions();
+      fetchStats();
+      fetchActivities();
+    }, 10000);
+
+    return () => clearInterval(interval);
+  }, [fetchSessions, fetchStats, fetchActivities, fetchUsers]);
+
+  // Revoke session
+  const revokeSession = async (sessionId: string) => {
+    try {
+      await fetch(`${API_BASE}/${sessionId}`, { method: 'DELETE' });
+      fetchSessions();
+      fetchStats();
+      fetchActivities();
+    } catch {
+      // Silently fail
+    }
+  };
+
+  // Create test session
+  const createTestSession = async () => {
+    try {
+      await fetch(`${API_BASE}/test`, { method: 'POST' });
+      fetchSessions();
+      fetchStats();
+      fetchActivities();
+    } catch {
+      // Silently fail
+    }
+  };
+
+  // Clear all sessions
+  const clearSessions = async () => {
+    try {
+      await fetch(API_BASE, { method: 'DELETE' });
+      setSessions([]);
+      fetchStats();
+      setActivities([]);
+    } catch {
+      // Silently fail
+    }
+  };
+
+  // Format time
+  const formatTime = (timestamp: string) => {
+    try {
+      const date = new Date(timestamp);
+      return date.toLocaleString();
+    } catch {
+      return timestamp;
+    }
+  };
+
+  // Format relative time
+  const formatRelativeTime = (timestamp: string) => {
+    try {
+      const date = new Date(timestamp);
+      const now = new Date();
+      const diff = now.getTime() - date.getTime();
+      const minutes = Math.floor(diff / 60000);
+      const hours = Math.floor(minutes / 60);
+      const days = Math.floor(hours / 24);
+
+      if (days > 0) return `${days}d ago`;
+      if (hours > 0) return `${hours}h ago`;
+      if (minutes > 0) return `${minutes}m ago`;
+      return 'just now';
+    } catch {
+      return '';
+    }
+  };
+
+  // Calculate session duration
+  const getSessionDuration = (session: SessionInfo) => {
+    try {
+      const created = new Date(session.created_at);
+      const last = new Date(session.last_activity);
+      const diff = last.getTime() - created.getTime();
+      const minutes = Math.floor(diff / 60000);
+      const hours = Math.floor(minutes / 60);
+
+      if (hours > 0) return `${hours}h ${minutes % 60}m`;
+      return `${minutes}m`;
+    } catch {
+      return '-';
+    }
+  };
+
+  if (loading) {
+    return (
+      <div className="session-inspector">
+        <div className="session-loading">
+          <div className="loading-spinner" />
+          <p>Loading session data...</p>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="session-inspector">
+      {/* Header */}
+      <header className="session-header">
+        <div className="header-left">
+          <h1>Session Inspector</h1>
+          <span className="header-badge">
+            {stats?.total_active || 0} active
+          </span>
+        </div>
+        <div className="header-right">
+          <button onClick={createTestSession} className="test-btn">
+            + Test Session
+          </button>
+          <button onClick={clearSessions} className="clear-btn">
+            Clear All
+          </button>
+        </div>
+      </header>
+
+      {/* Stats Cards */}
+      {stats && (
+        <div className="stats-row">
+          <div className="stat-card">
+            <div className="stat-value">{stats.total_active}</div>
+            <div className="stat-label">Active Sessions</div>
+          </div>
+          <div className="stat-card">
+            <div className="stat-value">{stats.unique_users}</div>
+            <div className="stat-label">Unique Users</div>
+          </div>
+          <div className="stat-card">
+            <div className="stat-value">{stats.total_today}</div>
+            <div className="stat-label">Logins Today</div>
+          </div>
+          <div className="stat-card">
+            <div className="stat-value">{stats.avg_session_duration_minutes.toFixed(0)}m</div>
+            <div className="stat-label">Avg Duration</div>
+          </div>
+          <div className="stat-card device-breakdown">
+            <div className="device-items">
+              {Object.entries(stats.by_device).map(([device, count]) => (
+                <div key={device} className="device-item">
+                  <span className="device-icon">{DEVICE_ICONS[device] || '❓'}</span>
+                  <span className="device-count">{count}</span>
+                </div>
+              ))}
+            </div>
+            <div className="stat-label">By Device</div>
+          </div>
+        </div>
+      )}
+
+      {/* View Toggle */}
+      <div className="view-toggle">
+        <button
+          className={view === 'sessions' ? 'active' : ''}
+          onClick={() => setView('sessions')}
+        >
+          Active Sessions
+        </button>
+        <button
+          className={view === 'users' ? 'active' : ''}
+          onClick={() => setView('users')}
+        >
+          Users
+        </button>
+        <button
+          className={view === 'activity' ? 'active' : ''}
+          onClick={() => setView('activity')}
+        >
+          Activity Log
+        </button>
+      </div>
+
+      {/* Sessions View */}
+      {view === 'sessions' && (
+        <div className="sessions-list">
+          {sessions.length === 0 ? (
+            <div className="no-data">
+              <div className="no-data-icon">👤</div>
+              <p>No active sessions</p>
+              <p className="hint">Sessions appear when users log in</p>
+            </div>
+          ) : (
+            sessions.map((session) => (
+              <div
+                key={session.session_id}
+                className={`session-card ${expandedSession === session.session_id ? 'expanded' : ''}`}
+              >
+                <div
+                  className="session-header-row"
+                  onClick={() => setExpandedSession(
+                    expandedSession === session.session_id ? null : session.session_id
+                  )}
+                >
+                  <div className="session-main">
+                    <span className="device-icon">{DEVICE_ICONS[session.device_type]}</span>
+                    <div className="session-info">
+                      <span className="session-username">{session.display_name || session.username}</span>
+                      <span className="session-meta">
+                        {session.browser} on {session.os}
+                      </span>
+                    </div>
+                  </div>
+                  <div className="session-stats">
+                    <span className="session-requests">{session.request_count} requests</span>
+                    <span className="session-duration">{getSessionDuration(session)}</span>
+                    <span className="session-time" title={formatTime(session.last_activity)}>
+                      {formatRelativeTime(session.last_activity)}
+                    </span>
+                    <span className="expand-icon">
+                      {expandedSession === session.session_id ? '▼' : '▶'}
+                    </span>
+                  </div>
+                </div>
+
+                {expandedSession === session.session_id && (
+                  <div className="session-details">
+                    <div className="detail-grid">
+                      <div className="detail-item">
+                        <span className="detail-label">Session ID</span>
+                        <code className="detail-value">{session.session_id}</code>
+                      </div>
+                      <div className="detail-item">
+                        <span className="detail-label">User ID</span>
+                        <span className="detail-value">{session.user_id}</span>
+                      </div>
+                      <div className="detail-item">
+                        <span className="detail-label">IP Address</span>
+                        <span className="detail-value">{session.ip_address || 'Unknown'}</span>
+                      </div>
+                      <div className="detail-item">
+                        <span className="detail-label">Status</span>
+                        <span className={`status-badge status-${session.status}`}>
+                          {session.status}
+                        </span>
+                      </div>
+                      <div className="detail-item">
+                        <span className="detail-label">Created</span>
+                        <span className="detail-value">{formatTime(session.created_at)}</span>
+                      </div>
+                      <div className="detail-item">
+                        <span className="detail-label">Expires</span>
+                        <span className="detail-value">{formatTime(session.expires_at)}</span>
+                      </div>
+                      <div className="detail-item full-width">
+                        <span className="detail-label">User Agent</span>
+                        <span className="detail-value small">{session.user_agent || 'Unknown'}</span>
+                      </div>
+                    </div>
+                    <div className="session-actions">
+                      <button
+                        onClick={() => revokeSession(session.session_id)}
+                        className="revoke-btn"
+                      >
+                        Revoke Session
+                      </button>
+                    </div>
+                  </div>
+                )}
+              </div>
+            ))
+          )}
+        </div>
+      )}
+
+      {/* Users View */}
+      {view === 'users' && (
+        <div className="users-list">
+          {users.length === 0 ? (
+            <div className="no-data">
+              <p>No users with recent activity</p>
+            </div>
+          ) : (
+            <table className="users-table">
+              <thead>
+                <tr>
+                  <th>User</th>
+                  <th>Last Login</th>
+                  <th>Active Sessions</th>
+                  <th>Member Since</th>
+                </tr>
+              </thead>
+              <tbody>
+                {users.map((user) => (
+                  <tr key={user.id}>
+                    <td className="col-user">
+                      <span className="user-name">{user.display_name || user.username}</span>
+                      <span className="user-username">@{user.username}</span>
+                    </td>
+                    <td>
+                      {user.last_login ? formatRelativeTime(user.last_login) : 'Never'}
+                    </td>
+                    <td>
+                      <span className={`sessions-count ${user.active_sessions > 0 ? 'has-sessions' : ''}`}>
+                        {user.active_sessions}
+                      </span>
+                    </td>
+                    <td className="col-date">
+                      {user.created_at ? formatTime(user.created_at).split(',')[0] : '-'}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          )}
+        </div>
+      )}
+
+      {/* Activity View */}
+      {view === 'activity' && (
+        <div className="activity-list">
+          {activities.length === 0 ? (
+            <div className="no-data">
+              <p>No activity recorded</p>
+            </div>
+          ) : (
+            <div className="activity-timeline">
+              {activities.map((activity, i) => (
+                <div key={i} className="activity-item">
+                  <div
+                    className="activity-dot"
+                    style={{ background: EVENT_COLORS[activity.event] || '#8b949e' }}
+                  />
+                  <div className="activity-content">
+                    <div className="activity-header">
+                      <span
+                        className="activity-event"
+                        style={{ color: EVENT_COLORS[activity.event] || '#8b949e' }}
+                      >
+                        {activity.event.toUpperCase()}
+                      </span>
+                      <span className="activity-user">{activity.username}</span>
+                      <span className="activity-time">
+                        {formatRelativeTime(activity.timestamp)}
+                      </span>
+                    </div>
+                    <div className="activity-details">
+                      {activity.ip_address && (
+                        <span className="activity-ip">IP: {activity.ip_address}</span>
+                      )}
+                      {activity.details && (
+                        <span className="activity-detail">{activity.details}</span>
+                      )}
+                    </div>
+                  </div>
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default SessionInspector;

--- a/web/src/pages/index.ts
+++ b/web/src/pages/index.ts
@@ -26,3 +26,4 @@ export { BuildInfo } from './BuildInfo';
 export { LogViewer } from './LogViewer';
 export { ErrorTracker } from './ErrorTracker';
 export { PerformanceProfiler } from './PerformanceProfiler';
+export { SessionInspector } from './SessionInspector';


### PR DESCRIPTION
## Summary
- Backend API for tracking user sessions with in-memory store
- User agent parsing for device/browser/OS detection
- Activity timeline with login/logout/expired/revoked events
- Frontend with three views: Active Sessions, Users, Activity Log
- Session statistics (active count, unique users, device breakdown)
- Test session creation and session revoke functionality

## Test plan
- [ ] Navigate to Dev Tools > Sessions
- [ ] Click "Test Session" to create test sessions
- [ ] Verify session cards show device icons, browser, OS info
- [ ] Expand session to see full details (IP, user agent, timestamps)
- [ ] Test revoke session functionality
- [ ] Switch between Sessions, Users, Activity views
- [ ] Verify stats row updates correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)