### PR TITLE
feat(dev-tools): add Feature Flags dashboard

### DIFF
--- a/server/app/api/flags.py
+++ b/server/app/api/flags.py
@@ -1,0 +1,491 @@
+"""
+Feature Flags API - Manage feature toggles for the application.
+
+Features:
+- Boolean flags (on/off)
+- Percentage rollout (0-100%)
+- User targeting (specific user IDs)
+- Environment scoping (dev, staging, prod)
+- Flag history tracking
+"""
+
+import hashlib
+from datetime import datetime
+from collections import deque
+from typing import Optional
+from enum import Enum
+
+from fastapi import APIRouter, Depends, Query
+from pydantic import BaseModel, Field
+
+from ..api.dbexplorer import require_debug
+
+router = APIRouter(prefix="/api/flags", tags=["feature-flags"])
+
+# In-memory flag store
+feature_flags: dict[str, "FeatureFlag"] = {}
+
+# Flag change history
+MAX_HISTORY = 100
+flag_history: deque = deque(maxlen=MAX_HISTORY)
+
+
+class FlagType(str, Enum):
+    BOOLEAN = "boolean"
+    PERCENTAGE = "percentage"
+    USER_LIST = "user_list"
+
+
+class FlagEnvironment(str, Enum):
+    ALL = "all"
+    DEV = "dev"
+    STAGING = "staging"
+    PROD = "prod"
+
+
+class FeatureFlag(BaseModel):
+    """A feature flag definition."""
+    key: str = Field(..., min_length=1, max_length=100)
+    name: str = Field(..., min_length=1, max_length=200)
+    description: str = ""
+    flag_type: FlagType = FlagType.BOOLEAN
+    enabled: bool = False
+    percentage: int = Field(default=0, ge=0, le=100)
+    user_ids: list[int] = []
+    environment: FlagEnvironment = FlagEnvironment.ALL
+    created_at: str = ""
+    updated_at: str = ""
+    created_by: str = "system"
+    tags: list[str] = []
+
+
+class FlagChange(BaseModel):
+    """A flag change event."""
+    timestamp: str
+    flag_key: str
+    action: str  # created, updated, deleted, toggled
+    field: Optional[str] = None
+    old_value: Optional[str] = None
+    new_value: Optional[str] = None
+    changed_by: str = "system"
+
+
+class CreateFlagRequest(BaseModel):
+    """Request to create a new flag."""
+    key: str = Field(..., min_length=1, max_length=100)
+    name: str = Field(..., min_length=1, max_length=200)
+    description: str = ""
+    flag_type: FlagType = FlagType.BOOLEAN
+    enabled: bool = False
+    percentage: int = Field(default=0, ge=0, le=100)
+    user_ids: list[int] = []
+    environment: FlagEnvironment = FlagEnvironment.ALL
+    tags: list[str] = []
+
+
+class UpdateFlagRequest(BaseModel):
+    """Request to update a flag."""
+    name: Optional[str] = None
+    description: Optional[str] = None
+    flag_type: Optional[FlagType] = None
+    enabled: Optional[bool] = None
+    percentage: Optional[int] = Field(default=None, ge=0, le=100)
+    user_ids: Optional[list[int]] = None
+    environment: Optional[FlagEnvironment] = None
+    tags: Optional[list[str]] = None
+
+
+def log_change(
+    flag_key: str,
+    action: str,
+    field: Optional[str] = None,
+    old_value: Optional[str] = None,
+    new_value: Optional[str] = None,
+    changed_by: str = "system",
+):
+    """Log a flag change."""
+    change = FlagChange(
+        timestamp=datetime.utcnow().isoformat() + "Z",
+        flag_key=flag_key,
+        action=action,
+        field=field,
+        old_value=old_value,
+        new_value=new_value,
+        changed_by=changed_by,
+    )
+    flag_history.append(change)
+
+
+def evaluate_flag(flag: FeatureFlag, user_id: Optional[int] = None) -> bool:
+    """Evaluate if a flag is enabled for a given context."""
+    if not flag.enabled:
+        return False
+
+    if flag.flag_type == FlagType.BOOLEAN:
+        return True
+
+    if flag.flag_type == FlagType.USER_LIST:
+        return user_id in flag.user_ids if user_id else False
+
+    if flag.flag_type == FlagType.PERCENTAGE:
+        if user_id is None:
+            return False
+        # Deterministic hash-based rollout
+        hash_input = f"{flag.key}:{user_id}"
+        hash_value = int(hashlib.md5(hash_input.encode()).hexdigest(), 16)
+        bucket = hash_value % 100
+        return bucket < flag.percentage
+
+    return False
+
+
+def seed_default_flags():
+    """Seed some default feature flags for demo purposes."""
+    defaults = [
+        {
+            "key": "dark_mode",
+            "name": "Dark Mode",
+            "description": "Enable dark mode UI theme",
+            "flag_type": FlagType.BOOLEAN,
+            "enabled": True,
+            "tags": ["ui", "theme"],
+        },
+        {
+            "key": "new_combat_system",
+            "name": "New Combat System",
+            "description": "Beta combat mechanics with combo attacks",
+            "flag_type": FlagType.PERCENTAGE,
+            "enabled": True,
+            "percentage": 25,
+            "tags": ["gameplay", "beta"],
+        },
+        {
+            "key": "vip_features",
+            "name": "VIP Features",
+            "description": "Premium features for VIP users",
+            "flag_type": FlagType.USER_LIST,
+            "enabled": True,
+            "user_ids": [1, 2, 3],
+            "tags": ["premium"],
+        },
+        {
+            "key": "achievement_v2",
+            "name": "Achievement System V2",
+            "description": "Redesigned achievement tracking and display",
+            "flag_type": FlagType.BOOLEAN,
+            "enabled": False,
+            "tags": ["achievements", "v2"],
+        },
+        {
+            "key": "multiplayer_beta",
+            "name": "Multiplayer Beta",
+            "description": "Real-time multiplayer dungeon crawling",
+            "flag_type": FlagType.PERCENTAGE,
+            "enabled": True,
+            "percentage": 10,
+            "environment": FlagEnvironment.DEV,
+            "tags": ["multiplayer", "beta"],
+        },
+        {
+            "key": "debug_overlay",
+            "name": "Debug Overlay",
+            "description": "Show FPS and performance metrics in-game",
+            "flag_type": FlagType.BOOLEAN,
+            "enabled": True,
+            "environment": FlagEnvironment.DEV,
+            "tags": ["debug", "dev"],
+        },
+    ]
+
+    now = datetime.utcnow().isoformat() + "Z"
+    for flag_data in defaults:
+        if flag_data["key"] not in feature_flags:
+            flag = FeatureFlag(
+                **flag_data,
+                created_at=now,
+                updated_at=now,
+            )
+            feature_flags[flag.key] = flag
+
+
+# Seed defaults on module load
+seed_default_flags()
+
+
+@router.get("")
+async def get_flags(
+    _: None = Depends(require_debug),
+    enabled: Optional[bool] = None,
+    flag_type: Optional[FlagType] = None,
+    environment: Optional[FlagEnvironment] = None,
+    tag: Optional[str] = None,
+    search: Optional[str] = None,
+):
+    """Get all feature flags with optional filtering."""
+    flags = list(feature_flags.values())
+
+    if enabled is not None:
+        flags = [f for f in flags if f.enabled == enabled]
+
+    if flag_type:
+        flags = [f for f in flags if f.flag_type == flag_type]
+
+    if environment:
+        flags = [f for f in flags if f.environment == environment or f.environment == FlagEnvironment.ALL]
+
+    if tag:
+        flags = [f for f in flags if tag in f.tags]
+
+    if search:
+        search_lower = search.lower()
+        flags = [f for f in flags if search_lower in f.key.lower() or search_lower in f.name.lower()]
+
+    # Sort by name
+    flags.sort(key=lambda f: f.name.lower())
+
+    return {
+        "flags": [f.model_dump() for f in flags],
+        "total": len(flags),
+        "enabled_count": sum(1 for f in flags if f.enabled),
+    }
+
+
+@router.get("/stats")
+async def get_flag_stats(_: None = Depends(require_debug)):
+    """Get feature flag statistics."""
+    flags = list(feature_flags.values())
+
+    by_type = {}
+    by_environment = {}
+    by_tag = {}
+
+    for flag in flags:
+        # By type
+        type_key = flag.flag_type.value
+        by_type[type_key] = by_type.get(type_key, 0) + 1
+
+        # By environment
+        env_key = flag.environment.value
+        by_environment[env_key] = by_environment.get(env_key, 0) + 1
+
+        # By tag
+        for tag in flag.tags:
+            by_tag[tag] = by_tag.get(tag, 0) + 1
+
+    return {
+        "total": len(flags),
+        "enabled": sum(1 for f in flags if f.enabled),
+        "disabled": sum(1 for f in flags if not f.enabled),
+        "by_type": by_type,
+        "by_environment": by_environment,
+        "by_tag": by_tag,
+    }
+
+
+@router.get("/history")
+async def get_flag_history(
+    _: None = Depends(require_debug),
+    flag_key: Optional[str] = None,
+    action: Optional[str] = None,
+    limit: int = Query(50, ge=1, le=200),
+):
+    """Get flag change history."""
+    history = list(flag_history)
+
+    if flag_key:
+        history = [h for h in history if h.flag_key == flag_key]
+
+    if action:
+        history = [h for h in history if h.action == action]
+
+    # Reverse to show newest first
+    history = list(reversed(history))
+
+    return {
+        "history": [h.model_dump() for h in history[:limit]],
+        "total": len(history),
+    }
+
+
+@router.get("/evaluate/{flag_key}")
+async def evaluate_flag_endpoint(
+    flag_key: str,
+    user_id: Optional[int] = None,
+    _: None = Depends(require_debug),
+):
+    """Evaluate if a flag is enabled for a given user."""
+    if flag_key not in feature_flags:
+        return {"error": "Flag not found", "enabled": False}
+
+    flag = feature_flags[flag_key]
+    is_enabled = evaluate_flag(flag, user_id)
+
+    return {
+        "flag_key": flag_key,
+        "enabled": is_enabled,
+        "flag_type": flag.flag_type.value,
+        "user_id": user_id,
+    }
+
+
+@router.get("/{flag_key}")
+async def get_flag(
+    flag_key: str,
+    _: None = Depends(require_debug),
+):
+    """Get a specific feature flag."""
+    if flag_key not in feature_flags:
+        return {"error": "Flag not found"}
+
+    flag = feature_flags[flag_key]
+
+    # Get history for this flag
+    history = [h.model_dump() for h in flag_history if h.flag_key == flag_key]
+
+    return {
+        "flag": flag.model_dump(),
+        "history": list(reversed(history))[-10:],
+    }
+
+
+@router.post("")
+async def create_flag(
+    request: CreateFlagRequest,
+    _: None = Depends(require_debug),
+):
+    """Create a new feature flag."""
+    if request.key in feature_flags:
+        return {"error": "Flag with this key already exists"}
+
+    now = datetime.utcnow().isoformat() + "Z"
+
+    flag = FeatureFlag(
+        key=request.key,
+        name=request.name,
+        description=request.description,
+        flag_type=request.flag_type,
+        enabled=request.enabled,
+        percentage=request.percentage,
+        user_ids=request.user_ids,
+        environment=request.environment,
+        tags=request.tags,
+        created_at=now,
+        updated_at=now,
+    )
+
+    feature_flags[flag.key] = flag
+    log_change(flag.key, "created", new_value=f"Flag '{flag.name}' created")
+
+    return {
+        "status": "created",
+        "flag": flag.model_dump(),
+    }
+
+
+@router.put("/{flag_key}")
+async def update_flag(
+    flag_key: str,
+    request: UpdateFlagRequest,
+    _: None = Depends(require_debug),
+):
+    """Update a feature flag."""
+    if flag_key not in feature_flags:
+        return {"error": "Flag not found"}
+
+    flag = feature_flags[flag_key]
+    now = datetime.utcnow().isoformat() + "Z"
+
+    # Track changes
+    if request.name is not None and request.name != flag.name:
+        log_change(flag_key, "updated", "name", flag.name, request.name)
+        flag.name = request.name
+
+    if request.description is not None and request.description != flag.description:
+        log_change(flag_key, "updated", "description", flag.description, request.description)
+        flag.description = request.description
+
+    if request.flag_type is not None and request.flag_type != flag.flag_type:
+        log_change(flag_key, "updated", "flag_type", flag.flag_type.value, request.flag_type.value)
+        flag.flag_type = request.flag_type
+
+    if request.enabled is not None and request.enabled != flag.enabled:
+        log_change(flag_key, "toggled", "enabled", str(flag.enabled), str(request.enabled))
+        flag.enabled = request.enabled
+
+    if request.percentage is not None and request.percentage != flag.percentage:
+        log_change(flag_key, "updated", "percentage", str(flag.percentage), str(request.percentage))
+        flag.percentage = request.percentage
+
+    if request.user_ids is not None and request.user_ids != flag.user_ids:
+        log_change(flag_key, "updated", "user_ids", str(flag.user_ids), str(request.user_ids))
+        flag.user_ids = request.user_ids
+
+    if request.environment is not None and request.environment != flag.environment:
+        log_change(flag_key, "updated", "environment", flag.environment.value, request.environment.value)
+        flag.environment = request.environment
+
+    if request.tags is not None and request.tags != flag.tags:
+        log_change(flag_key, "updated", "tags", str(flag.tags), str(request.tags))
+        flag.tags = request.tags
+
+    flag.updated_at = now
+
+    return {
+        "status": "updated",
+        "flag": flag.model_dump(),
+    }
+
+
+@router.post("/{flag_key}/toggle")
+async def toggle_flag(
+    flag_key: str,
+    _: None = Depends(require_debug),
+):
+    """Toggle a flag on/off."""
+    if flag_key not in feature_flags:
+        return {"error": "Flag not found"}
+
+    flag = feature_flags[flag_key]
+    old_value = flag.enabled
+    flag.enabled = not flag.enabled
+    flag.updated_at = datetime.utcnow().isoformat() + "Z"
+
+    log_change(flag_key, "toggled", "enabled", str(old_value), str(flag.enabled))
+
+    return {
+        "status": "toggled",
+        "flag_key": flag_key,
+        "enabled": flag.enabled,
+    }
+
+
+@router.delete("/{flag_key}")
+async def delete_flag(
+    flag_key: str,
+    _: None = Depends(require_debug),
+):
+    """Delete a feature flag."""
+    if flag_key not in feature_flags:
+        return {"error": "Flag not found"}
+
+    flag = feature_flags[flag_key]
+    log_change(flag_key, "deleted", new_value=f"Flag '{flag.name}' deleted")
+    del feature_flags[flag_key]
+
+    return {
+        "status": "deleted",
+        "flag_key": flag_key,
+    }
+
+
+@router.delete("")
+async def reset_flags(_: None = Depends(require_debug)):
+    """Reset all flags to defaults."""
+    feature_flags.clear()
+    flag_history.clear()
+    seed_default_flags()
+
+    return {
+        "status": "reset",
+        "flags_count": len(feature_flags),
+    }

--- a/server/app/main.py
+++ b/server/app/main.py
@@ -24,6 +24,7 @@ from .api.logs import router as logs_router
 from .api.errors import router as errors_router, capture_error
 from .api.profiler import router as profiler_router, ProfilingMiddleware
 from .api.sessions import router as sessions_router
+from .api.flags import router as flags_router
 
 
 @asynccontextmanager
@@ -93,6 +94,7 @@ def create_app() -> FastAPI:
     app.include_router(errors_router, tags=["dev-tools"])
     app.include_router(profiler_router, tags=["dev-tools"])
     app.include_router(sessions_router, tags=["dev-tools"])
+    app.include_router(flags_router, tags=["dev-tools"])
 
     # Add exception handler to capture errors (only in debug mode)
     if settings.debug:

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,6 +1,6 @@
 import { Routes, Route } from 'react-router-dom';
 import { Layout } from './components/Layout';
-import { Home, Login, Register, Play, Features, About, PlayScene, SceneDemo, Leaderboard, Ghosts, Profile, Achievements, Spectate, Friends, Presentation, Roadmap, CodebaseHealth, Changelog, DatabaseExplorer, CacheInspector, AudioJukebox, SystemStatus, ApiPlayground, WebSocketMonitor, BuildInfo, LogViewer, ErrorTracker, PerformanceProfiler, SessionInspector } from './pages';
+import { Home, Login, Register, Play, Features, About, PlayScene, SceneDemo, Leaderboard, Ghosts, Profile, Achievements, Spectate, Friends, Presentation, Roadmap, CodebaseHealth, Changelog, DatabaseExplorer, CacheInspector, AudioJukebox, SystemStatus, ApiPlayground, WebSocketMonitor, BuildInfo, LogViewer, ErrorTracker, PerformanceProfiler, SessionInspector, FeatureFlags } from './pages';
 import { FirstPersonDemo } from './pages/FirstPersonDemo';
 import { FirstPersonTestPage } from './pages/FirstPersonTestPage';
 import { Debug3DPage } from './pages/Debug3DPage';
@@ -44,6 +44,7 @@ function App() {
         <Route path="error-tracker" element={<ErrorTracker />} />
         <Route path="profiler" element={<PerformanceProfiler />} />
         <Route path="session-inspector" element={<SessionInspector />} />
+        <Route path="feature-flags" element={<FeatureFlags />} />
       </Route>
     </Routes>
   );

--- a/web/src/components/Layout.tsx
+++ b/web/src/components/Layout.tsx
@@ -168,6 +168,10 @@ export function Layout() {
                     <span className="menu-icon">👤</span>
                     Sessions
                   </Link>
+                  <Link to="/feature-flags" onClick={closeDropdown}>
+                    <span className="menu-icon">🚩</span>
+                    Feature Flags
+                  </Link>
                   <Link to="/codebase-health" onClick={closeDropdown}>
                     <span className="menu-icon">🩺</span>
                     Codebase Health

--- a/web/src/pages/FeatureFlags.css
+++ b/web/src/pages/FeatureFlags.css
@@ -1,0 +1,843 @@
+/**
+ * Feature Flags Styles - Green/toggle theme
+ */
+
+.feature-flags {
+  min-height: 100vh;
+  background: #0d1117;
+  color: #e6edf3;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+}
+
+/* Loading State */
+.flags-loading {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  min-height: 60vh;
+  gap: 1rem;
+}
+
+.loading-spinner {
+  width: 40px;
+  height: 40px;
+  border: 3px solid #21262d;
+  border-top-color: #22c55e;
+  border-radius: 50%;
+  animation: spin 1s linear infinite;
+}
+
+@keyframes spin {
+  to { transform: rotate(360deg); }
+}
+
+/* Header */
+.flags-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 1rem 1.5rem;
+  background: #161b22;
+  border-bottom: 1px solid #30363d;
+}
+
+.flags-header .header-left {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+}
+
+.flags-header h1 {
+  margin: 0;
+  font-size: 1.25rem;
+  font-weight: 600;
+}
+
+.header-badge {
+  font-size: 0.75rem;
+  font-weight: 600;
+  padding: 0.25rem 0.75rem;
+  background: #22c55e22;
+  color: #22c55e;
+  border-radius: 12px;
+}
+
+.header-right {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.create-btn {
+  padding: 0.5rem 1rem;
+  background: #22c55e;
+  border: none;
+  border-radius: 6px;
+  color: #fff;
+  font-weight: 500;
+  cursor: pointer;
+  transition: all 0.15s;
+}
+
+.create-btn:hover {
+  background: #16a34a;
+}
+
+.reset-btn {
+  padding: 0.5rem 1rem;
+  background: transparent;
+  border: 1px solid #30363d;
+  border-radius: 6px;
+  color: #8b949e;
+  cursor: pointer;
+  transition: all 0.15s;
+}
+
+.reset-btn:hover {
+  background: #21262d;
+  color: #e6edf3;
+}
+
+/* Stats Row */
+.stats-row {
+  display: flex;
+  gap: 1rem;
+  padding: 1rem 1.5rem;
+  background: #161b22;
+  border-bottom: 1px solid #21262d;
+  overflow-x: auto;
+}
+
+.stat-card {
+  flex: 1;
+  min-width: 100px;
+  background: #0d1117;
+  border: 1px solid #30363d;
+  border-radius: 8px;
+  padding: 0.75rem 1rem;
+  text-align: center;
+}
+
+.stat-card.enabled .stat-value {
+  color: #22c55e;
+}
+
+.stat-card.disabled .stat-value {
+  color: #f85149;
+}
+
+.stat-value {
+  font-size: 1.5rem;
+  font-weight: 700;
+  color: #e6edf3;
+}
+
+.stat-label {
+  font-size: 0.7rem;
+  color: #8b949e;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  margin-top: 0.25rem;
+}
+
+.stat-card.types {
+  min-width: 160px;
+}
+
+.type-items {
+  display: flex;
+  justify-content: center;
+  gap: 1rem;
+}
+
+.type-item {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.1rem;
+}
+
+.type-label {
+  font-size: 0.65rem;
+  color: #8b949e;
+}
+
+.type-count {
+  font-size: 1rem;
+  font-weight: 600;
+  color: #e6edf3;
+}
+
+/* Controls Row */
+.controls-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 0.75rem 1.5rem;
+  background: #161b22;
+  border-bottom: 1px solid #21262d;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+.view-toggle {
+  display: flex;
+  gap: 0;
+}
+
+.view-toggle button {
+  padding: 0.5rem 1rem;
+  background: transparent;
+  border: 1px solid #30363d;
+  color: #8b949e;
+  font-size: 0.85rem;
+  cursor: pointer;
+  transition: all 0.15s;
+}
+
+.view-toggle button:first-child {
+  border-radius: 6px 0 0 6px;
+}
+
+.view-toggle button:last-child {
+  border-radius: 0 6px 6px 0;
+  border-left: none;
+}
+
+.view-toggle button:hover {
+  color: #e6edf3;
+  background: #21262d;
+}
+
+.view-toggle button.active {
+  color: #22c55e;
+  background: #22c55e22;
+  border-color: #22c55e55;
+}
+
+.filters {
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
+.search-input {
+  padding: 0.4rem 0.75rem;
+  background: #0d1117;
+  border: 1px solid #30363d;
+  border-radius: 6px;
+  color: #e6edf3;
+  font-size: 0.85rem;
+  min-width: 180px;
+}
+
+.search-input:focus {
+  outline: none;
+  border-color: #22c55e;
+}
+
+.filter-select {
+  padding: 0.4rem 0.75rem;
+  background: #0d1117;
+  border: 1px solid #30363d;
+  border-radius: 6px;
+  color: #e6edf3;
+  font-size: 0.85rem;
+  cursor: pointer;
+}
+
+.filter-select:focus {
+  outline: none;
+  border-color: #22c55e;
+}
+
+/* No Data */
+.no-data {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  min-height: 300px;
+  color: #6b7280;
+  gap: 1rem;
+}
+
+.no-data-icon {
+  font-size: 3rem;
+}
+
+/* Flags List */
+.flags-list {
+  padding: 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.flag-card {
+  background: #161b22;
+  border: 1px solid #30363d;
+  border-radius: 8px;
+  overflow: hidden;
+  transition: all 0.15s;
+}
+
+.flag-card:hover {
+  border-color: #484f58;
+}
+
+.flag-card.expanded {
+  border-color: #22c55e;
+}
+
+.flag-card.disabled {
+  opacity: 0.8;
+}
+
+.flag-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 1rem;
+  cursor: pointer;
+  transition: background 0.15s;
+}
+
+.flag-header:hover {
+  background: #21262d;
+}
+
+.flag-main {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+}
+
+/* Toggle Switch */
+.flag-toggle-wrapper {
+  flex-shrink: 0;
+}
+
+.flag-toggle {
+  position: relative;
+  width: 48px;
+  height: 26px;
+  background: #21262d;
+  border: 1px solid #30363d;
+  border-radius: 13px;
+  cursor: pointer;
+  transition: all 0.2s;
+}
+
+.flag-toggle.on {
+  background: #22c55e;
+  border-color: #22c55e;
+}
+
+.toggle-slider {
+  position: absolute;
+  top: 2px;
+  left: 2px;
+  width: 20px;
+  height: 20px;
+  background: #fff;
+  border-radius: 50%;
+  transition: transform 0.2s;
+}
+
+.flag-toggle.on .toggle-slider {
+  transform: translateX(22px);
+}
+
+.flag-info {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.flag-name-row {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.flag-name {
+  font-weight: 600;
+  color: #e6edf3;
+}
+
+.flag-key {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.75rem;
+  background: #21262d;
+  padding: 0.15rem 0.4rem;
+  border-radius: 3px;
+  color: #8b949e;
+}
+
+.flag-meta {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  font-size: 0.8rem;
+}
+
+.flag-type {
+  padding: 0.15rem 0.4rem;
+  background: #21262d;
+  border-radius: 4px;
+  color: #8b949e;
+}
+
+.flag-type[data-type="percentage"] {
+  background: #a855f722;
+  color: #a855f7;
+}
+
+.flag-type[data-type="user_list"] {
+  background: #3b82f622;
+  color: #3b82f6;
+}
+
+.flag-percentage,
+.flag-users {
+  color: #8b949e;
+}
+
+.flag-env {
+  font-size: 0.75rem;
+  font-weight: 500;
+}
+
+.flag-actions {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.flag-tag {
+  font-size: 0.7rem;
+  padding: 0.15rem 0.5rem;
+  background: #21262d;
+  border-radius: 10px;
+  color: #8b949e;
+}
+
+.expand-icon {
+  color: #6b7280;
+  font-size: 0.75rem;
+  margin-left: 0.5rem;
+}
+
+/* Flag Details */
+.flag-details {
+  border-top: 1px solid #21262d;
+  padding: 1rem;
+  background: #0d1117;
+}
+
+.detail-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 0.75rem;
+  margin-bottom: 1rem;
+}
+
+.detail-item {
+  background: #161b22;
+  border: 1px solid #21262d;
+  border-radius: 6px;
+  padding: 0.75rem;
+}
+
+.detail-item.full-width {
+  grid-column: 1 / -1;
+}
+
+.detail-label {
+  display: block;
+  font-size: 0.7rem;
+  font-weight: 600;
+  color: #8b949e;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  margin-bottom: 0.25rem;
+}
+
+.detail-value {
+  font-size: 0.85rem;
+  color: #e6edf3;
+}
+
+/* Percentage Bar */
+.percentage-bar {
+  position: relative;
+  height: 24px;
+  background: #21262d;
+  border-radius: 4px;
+  overflow: hidden;
+}
+
+.percentage-fill {
+  height: 100%;
+  background: linear-gradient(90deg, #22c55e, #16a34a);
+  transition: width 0.3s;
+}
+
+.percentage-text {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  font-size: 0.8rem;
+  font-weight: 600;
+  color: #fff;
+  text-shadow: 0 1px 2px rgba(0, 0, 0, 0.5);
+}
+
+.flag-detail-actions {
+  display: flex;
+  gap: 0.5rem;
+  padding-top: 0.75rem;
+  border-top: 1px solid #21262d;
+}
+
+.edit-btn {
+  padding: 0.5rem 1rem;
+  background: #21262d;
+  border: 1px solid #30363d;
+  border-radius: 6px;
+  color: #e6edf3;
+  cursor: pointer;
+  transition: all 0.15s;
+}
+
+.edit-btn:hover {
+  background: #30363d;
+}
+
+.delete-btn {
+  padding: 0.5rem 1rem;
+  background: transparent;
+  border: 1px solid #f8514955;
+  border-radius: 6px;
+  color: #f85149;
+  cursor: pointer;
+  transition: all 0.15s;
+}
+
+.delete-btn:hover {
+  background: #f8514922;
+}
+
+/* History List */
+.history-list {
+  padding: 1.5rem;
+}
+
+.history-timeline {
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+}
+
+.history-item {
+  display: flex;
+  gap: 1rem;
+  padding: 0.75rem 0;
+  border-bottom: 1px solid #21262d;
+}
+
+.history-dot {
+  flex-shrink: 0;
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  margin-top: 0.35rem;
+  background: #8b949e;
+}
+
+.history-dot[data-action="created"] {
+  background: #22c55e;
+}
+
+.history-dot[data-action="toggled"] {
+  background: #3b82f6;
+}
+
+.history-dot[data-action="updated"] {
+  background: #d29922;
+}
+
+.history-dot[data-action="deleted"] {
+  background: #f85149;
+}
+
+.history-content {
+  flex: 1;
+}
+
+.history-header {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  margin-bottom: 0.25rem;
+}
+
+.history-action {
+  font-size: 0.7rem;
+  font-weight: 700;
+  letter-spacing: 0.5px;
+  color: #8b949e;
+}
+
+.history-action[data-action="created"] {
+  color: #22c55e;
+}
+
+.history-action[data-action="toggled"] {
+  color: #3b82f6;
+}
+
+.history-action[data-action="updated"] {
+  color: #d29922;
+}
+
+.history-action[data-action="deleted"] {
+  color: #f85149;
+}
+
+.history-key {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.8rem;
+  background: #21262d;
+  padding: 0.1rem 0.4rem;
+  border-radius: 3px;
+  color: #e6edf3;
+}
+
+.history-time {
+  font-size: 0.8rem;
+  color: #6b7280;
+  margin-left: auto;
+}
+
+.history-change {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.8rem;
+}
+
+.change-field {
+  color: #8b949e;
+}
+
+.change-old {
+  color: #f85149;
+  text-decoration: line-through;
+}
+
+.change-arrow {
+  color: #6b7280;
+}
+
+.change-new {
+  color: #22c55e;
+}
+
+/* Modal */
+.modal-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(0, 0, 0, 0.7);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+}
+
+.modal {
+  background: #161b22;
+  border: 1px solid #30363d;
+  border-radius: 12px;
+  width: 90%;
+  max-width: 500px;
+  max-height: 90vh;
+  overflow-y: auto;
+}
+
+.modal-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 1rem 1.5rem;
+  border-bottom: 1px solid #21262d;
+}
+
+.modal-header h2 {
+  margin: 0;
+  font-size: 1.1rem;
+}
+
+.modal-close {
+  background: transparent;
+  border: none;
+  color: #8b949e;
+  font-size: 1.5rem;
+  cursor: pointer;
+  padding: 0;
+  line-height: 1;
+}
+
+.modal-close:hover {
+  color: #e6edf3;
+}
+
+.modal-body {
+  padding: 1.5rem;
+}
+
+.form-group {
+  margin-bottom: 1rem;
+}
+
+.form-group label {
+  display: block;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #e6edf3;
+  margin-bottom: 0.5rem;
+}
+
+.form-group input[type="text"],
+.form-group textarea,
+.form-group select {
+  width: 100%;
+  padding: 0.6rem 0.75rem;
+  background: #0d1117;
+  border: 1px solid #30363d;
+  border-radius: 6px;
+  color: #e6edf3;
+  font-size: 0.9rem;
+}
+
+.form-group input:focus,
+.form-group textarea:focus,
+.form-group select:focus {
+  outline: none;
+  border-color: #22c55e;
+}
+
+.form-group textarea {
+  min-height: 80px;
+  resize: vertical;
+}
+
+.form-group input[type="range"] {
+  width: 100%;
+  accent-color: #22c55e;
+}
+
+.form-group.checkbox label {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  cursor: pointer;
+}
+
+.form-group.checkbox input {
+  width: auto;
+  accent-color: #22c55e;
+}
+
+.form-row {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 1rem;
+}
+
+.modal-footer {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.75rem;
+  padding: 1rem 1.5rem;
+  border-top: 1px solid #21262d;
+}
+
+.cancel-btn {
+  padding: 0.5rem 1rem;
+  background: transparent;
+  border: 1px solid #30363d;
+  border-radius: 6px;
+  color: #8b949e;
+  cursor: pointer;
+  transition: all 0.15s;
+}
+
+.cancel-btn:hover {
+  background: #21262d;
+  color: #e6edf3;
+}
+
+.save-btn {
+  padding: 0.5rem 1rem;
+  background: #22c55e;
+  border: none;
+  border-radius: 6px;
+  color: #fff;
+  font-weight: 500;
+  cursor: pointer;
+  transition: all 0.15s;
+}
+
+.save-btn:hover {
+  background: #16a34a;
+}
+
+/* Responsive */
+@media (max-width: 768px) {
+  .stats-row {
+    flex-wrap: nowrap;
+    overflow-x: auto;
+  }
+
+  .controls-row {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .filters {
+    flex-direction: column;
+  }
+
+  .search-input {
+    min-width: 100%;
+  }
+
+  .flag-header {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 0.75rem;
+  }
+
+  .flag-actions {
+    flex-wrap: wrap;
+  }
+
+  .detail-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .form-row {
+    grid-template-columns: 1fr;
+  }
+
+  .modal {
+    width: 95%;
+    margin: 1rem;
+  }
+}

--- a/web/src/pages/FeatureFlags.tsx
+++ b/web/src/pages/FeatureFlags.tsx
@@ -1,0 +1,719 @@
+/**
+ * Feature Flags Dashboard - Manage feature toggles
+ *
+ * Features:
+ * - View all feature flags with status
+ * - Toggle flags on/off
+ * - Create/edit/delete flags
+ * - Percentage rollout and user targeting
+ * - Flag change history
+ */
+
+import { useState, useEffect, useCallback } from 'react';
+import './FeatureFlags.css';
+
+const API_BASE = 'http://localhost:8000/api/flags';
+
+interface FeatureFlag {
+  key: string;
+  name: string;
+  description: string;
+  flag_type: 'boolean' | 'percentage' | 'user_list';
+  enabled: boolean;
+  percentage: number;
+  user_ids: number[];
+  environment: 'all' | 'dev' | 'staging' | 'prod';
+  created_at: string;
+  updated_at: string;
+  created_by: string;
+  tags: string[];
+}
+
+interface FlagChange {
+  timestamp: string;
+  flag_key: string;
+  action: string;
+  field?: string;
+  old_value?: string;
+  new_value?: string;
+  changed_by: string;
+}
+
+interface FlagStats {
+  total: number;
+  enabled: number;
+  disabled: number;
+  by_type: Record<string, number>;
+  by_environment: Record<string, number>;
+  by_tag: Record<string, number>;
+}
+
+const FLAG_TYPE_LABELS: Record<string, string> = {
+  boolean: 'Boolean',
+  percentage: 'Percentage',
+  user_list: 'User List',
+};
+
+const ENVIRONMENT_LABELS: Record<string, string> = {
+  all: 'All',
+  dev: 'Dev',
+  staging: 'Staging',
+  prod: 'Production',
+};
+
+const ENVIRONMENT_COLORS: Record<string, string> = {
+  all: '#8b949e',
+  dev: '#a855f7',
+  staging: '#d29922',
+  prod: '#22c55e',
+};
+
+export function FeatureFlags() {
+  const [flags, setFlags] = useState<FeatureFlag[]>([]);
+  const [history, setHistory] = useState<FlagChange[]>([]);
+  const [stats, setStats] = useState<FlagStats | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  // View state
+  const [view, setView] = useState<'flags' | 'history'>('flags');
+  const [searchQuery, setSearchQuery] = useState('');
+  const [filterType, setFilterType] = useState<string>('');
+  const [filterEnabled, setFilterEnabled] = useState<string>('');
+
+  // Modal state
+  const [showModal, setShowModal] = useState(false);
+  const [editingFlag, setEditingFlag] = useState<FeatureFlag | null>(null);
+  const [expandedFlag, setExpandedFlag] = useState<string | null>(null);
+
+  // Form state
+  const [formData, setFormData] = useState({
+    key: '',
+    name: '',
+    description: '',
+    flag_type: 'boolean' as 'boolean' | 'percentage' | 'user_list',
+    enabled: false,
+    percentage: 50,
+    user_ids: '',
+    environment: 'all' as 'all' | 'dev' | 'staging' | 'prod',
+    tags: '',
+  });
+
+  // Fetch flags
+  const fetchFlags = useCallback(async () => {
+    try {
+      const params = new URLSearchParams();
+      if (searchQuery) params.set('search', searchQuery);
+      if (filterType) params.set('flag_type', filterType);
+      if (filterEnabled) params.set('enabled', filterEnabled);
+
+      const res = await fetch(`${API_BASE}?${params}`);
+      if (res.ok) {
+        const data = await res.json();
+        setFlags(data.flags);
+      }
+    } catch {
+      // Silently fail
+    }
+  }, [searchQuery, filterType, filterEnabled]);
+
+  // Fetch stats
+  const fetchStats = useCallback(async () => {
+    try {
+      const res = await fetch(`${API_BASE}/stats`);
+      if (res.ok) {
+        const data = await res.json();
+        setStats(data);
+      }
+    } catch {
+      // Silently fail
+    }
+  }, []);
+
+  // Fetch history
+  const fetchHistory = useCallback(async () => {
+    try {
+      const res = await fetch(`${API_BASE}/history?limit=50`);
+      if (res.ok) {
+        const data = await res.json();
+        setHistory(data.history);
+      }
+    } catch {
+      // Silently fail
+    }
+  }, []);
+
+  // Initial fetch
+  useEffect(() => {
+    const loadData = async () => {
+      setLoading(true);
+      await Promise.all([fetchFlags(), fetchStats(), fetchHistory()]);
+      setLoading(false);
+    };
+    loadData();
+  }, [fetchFlags, fetchStats, fetchHistory]);
+
+  // Toggle flag
+  const toggleFlag = async (flagKey: string) => {
+    try {
+      await fetch(`${API_BASE}/${flagKey}/toggle`, { method: 'POST' });
+      fetchFlags();
+      fetchStats();
+      fetchHistory();
+    } catch {
+      // Silently fail
+    }
+  };
+
+  // Delete flag
+  const deleteFlag = async (flagKey: string) => {
+    if (!confirm(`Delete flag "${flagKey}"?`)) return;
+    try {
+      await fetch(`${API_BASE}/${flagKey}`, { method: 'DELETE' });
+      fetchFlags();
+      fetchStats();
+      fetchHistory();
+    } catch {
+      // Silently fail
+    }
+  };
+
+  // Open create modal
+  const openCreateModal = () => {
+    setEditingFlag(null);
+    setFormData({
+      key: '',
+      name: '',
+      description: '',
+      flag_type: 'boolean',
+      enabled: false,
+      percentage: 50,
+      user_ids: '',
+      environment: 'all',
+      tags: '',
+    });
+    setShowModal(true);
+  };
+
+  // Open edit modal
+  const openEditModal = (flag: FeatureFlag) => {
+    setEditingFlag(flag);
+    setFormData({
+      key: flag.key,
+      name: flag.name,
+      description: flag.description,
+      flag_type: flag.flag_type,
+      enabled: flag.enabled,
+      percentage: flag.percentage,
+      user_ids: flag.user_ids.join(', '),
+      environment: flag.environment,
+      tags: flag.tags.join(', '),
+    });
+    setShowModal(true);
+  };
+
+  // Save flag
+  const saveFlag = async () => {
+    const payload = {
+      key: formData.key,
+      name: formData.name,
+      description: formData.description,
+      flag_type: formData.flag_type,
+      enabled: formData.enabled,
+      percentage: formData.percentage,
+      user_ids: formData.user_ids
+        .split(',')
+        .map(s => s.trim())
+        .filter(s => s)
+        .map(Number)
+        .filter(n => !isNaN(n)),
+      environment: formData.environment,
+      tags: formData.tags
+        .split(',')
+        .map(s => s.trim())
+        .filter(s => s),
+    };
+
+    try {
+      if (editingFlag) {
+        await fetch(`${API_BASE}/${editingFlag.key}`, {
+          method: 'PUT',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(payload),
+        });
+      } else {
+        await fetch(API_BASE, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(payload),
+        });
+      }
+      setShowModal(false);
+      fetchFlags();
+      fetchStats();
+      fetchHistory();
+    } catch {
+      // Silently fail
+    }
+  };
+
+  // Reset flags
+  const resetFlags = async () => {
+    if (!confirm('Reset all flags to defaults?')) return;
+    try {
+      await fetch(API_BASE, { method: 'DELETE' });
+      fetchFlags();
+      fetchStats();
+      fetchHistory();
+    } catch {
+      // Silently fail
+    }
+  };
+
+  // Format time
+  const formatTime = (timestamp: string) => {
+    try {
+      const date = new Date(timestamp);
+      return date.toLocaleString();
+    } catch {
+      return timestamp;
+    }
+  };
+
+  // Format relative time
+  const formatRelativeTime = (timestamp: string) => {
+    try {
+      const date = new Date(timestamp);
+      const now = new Date();
+      const diff = now.getTime() - date.getTime();
+      const minutes = Math.floor(diff / 60000);
+      const hours = Math.floor(minutes / 60);
+      const days = Math.floor(hours / 24);
+
+      if (days > 0) return `${days}d ago`;
+      if (hours > 0) return `${hours}h ago`;
+      if (minutes > 0) return `${minutes}m ago`;
+      return 'just now';
+    } catch {
+      return '';
+    }
+  };
+
+  if (loading) {
+    return (
+      <div className="feature-flags">
+        <div className="flags-loading">
+          <div className="loading-spinner" />
+          <p>Loading feature flags...</p>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="feature-flags">
+      {/* Header */}
+      <header className="flags-header">
+        <div className="header-left">
+          <h1>Feature Flags</h1>
+          <span className="header-badge">
+            {stats?.enabled || 0}/{stats?.total || 0} enabled
+          </span>
+        </div>
+        <div className="header-right">
+          <button onClick={openCreateModal} className="create-btn">
+            + New Flag
+          </button>
+          <button onClick={resetFlags} className="reset-btn">
+            Reset
+          </button>
+        </div>
+      </header>
+
+      {/* Stats Cards */}
+      {stats && (
+        <div className="stats-row">
+          <div className="stat-card">
+            <div className="stat-value">{stats.total}</div>
+            <div className="stat-label">Total Flags</div>
+          </div>
+          <div className="stat-card enabled">
+            <div className="stat-value">{stats.enabled}</div>
+            <div className="stat-label">Enabled</div>
+          </div>
+          <div className="stat-card disabled">
+            <div className="stat-value">{stats.disabled}</div>
+            <div className="stat-label">Disabled</div>
+          </div>
+          <div className="stat-card types">
+            <div className="type-items">
+              {Object.entries(stats.by_type).map(([type, count]) => (
+                <div key={type} className="type-item">
+                  <span className="type-label">{FLAG_TYPE_LABELS[type]}</span>
+                  <span className="type-count">{count}</span>
+                </div>
+              ))}
+            </div>
+            <div className="stat-label">By Type</div>
+          </div>
+        </div>
+      )}
+
+      {/* View Toggle & Filters */}
+      <div className="controls-row">
+        <div className="view-toggle">
+          <button
+            className={view === 'flags' ? 'active' : ''}
+            onClick={() => setView('flags')}
+          >
+            Flags
+          </button>
+          <button
+            className={view === 'history' ? 'active' : ''}
+            onClick={() => setView('history')}
+          >
+            History
+          </button>
+        </div>
+
+        {view === 'flags' && (
+          <div className="filters">
+            <input
+              type="text"
+              placeholder="Search flags..."
+              value={searchQuery}
+              onChange={(e) => setSearchQuery(e.target.value)}
+              className="search-input"
+            />
+            <select
+              value={filterType}
+              onChange={(e) => setFilterType(e.target.value)}
+              className="filter-select"
+            >
+              <option value="">All Types</option>
+              <option value="boolean">Boolean</option>
+              <option value="percentage">Percentage</option>
+              <option value="user_list">User List</option>
+            </select>
+            <select
+              value={filterEnabled}
+              onChange={(e) => setFilterEnabled(e.target.value)}
+              className="filter-select"
+            >
+              <option value="">All Status</option>
+              <option value="true">Enabled</option>
+              <option value="false">Disabled</option>
+            </select>
+          </div>
+        )}
+      </div>
+
+      {/* Flags View */}
+      {view === 'flags' && (
+        <div className="flags-list">
+          {flags.length === 0 ? (
+            <div className="no-data">
+              <div className="no-data-icon">🚩</div>
+              <p>No feature flags found</p>
+              <button onClick={openCreateModal} className="create-btn">
+                Create First Flag
+              </button>
+            </div>
+          ) : (
+            flags.map((flag) => (
+              <div
+                key={flag.key}
+                className={`flag-card ${flag.enabled ? 'enabled' : 'disabled'} ${expandedFlag === flag.key ? 'expanded' : ''}`}
+              >
+                <div
+                  className="flag-header"
+                  onClick={() => setExpandedFlag(expandedFlag === flag.key ? null : flag.key)}
+                >
+                  <div className="flag-main">
+                    <div className="flag-toggle-wrapper">
+                      <button
+                        className={`flag-toggle ${flag.enabled ? 'on' : 'off'}`}
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          toggleFlag(flag.key);
+                        }}
+                      >
+                        <span className="toggle-slider" />
+                      </button>
+                    </div>
+                    <div className="flag-info">
+                      <div className="flag-name-row">
+                        <span className="flag-name">{flag.name}</span>
+                        <code className="flag-key">{flag.key}</code>
+                      </div>
+                      <div className="flag-meta">
+                        <span
+                          className="flag-type"
+                          data-type={flag.flag_type}
+                        >
+                          {FLAG_TYPE_LABELS[flag.flag_type]}
+                        </span>
+                        {flag.flag_type === 'percentage' && (
+                          <span className="flag-percentage">{flag.percentage}%</span>
+                        )}
+                        {flag.flag_type === 'user_list' && (
+                          <span className="flag-users">{flag.user_ids.length} users</span>
+                        )}
+                        <span
+                          className="flag-env"
+                          style={{ color: ENVIRONMENT_COLORS[flag.environment] }}
+                        >
+                          {ENVIRONMENT_LABELS[flag.environment]}
+                        </span>
+                      </div>
+                    </div>
+                  </div>
+                  <div className="flag-actions">
+                    {flag.tags.map((tag) => (
+                      <span key={tag} className="flag-tag">{tag}</span>
+                    ))}
+                    <span className="expand-icon">
+                      {expandedFlag === flag.key ? '▼' : '▶'}
+                    </span>
+                  </div>
+                </div>
+
+                {expandedFlag === flag.key && (
+                  <div className="flag-details">
+                    <div className="detail-grid">
+                      <div className="detail-item full-width">
+                        <span className="detail-label">Description</span>
+                        <span className="detail-value">
+                          {flag.description || 'No description'}
+                        </span>
+                      </div>
+                      {flag.flag_type === 'percentage' && (
+                        <div className="detail-item">
+                          <span className="detail-label">Rollout Percentage</span>
+                          <div className="percentage-bar">
+                            <div
+                              className="percentage-fill"
+                              style={{ width: `${flag.percentage}%` }}
+                            />
+                            <span className="percentage-text">{flag.percentage}%</span>
+                          </div>
+                        </div>
+                      )}
+                      {flag.flag_type === 'user_list' && (
+                        <div className="detail-item">
+                          <span className="detail-label">Target Users</span>
+                          <span className="detail-value">
+                            {flag.user_ids.length > 0
+                              ? flag.user_ids.join(', ')
+                              : 'None'}
+                          </span>
+                        </div>
+                      )}
+                      <div className="detail-item">
+                        <span className="detail-label">Created</span>
+                        <span className="detail-value">{formatTime(flag.created_at)}</span>
+                      </div>
+                      <div className="detail-item">
+                        <span className="detail-label">Last Updated</span>
+                        <span className="detail-value">{formatTime(flag.updated_at)}</span>
+                      </div>
+                    </div>
+                    <div className="flag-detail-actions">
+                      <button
+                        onClick={() => openEditModal(flag)}
+                        className="edit-btn"
+                      >
+                        Edit
+                      </button>
+                      <button
+                        onClick={() => deleteFlag(flag.key)}
+                        className="delete-btn"
+                      >
+                        Delete
+                      </button>
+                    </div>
+                  </div>
+                )}
+              </div>
+            ))
+          )}
+        </div>
+      )}
+
+      {/* History View */}
+      {view === 'history' && (
+        <div className="history-list">
+          {history.length === 0 ? (
+            <div className="no-data">
+              <p>No history recorded</p>
+            </div>
+          ) : (
+            <div className="history-timeline">
+              {history.map((change, i) => (
+                <div key={i} className="history-item">
+                  <div
+                    className="history-dot"
+                    data-action={change.action}
+                  />
+                  <div className="history-content">
+                    <div className="history-header">
+                      <span className="history-action" data-action={change.action}>
+                        {change.action.toUpperCase()}
+                      </span>
+                      <code className="history-key">{change.flag_key}</code>
+                      <span className="history-time">
+                        {formatRelativeTime(change.timestamp)}
+                      </span>
+                    </div>
+                    {change.field && (
+                      <div className="history-change">
+                        <span className="change-field">{change.field}:</span>
+                        {change.old_value && (
+                          <span className="change-old">{change.old_value}</span>
+                        )}
+                        {change.old_value && change.new_value && (
+                          <span className="change-arrow">→</span>
+                        )}
+                        {change.new_value && (
+                          <span className="change-new">{change.new_value}</span>
+                        )}
+                      </div>
+                    )}
+                  </div>
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+      )}
+
+      {/* Create/Edit Modal */}
+      {showModal && (
+        <div className="modal-overlay" onClick={() => setShowModal(false)}>
+          <div className="modal" onClick={(e) => e.stopPropagation()}>
+            <div className="modal-header">
+              <h2>{editingFlag ? 'Edit Flag' : 'Create Flag'}</h2>
+              <button className="modal-close" onClick={() => setShowModal(false)}>
+                ×
+              </button>
+            </div>
+            <div className="modal-body">
+              <div className="form-group">
+                <label>Key</label>
+                <input
+                  type="text"
+                  value={formData.key}
+                  onChange={(e) => setFormData({ ...formData, key: e.target.value })}
+                  placeholder="feature_key"
+                  disabled={!!editingFlag}
+                />
+              </div>
+              <div className="form-group">
+                <label>Name</label>
+                <input
+                  type="text"
+                  value={formData.name}
+                  onChange={(e) => setFormData({ ...formData, name: e.target.value })}
+                  placeholder="Feature Name"
+                />
+              </div>
+              <div className="form-group">
+                <label>Description</label>
+                <textarea
+                  value={formData.description}
+                  onChange={(e) => setFormData({ ...formData, description: e.target.value })}
+                  placeholder="What does this flag control?"
+                />
+              </div>
+              <div className="form-row">
+                <div className="form-group">
+                  <label>Type</label>
+                  <select
+                    value={formData.flag_type}
+                    onChange={(e) => setFormData({
+                      ...formData,
+                      flag_type: e.target.value as 'boolean' | 'percentage' | 'user_list'
+                    })}
+                  >
+                    <option value="boolean">Boolean</option>
+                    <option value="percentage">Percentage Rollout</option>
+                    <option value="user_list">User List</option>
+                  </select>
+                </div>
+                <div className="form-group">
+                  <label>Environment</label>
+                  <select
+                    value={formData.environment}
+                    onChange={(e) => setFormData({
+                      ...formData,
+                      environment: e.target.value as 'all' | 'dev' | 'staging' | 'prod'
+                    })}
+                  >
+                    <option value="all">All Environments</option>
+                    <option value="dev">Development</option>
+                    <option value="staging">Staging</option>
+                    <option value="prod">Production</option>
+                  </select>
+                </div>
+              </div>
+              {formData.flag_type === 'percentage' && (
+                <div className="form-group">
+                  <label>Rollout Percentage: {formData.percentage}%</label>
+                  <input
+                    type="range"
+                    min="0"
+                    max="100"
+                    value={formData.percentage}
+                    onChange={(e) => setFormData({
+                      ...formData,
+                      percentage: parseInt(e.target.value)
+                    })}
+                  />
+                </div>
+              )}
+              {formData.flag_type === 'user_list' && (
+                <div className="form-group">
+                  <label>User IDs (comma-separated)</label>
+                  <input
+                    type="text"
+                    value={formData.user_ids}
+                    onChange={(e) => setFormData({ ...formData, user_ids: e.target.value })}
+                    placeholder="1, 2, 3"
+                  />
+                </div>
+              )}
+              <div className="form-group">
+                <label>Tags (comma-separated)</label>
+                <input
+                  type="text"
+                  value={formData.tags}
+                  onChange={(e) => setFormData({ ...formData, tags: e.target.value })}
+                  placeholder="beta, experimental"
+                />
+              </div>
+              <div className="form-group checkbox">
+                <label>
+                  <input
+                    type="checkbox"
+                    checked={formData.enabled}
+                    onChange={(e) => setFormData({ ...formData, enabled: e.target.checked })}
+                  />
+                  Enabled
+                </label>
+              </div>
+            </div>
+            <div className="modal-footer">
+              <button className="cancel-btn" onClick={() => setShowModal(false)}>
+                Cancel
+              </button>
+              <button className="save-btn" onClick={saveFlag}>
+                {editingFlag ? 'Save Changes' : 'Create Flag'}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default FeatureFlags;

--- a/web/src/pages/index.ts
+++ b/web/src/pages/index.ts
@@ -27,3 +27,4 @@ export { LogViewer } from './LogViewer';
 export { ErrorTracker } from './ErrorTracker';
 export { PerformanceProfiler } from './PerformanceProfiler';
 export { SessionInspector } from './SessionInspector';
+export { FeatureFlags } from './FeatureFlags';


### PR DESCRIPTION
## Summary
- Backend API for managing feature flags with in-memory store
- Three flag types: boolean, percentage rollout, user list targeting
- Environment scoping (all, dev, staging, prod)
- Flag change history with audit trail
- Frontend dashboard with toggle switches and search/filter
- Create/edit modal with percentage slider and user targeting
- Pre-seeded demo flags for testing

## Test plan
- [ ] Navigate to Dev Tools > Feature Flags
- [ ] Verify 6 pre-seeded demo flags are displayed
- [ ] Toggle flags on/off using the switch
- [ ] Create a new flag using "+ New Flag" button
- [ ] Edit an existing flag by expanding and clicking "Edit"
- [ ] Delete a flag and confirm removal
- [ ] Test search/filter functionality
- [ ] Check History tab shows flag changes
- [ ] Verify percentage bar displays correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)