### PR TITLE
feat(dev-tools): add Environment Config viewer

### DIFF
--- a/server/app/api/config.py
+++ b/server/app/api/config.py
@@ -1,0 +1,361 @@
+"""
+Environment Config API - View application configuration and environment.
+
+Features:
+- View application settings (masked sensitive values)
+- View environment variables
+- Runtime information (Python version, platform, etc.)
+- Configuration validation status
+"""
+
+import os
+import sys
+import platform
+from datetime import datetime
+from typing import Optional
+
+from fastapi import APIRouter, Depends
+from pydantic import BaseModel
+
+from ..api.dbexplorer import require_debug
+from ..core.config import settings
+
+router = APIRouter(prefix="/api/config", tags=["config"])
+
+# Sensitive field patterns to mask
+SENSITIVE_PATTERNS = [
+    "password",
+    "secret",
+    "key",
+    "token",
+    "credential",
+    "auth",
+    "api_key",
+    "apikey",
+    "private",
+]
+
+# Environment variables to hide completely
+HIDDEN_ENV_VARS = [
+    "PATH",
+    "PATHEXT",
+    "SYSTEMROOT",
+    "WINDIR",
+    "COMSPEC",
+    "PROGRAMFILES",
+    "PROGRAMDATA",
+    "APPDATA",
+    "LOCALAPPDATA",
+    "USERPROFILE",
+    "HOMEDRIVE",
+    "HOMEPATH",
+    "TEMP",
+    "TMP",
+    "SYSTEMDRIVE",
+    "PROCESSOR_IDENTIFIER",
+    "PROCESSOR_ARCHITECTURE",
+    "PROCESSOR_LEVEL",
+    "PROCESSOR_REVISION",
+    "NUMBER_OF_PROCESSORS",
+    "OS",
+    "COMPUTERNAME",
+    "USERNAME",
+    "USERDOMAIN",
+]
+
+
+class ConfigValue(BaseModel):
+    """A configuration value."""
+    key: str
+    value: str
+    category: str
+    is_sensitive: bool = False
+    is_default: bool = False
+    description: Optional[str] = None
+
+
+class RuntimeInfo(BaseModel):
+    """Runtime environment information."""
+    python_version: str
+    platform: str
+    platform_release: str
+    platform_version: str
+    architecture: str
+    hostname: str
+    cpu_count: Optional[int]
+    pid: int
+    cwd: str
+    start_time: str
+
+
+class ConfigStats(BaseModel):
+    """Configuration statistics."""
+    total_settings: int
+    total_env_vars: int
+    sensitive_count: int
+    categories: dict[str, int]
+
+
+def is_sensitive(key: str) -> bool:
+    """Check if a key is sensitive and should be masked."""
+    key_lower = key.lower()
+    return any(pattern in key_lower for pattern in SENSITIVE_PATTERNS)
+
+
+def mask_value(value: str) -> str:
+    """Mask a sensitive value."""
+    if not value:
+        return "(empty)"
+    if len(value) <= 4:
+        return "*" * len(value)
+    return value[:2] + "*" * (len(value) - 4) + value[-2:]
+
+
+def get_setting_description(key: str) -> Optional[str]:
+    """Get a description for a setting key."""
+    descriptions = {
+        "app_name": "Application display name",
+        "app_version": "Current application version",
+        "debug": "Enable debug mode with extra logging",
+        "host": "Server bind address",
+        "port": "Server port number",
+        "postgres_host": "PostgreSQL server hostname",
+        "postgres_port": "PostgreSQL server port",
+        "postgres_user": "Database username",
+        "postgres_password": "Database password",
+        "postgres_db": "Database name",
+        "redis_host": "Redis server hostname",
+        "redis_port": "Redis server port",
+        "redis_password": "Redis authentication password",
+        "jwt_secret_key": "Secret key for JWT token signing",
+        "jwt_algorithm": "JWT signing algorithm",
+        "jwt_expire_minutes": "JWT token expiration time in minutes",
+        "cors_origins": "Allowed CORS origins for API access",
+    }
+    return descriptions.get(key)
+
+
+@router.get("")
+async def get_config(_: None = Depends(require_debug)):
+    """Get all configuration values."""
+    config_values = []
+
+    # Application settings from pydantic model
+    settings_dict = {
+        "app_name": settings.app_name,
+        "app_version": settings.app_version,
+        "debug": str(settings.debug),
+        "host": settings.host,
+        "port": str(settings.port),
+        "postgres_host": settings.postgres_host,
+        "postgres_port": str(settings.postgres_port),
+        "postgres_user": settings.postgres_user,
+        "postgres_password": settings.postgres_password,
+        "postgres_db": settings.postgres_db,
+        "redis_host": settings.redis_host,
+        "redis_port": str(settings.redis_port),
+        "redis_password": settings.redis_password or "(not set)",
+        "jwt_secret_key": settings.jwt_secret_key,
+        "jwt_algorithm": settings.jwt_algorithm,
+        "jwt_expire_minutes": str(settings.jwt_expire_minutes),
+        "cors_origins": ", ".join(settings.cors_origins),
+    }
+
+    # Define categories
+    categories = {
+        "Application": ["app_name", "app_version", "debug"],
+        "Server": ["host", "port", "cors_origins"],
+        "Database": ["postgres_host", "postgres_port", "postgres_user", "postgres_password", "postgres_db"],
+        "Redis": ["redis_host", "redis_port", "redis_password"],
+        "Authentication": ["jwt_secret_key", "jwt_algorithm", "jwt_expire_minutes"],
+    }
+
+    # Build config values list
+    for category, keys in categories.items():
+        for key in keys:
+            if key in settings_dict:
+                sensitive = is_sensitive(key)
+                value = settings_dict[key]
+
+                config_values.append(ConfigValue(
+                    key=key,
+                    value=mask_value(value) if sensitive else value,
+                    category=category,
+                    is_sensitive=sensitive,
+                    description=get_setting_description(key),
+                ))
+
+    return {
+        "settings": [v.model_dump() for v in config_values],
+        "total": len(config_values),
+    }
+
+
+@router.get("/env")
+async def get_env_vars(_: None = Depends(require_debug)):
+    """Get environment variables (filtered and masked)."""
+    env_vars = []
+
+    for key, value in sorted(os.environ.items()):
+        # Skip hidden system vars
+        if key.upper() in HIDDEN_ENV_VARS:
+            continue
+
+        # Skip very long values (like PATH)
+        if len(value) > 500:
+            continue
+
+        sensitive = is_sensitive(key)
+
+        env_vars.append({
+            "key": key,
+            "value": mask_value(value) if sensitive else value,
+            "is_sensitive": sensitive,
+        })
+
+    return {
+        "env_vars": env_vars,
+        "total": len(env_vars),
+        "hidden": len(HIDDEN_ENV_VARS),
+    }
+
+
+@router.get("/runtime")
+async def get_runtime_info(_: None = Depends(require_debug)):
+    """Get runtime environment information."""
+    return RuntimeInfo(
+        python_version=sys.version,
+        platform=platform.system(),
+        platform_release=platform.release(),
+        platform_version=platform.version(),
+        architecture=platform.machine(),
+        hostname=platform.node(),
+        cpu_count=os.cpu_count(),
+        pid=os.getpid(),
+        cwd=os.getcwd(),
+        start_time=datetime.utcnow().isoformat() + "Z",
+    )
+
+
+@router.get("/stats")
+async def get_config_stats(_: None = Depends(require_debug)):
+    """Get configuration statistics."""
+    # Count settings by category
+    categories = {
+        "Application": 3,
+        "Server": 3,
+        "Database": 5,
+        "Redis": 3,
+        "Authentication": 3,
+    }
+
+    # Count env vars
+    env_count = sum(
+        1 for key in os.environ.keys()
+        if key.upper() not in HIDDEN_ENV_VARS
+    )
+
+    # Count sensitive
+    sensitive_settings = sum(
+        1 for key in [
+            "postgres_password", "redis_password",
+            "jwt_secret_key"
+        ]
+    )
+
+    return ConfigStats(
+        total_settings=sum(categories.values()),
+        total_env_vars=env_count,
+        sensitive_count=sensitive_settings,
+        categories=categories,
+    )
+
+
+@router.get("/validate")
+async def validate_config(_: None = Depends(require_debug)):
+    """Validate configuration and check for issues."""
+    issues = []
+    warnings = []
+
+    # Check debug mode
+    if settings.debug:
+        warnings.append({
+            "key": "debug",
+            "message": "Debug mode is enabled - disable in production",
+            "severity": "warning",
+        })
+
+    # Check JWT secret
+    if "change-this" in settings.jwt_secret_key.lower():
+        issues.append({
+            "key": "jwt_secret_key",
+            "message": "Using default JWT secret - change in production",
+            "severity": "error",
+        })
+
+    # Check database password
+    if settings.postgres_password == "roguelike_secret":
+        warnings.append({
+            "key": "postgres_password",
+            "message": "Using default database password",
+            "severity": "warning",
+        })
+
+    # Check host binding
+    if settings.host == "0.0.0.0":
+        warnings.append({
+            "key": "host",
+            "message": "Server binds to all interfaces - restrict in production",
+            "severity": "info",
+        })
+
+    # Check CORS origins
+    if len(settings.cors_origins) > 5:
+        warnings.append({
+            "key": "cors_origins",
+            "message": f"Many CORS origins configured ({len(settings.cors_origins)})",
+            "severity": "info",
+        })
+
+    return {
+        "valid": len(issues) == 0,
+        "issues": issues,
+        "warnings": warnings,
+        "total_issues": len(issues),
+        "total_warnings": len(warnings),
+    }
+
+
+@router.get("/connections")
+async def get_connection_strings(_: None = Depends(require_debug)):
+    """Get connection strings (masked)."""
+    return {
+        "database_url": mask_value(settings.database_url),
+        "database_url_sync": mask_value(settings.database_url_sync),
+        "redis_url": mask_value(settings.redis_url),
+    }
+
+
+@router.post("/reveal/{key}")
+async def reveal_value(
+    key: str,
+    _: None = Depends(require_debug),
+):
+    """Reveal a masked configuration value (debug only)."""
+    # Map of revealable keys to their values
+    revealable = {
+        "postgres_password": settings.postgres_password,
+        "redis_password": settings.redis_password,
+        "jwt_secret_key": settings.jwt_secret_key,
+        "database_url": settings.database_url,
+        "redis_url": settings.redis_url,
+    }
+
+    if key not in revealable:
+        return {"error": "Key not found or not revealable"}
+
+    return {
+        "key": key,
+        "value": revealable[key] or "(not set)",
+        "warning": "This value is sensitive - do not share or log",
+    }

--- a/server/app/main.py
+++ b/server/app/main.py
@@ -25,6 +25,7 @@ from .api.errors import router as errors_router, capture_error
 from .api.profiler import router as profiler_router, ProfilingMiddleware
 from .api.sessions import router as sessions_router
 from .api.flags import router as flags_router
+from .api.config import router as config_router
 
 
 @asynccontextmanager
@@ -95,6 +96,7 @@ def create_app() -> FastAPI:
     app.include_router(profiler_router, tags=["dev-tools"])
     app.include_router(sessions_router, tags=["dev-tools"])
     app.include_router(flags_router, tags=["dev-tools"])
+    app.include_router(config_router, tags=["dev-tools"])
 
     # Add exception handler to capture errors (only in debug mode)
     if settings.debug:

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,6 +1,6 @@
 import { Routes, Route } from 'react-router-dom';
 import { Layout } from './components/Layout';
-import { Home, Login, Register, Play, Features, About, PlayScene, SceneDemo, Leaderboard, Ghosts, Profile, Achievements, Spectate, Friends, Presentation, Roadmap, CodebaseHealth, Changelog, DatabaseExplorer, CacheInspector, AudioJukebox, SystemStatus, ApiPlayground, WebSocketMonitor, BuildInfo, LogViewer, ErrorTracker, PerformanceProfiler, SessionInspector, FeatureFlags } from './pages';
+import { Home, Login, Register, Play, Features, About, PlayScene, SceneDemo, Leaderboard, Ghosts, Profile, Achievements, Spectate, Friends, Presentation, Roadmap, CodebaseHealth, Changelog, DatabaseExplorer, CacheInspector, AudioJukebox, SystemStatus, ApiPlayground, WebSocketMonitor, BuildInfo, LogViewer, ErrorTracker, PerformanceProfiler, SessionInspector, FeatureFlags, EnvConfig } from './pages';
 import { FirstPersonDemo } from './pages/FirstPersonDemo';
 import { FirstPersonTestPage } from './pages/FirstPersonTestPage';
 import { Debug3DPage } from './pages/Debug3DPage';
@@ -45,6 +45,7 @@ function App() {
         <Route path="profiler" element={<PerformanceProfiler />} />
         <Route path="session-inspector" element={<SessionInspector />} />
         <Route path="feature-flags" element={<FeatureFlags />} />
+        <Route path="env-config" element={<EnvConfig />} />
       </Route>
     </Routes>
   );

--- a/web/src/components/Layout.tsx
+++ b/web/src/components/Layout.tsx
@@ -172,6 +172,10 @@ export function Layout() {
                     <span className="menu-icon">🚩</span>
                     Feature Flags
                   </Link>
+                  <Link to="/env-config" onClick={closeDropdown}>
+                    <span className="menu-icon">⚙️</span>
+                    Env Config
+                  </Link>
                   <Link to="/codebase-health" onClick={closeDropdown}>
                     <span className="menu-icon">🩺</span>
                     Codebase Health

--- a/web/src/pages/EnvConfig.css
+++ b/web/src/pages/EnvConfig.css
@@ -1,0 +1,645 @@
+/**
+ * Environment Config Styles - Cyan/config theme
+ */
+
+.env-config {
+  min-height: 100vh;
+  background: #0d1117;
+  color: #e6edf3;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+}
+
+/* Loading State */
+.config-loading {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  min-height: 60vh;
+  gap: 1rem;
+}
+
+.loading-spinner {
+  width: 40px;
+  height: 40px;
+  border: 3px solid #21262d;
+  border-top-color: #06b6d4;
+  border-radius: 50%;
+  animation: spin 1s linear infinite;
+}
+
+@keyframes spin {
+  to { transform: rotate(360deg); }
+}
+
+/* Header */
+.config-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 1rem 1.5rem;
+  background: #161b22;
+  border-bottom: 1px solid #30363d;
+}
+
+.config-header .header-left {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+}
+
+.config-header h1 {
+  margin: 0;
+  font-size: 1.25rem;
+  font-weight: 600;
+}
+
+.header-badge {
+  font-size: 0.75rem;
+  font-weight: 600;
+  padding: 0.25rem 0.75rem;
+  border-radius: 12px;
+}
+
+.header-badge.valid {
+  background: #22c55e22;
+  color: #22c55e;
+}
+
+.header-badge.invalid {
+  background: #f8514922;
+  color: #f85149;
+}
+
+.config-count {
+  font-size: 0.85rem;
+  color: #8b949e;
+}
+
+/* Stats Row */
+.stats-row {
+  display: flex;
+  gap: 1rem;
+  padding: 1rem 1.5rem;
+  background: #161b22;
+  border-bottom: 1px solid #21262d;
+  overflow-x: auto;
+}
+
+.stat-card {
+  flex: 1;
+  min-width: 100px;
+  background: #0d1117;
+  border: 1px solid #30363d;
+  border-radius: 8px;
+  padding: 0.75rem 1rem;
+  text-align: center;
+}
+
+.stat-card.sensitive .stat-value {
+  color: #d29922;
+}
+
+.stat-value {
+  font-size: 1.5rem;
+  font-weight: 700;
+  color: #e6edf3;
+}
+
+.stat-label {
+  font-size: 0.7rem;
+  color: #8b949e;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  margin-top: 0.25rem;
+}
+
+.stat-card.categories {
+  min-width: 180px;
+}
+
+.category-items {
+  display: flex;
+  justify-content: center;
+  gap: 0.75rem;
+}
+
+.category-item {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.1rem;
+}
+
+.category-icon {
+  font-size: 1rem;
+}
+
+.category-count {
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: #e6edf3;
+}
+
+/* Controls Row */
+.controls-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 0.75rem 1.5rem;
+  background: #161b22;
+  border-bottom: 1px solid #21262d;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+.view-toggle {
+  display: flex;
+  gap: 0;
+}
+
+.view-toggle button {
+  padding: 0.5rem 1rem;
+  background: transparent;
+  border: 1px solid #30363d;
+  color: #8b949e;
+  font-size: 0.85rem;
+  cursor: pointer;
+  transition: all 0.15s;
+}
+
+.view-toggle button:first-child {
+  border-radius: 6px 0 0 6px;
+}
+
+.view-toggle button:last-child {
+  border-radius: 0 6px 6px 0;
+}
+
+.view-toggle button:not(:first-child) {
+  border-left: none;
+}
+
+.view-toggle button:hover {
+  color: #e6edf3;
+  background: #21262d;
+}
+
+.view-toggle button.active {
+  color: #06b6d4;
+  background: #06b6d422;
+  border-color: #06b6d455;
+}
+
+.search-input {
+  padding: 0.4rem 0.75rem;
+  background: #0d1117;
+  border: 1px solid #30363d;
+  border-radius: 6px;
+  color: #e6edf3;
+  font-size: 0.85rem;
+  min-width: 200px;
+}
+
+.search-input:focus {
+  outline: none;
+  border-color: #06b6d4;
+}
+
+/* Settings View */
+.settings-view {
+  padding: 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.settings-category {
+  background: #161b22;
+  border: 1px solid #30363d;
+  border-radius: 8px;
+  overflow: hidden;
+}
+
+.category-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 1rem;
+  cursor: pointer;
+  transition: background 0.15s;
+}
+
+.category-header:hover {
+  background: #21262d;
+}
+
+.category-title {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  font-weight: 600;
+}
+
+.category-count-badge {
+  font-size: 0.75rem;
+  padding: 0.15rem 0.5rem;
+  background: #21262d;
+  border-radius: 10px;
+  color: #8b949e;
+}
+
+.expand-icon {
+  color: #6b7280;
+  font-size: 0.75rem;
+}
+
+.settings-list {
+  border-top: 1px solid #21262d;
+  background: #0d1117;
+}
+
+.setting-item {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  padding: 0.75rem 1rem;
+  border-bottom: 1px solid #21262d;
+  gap: 1rem;
+}
+
+.setting-item:last-child {
+  border-bottom: none;
+}
+
+.setting-info {
+  flex: 1;
+  min-width: 0;
+}
+
+.setting-key {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
+.setting-key code {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.85rem;
+  color: #06b6d4;
+}
+
+.sensitive-badge {
+  font-size: 0.65rem;
+  padding: 0.1rem 0.4rem;
+  background: #d2992222;
+  color: #d29922;
+  border-radius: 4px;
+  text-transform: uppercase;
+  font-weight: 600;
+}
+
+.setting-description {
+  font-size: 0.8rem;
+  color: #8b949e;
+  margin-top: 0.25rem;
+}
+
+.setting-value-wrapper {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  flex-shrink: 0;
+}
+
+.setting-value {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.8rem;
+  background: #21262d;
+  padding: 0.25rem 0.5rem;
+  border-radius: 4px;
+  color: #e6edf3;
+  max-width: 300px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.reveal-btn,
+.copy-btn {
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  font-size: 0.9rem;
+  padding: 0.25rem;
+  opacity: 0.6;
+  transition: opacity 0.15s;
+}
+
+.reveal-btn:hover,
+.copy-btn:hover {
+  opacity: 1;
+}
+
+/* Env View */
+.env-view {
+  padding: 1.5rem;
+}
+
+.env-list {
+  background: #161b22;
+  border: 1px solid #30363d;
+  border-radius: 8px;
+  overflow: hidden;
+}
+
+.env-item {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 0.6rem 1rem;
+  border-bottom: 1px solid #21262d;
+  gap: 1rem;
+}
+
+.env-item:last-child {
+  border-bottom: none;
+}
+
+.env-key {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.env-key code {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.8rem;
+  color: #06b6d4;
+}
+
+.env-value-wrapper {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.env-value {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.75rem;
+  background: #21262d;
+  padding: 0.2rem 0.4rem;
+  border-radius: 4px;
+  color: #8b949e;
+  max-width: 400px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+/* Runtime View */
+.runtime-view {
+  padding: 1.5rem;
+}
+
+.runtime-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+  gap: 1rem;
+  margin-bottom: 1.5rem;
+}
+
+.runtime-card {
+  background: #161b22;
+  border: 1px solid #30363d;
+  border-radius: 8px;
+  padding: 1rem;
+  text-align: center;
+}
+
+.runtime-icon {
+  font-size: 1.5rem;
+  margin-bottom: 0.5rem;
+}
+
+.runtime-label {
+  font-size: 0.7rem;
+  color: #8b949e;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  margin-bottom: 0.25rem;
+}
+
+.runtime-value {
+  font-size: 0.9rem;
+  font-weight: 600;
+  color: #e6edf3;
+}
+
+.runtime-details {
+  background: #161b22;
+  border: 1px solid #30363d;
+  border-radius: 8px;
+  padding: 1rem;
+}
+
+.detail-row {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  padding: 0.5rem 0;
+  border-bottom: 1px solid #21262d;
+}
+
+.detail-row:last-child {
+  border-bottom: none;
+}
+
+.detail-label {
+  font-size: 0.75rem;
+  color: #8b949e;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+
+.detail-value {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.85rem;
+  color: #e6edf3;
+  word-break: break-all;
+}
+
+.detail-value.small {
+  font-size: 0.75rem;
+  color: #8b949e;
+}
+
+/* Validation View */
+.validation-view {
+  padding: 1.5rem;
+}
+
+.validation-status {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  padding: 1.5rem;
+  background: #161b22;
+  border: 1px solid #30363d;
+  border-radius: 8px;
+  margin-bottom: 1.5rem;
+}
+
+.validation-status.valid {
+  border-color: #22c55e55;
+  background: #22c55e11;
+}
+
+.validation-status.invalid {
+  border-color: #f8514955;
+  background: #f8514911;
+}
+
+.status-icon {
+  font-size: 2rem;
+}
+
+.status-text {
+  font-size: 1.1rem;
+  font-weight: 600;
+}
+
+.validation-section {
+  margin-bottom: 1.5rem;
+}
+
+.validation-section h3 {
+  font-size: 0.9rem;
+  font-weight: 600;
+  color: #8b949e;
+  margin-bottom: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+
+.validation-items {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.validation-item {
+  background: #161b22;
+  border: 1px solid #30363d;
+  border-left: 3px solid;
+  border-radius: 0 6px 6px 0;
+  padding: 0.75rem 1rem;
+}
+
+.validation-item-header {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  margin-bottom: 0.25rem;
+}
+
+.validation-key {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.85rem;
+  background: #21262d;
+  padding: 0.15rem 0.4rem;
+  border-radius: 3px;
+}
+
+.severity-badge {
+  font-size: 0.65rem;
+  font-weight: 600;
+  padding: 0.15rem 0.4rem;
+  border-radius: 4px;
+  text-transform: uppercase;
+}
+
+.validation-message {
+  font-size: 0.85rem;
+  color: #e6edf3;
+}
+
+.no-issues {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 3rem;
+  background: #161b22;
+  border: 1px solid #30363d;
+  border-radius: 8px;
+  color: #8b949e;
+}
+
+.no-issues-icon {
+  font-size: 3rem;
+  margin-bottom: 1rem;
+}
+
+/* No Data */
+.no-data {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  min-height: 200px;
+  color: #6b7280;
+}
+
+/* Responsive */
+@media (max-width: 768px) {
+  .stats-row {
+    flex-wrap: nowrap;
+    overflow-x: auto;
+  }
+
+  .controls-row {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .view-toggle {
+    width: 100%;
+  }
+
+  .view-toggle button {
+    flex: 1;
+  }
+
+  .search-input {
+    min-width: 100%;
+  }
+
+  .setting-item {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .setting-value-wrapper {
+    width: 100%;
+  }
+
+  .setting-value {
+    max-width: 100%;
+    flex: 1;
+  }
+
+  .env-item {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .env-value {
+    max-width: 100%;
+  }
+
+  .runtime-grid {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}

--- a/web/src/pages/EnvConfig.tsx
+++ b/web/src/pages/EnvConfig.tsx
@@ -1,0 +1,618 @@
+/**
+ * Environment Config Viewer - View application configuration
+ *
+ * Features:
+ * - View application settings by category
+ * - Environment variables display
+ * - Runtime information
+ * - Configuration validation
+ * - Reveal sensitive values (with warning)
+ */
+
+import { useState, useEffect, useCallback } from 'react';
+import './EnvConfig.css';
+
+const API_BASE = 'http://localhost:8000/api/config';
+
+interface ConfigValue {
+  key: string;
+  value: string;
+  category: string;
+  is_sensitive: boolean;
+  is_default?: boolean;
+  description?: string;
+}
+
+interface EnvVar {
+  key: string;
+  value: string;
+  is_sensitive: boolean;
+}
+
+interface RuntimeInfo {
+  python_version: string;
+  platform: string;
+  platform_release: string;
+  platform_version: string;
+  architecture: string;
+  hostname: string;
+  cpu_count: number | null;
+  pid: number;
+  cwd: string;
+  start_time: string;
+}
+
+interface ValidationResult {
+  valid: boolean;
+  issues: Array<{ key: string; message: string; severity: string }>;
+  warnings: Array<{ key: string; message: string; severity: string }>;
+  total_issues: number;
+  total_warnings: number;
+}
+
+interface ConfigStats {
+  total_settings: number;
+  total_env_vars: number;
+  sensitive_count: number;
+  categories: Record<string, number>;
+}
+
+interface ConnectionStrings {
+  database_url: string;
+  database_url_sync: string;
+  redis_url: string;
+}
+
+const CATEGORY_ICONS: Record<string, string> = {
+  Application: '📱',
+  Server: '🖥️',
+  Database: '🗄️',
+  Redis: '⚡',
+  Authentication: '🔐',
+};
+
+const SEVERITY_COLORS: Record<string, string> = {
+  error: '#f85149',
+  warning: '#d29922',
+  info: '#3b82f6',
+};
+
+export function EnvConfig() {
+  const [settings, setSettings] = useState<ConfigValue[]>([]);
+  const [envVars, setEnvVars] = useState<EnvVar[]>([]);
+  const [runtime, setRuntime] = useState<RuntimeInfo | null>(null);
+  const [validation, setValidation] = useState<ValidationResult | null>(null);
+  const [stats, setStats] = useState<ConfigStats | null>(null);
+  const [connections, setConnections] = useState<ConnectionStrings | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  // View state
+  const [view, setView] = useState<'settings' | 'env' | 'runtime' | 'validation'>('settings');
+  const [searchQuery, setSearchQuery] = useState('');
+  const [expandedCategory, setExpandedCategory] = useState<string | null>('Application');
+
+  // Reveal state
+  const [revealedKeys, setRevealedKeys] = useState<Set<string>>(new Set());
+  const [revealedValues, setRevealedValues] = useState<Record<string, string>>({});
+
+  // Fetch settings
+  const fetchSettings = useCallback(async () => {
+    try {
+      const res = await fetch(API_BASE);
+      if (res.ok) {
+        const data = await res.json();
+        setSettings(data.settings);
+      }
+    } catch {
+      // Silently fail
+    }
+  }, []);
+
+  // Fetch env vars
+  const fetchEnvVars = useCallback(async () => {
+    try {
+      const res = await fetch(`${API_BASE}/env`);
+      if (res.ok) {
+        const data = await res.json();
+        setEnvVars(data.env_vars);
+      }
+    } catch {
+      // Silently fail
+    }
+  }, []);
+
+  // Fetch runtime
+  const fetchRuntime = useCallback(async () => {
+    try {
+      const res = await fetch(`${API_BASE}/runtime`);
+      if (res.ok) {
+        const data = await res.json();
+        setRuntime(data);
+      }
+    } catch {
+      // Silently fail
+    }
+  }, []);
+
+  // Fetch validation
+  const fetchValidation = useCallback(async () => {
+    try {
+      const res = await fetch(`${API_BASE}/validate`);
+      if (res.ok) {
+        const data = await res.json();
+        setValidation(data);
+      }
+    } catch {
+      // Silently fail
+    }
+  }, []);
+
+  // Fetch stats
+  const fetchStats = useCallback(async () => {
+    try {
+      const res = await fetch(`${API_BASE}/stats`);
+      if (res.ok) {
+        const data = await res.json();
+        setStats(data);
+      }
+    } catch {
+      // Silently fail
+    }
+  }, []);
+
+  // Fetch connections
+  const fetchConnections = useCallback(async () => {
+    try {
+      const res = await fetch(`${API_BASE}/connections`);
+      if (res.ok) {
+        const data = await res.json();
+        setConnections(data);
+      }
+    } catch {
+      // Silently fail
+    }
+  }, []);
+
+  // Initial fetch
+  useEffect(() => {
+    const loadData = async () => {
+      setLoading(true);
+      await Promise.all([
+        fetchSettings(),
+        fetchEnvVars(),
+        fetchRuntime(),
+        fetchValidation(),
+        fetchStats(),
+        fetchConnections(),
+      ]);
+      setLoading(false);
+    };
+    loadData();
+  }, [fetchSettings, fetchEnvVars, fetchRuntime, fetchValidation, fetchStats, fetchConnections]);
+
+  // Reveal sensitive value
+  const revealValue = async (key: string) => {
+    if (revealedKeys.has(key)) {
+      // Hide it
+      const newRevealed = new Set(revealedKeys);
+      newRevealed.delete(key);
+      setRevealedKeys(newRevealed);
+      return;
+    }
+
+    try {
+      const res = await fetch(`${API_BASE}/reveal/${key}`, { method: 'POST' });
+      if (res.ok) {
+        const data = await res.json();
+        setRevealedValues({ ...revealedValues, [key]: data.value });
+        setRevealedKeys(new Set([...revealedKeys, key]));
+      }
+    } catch {
+      // Silently fail
+    }
+  };
+
+  // Copy to clipboard
+  const copyToClipboard = (text: string) => {
+    navigator.clipboard.writeText(text);
+  };
+
+  // Group settings by category
+  const settingsByCategory = settings.reduce((acc, setting) => {
+    if (!acc[setting.category]) {
+      acc[setting.category] = [];
+    }
+    acc[setting.category].push(setting);
+    return acc;
+  }, {} as Record<string, ConfigValue[]>);
+
+  // Filter env vars
+  const filteredEnvVars = envVars.filter(
+    (v) =>
+      v.key.toLowerCase().includes(searchQuery.toLowerCase()) ||
+      v.value.toLowerCase().includes(searchQuery.toLowerCase())
+  );
+
+  if (loading) {
+    return (
+      <div className="env-config">
+        <div className="config-loading">
+          <div className="loading-spinner" />
+          <p>Loading configuration...</p>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="env-config">
+      {/* Header */}
+      <header className="config-header">
+        <div className="header-left">
+          <h1>Environment Config</h1>
+          {validation && (
+            <span className={`header-badge ${validation.valid ? 'valid' : 'invalid'}`}>
+              {validation.valid ? 'Valid' : `${validation.total_issues} issues`}
+            </span>
+          )}
+        </div>
+        <div className="header-right">
+          <span className="config-count">
+            {stats?.total_settings || 0} settings
+          </span>
+        </div>
+      </header>
+
+      {/* Stats Cards */}
+      {stats && (
+        <div className="stats-row">
+          <div className="stat-card">
+            <div className="stat-value">{stats.total_settings}</div>
+            <div className="stat-label">Settings</div>
+          </div>
+          <div className="stat-card">
+            <div className="stat-value">{stats.total_env_vars}</div>
+            <div className="stat-label">Env Vars</div>
+          </div>
+          <div className="stat-card sensitive">
+            <div className="stat-value">{stats.sensitive_count}</div>
+            <div className="stat-label">Sensitive</div>
+          </div>
+          <div className="stat-card categories">
+            <div className="category-items">
+              {Object.entries(stats.categories).map(([cat, count]) => (
+                <div key={cat} className="category-item">
+                  <span className="category-icon">{CATEGORY_ICONS[cat] || '📁'}</span>
+                  <span className="category-count">{count}</span>
+                </div>
+              ))}
+            </div>
+            <div className="stat-label">By Category</div>
+          </div>
+        </div>
+      )}
+
+      {/* View Toggle */}
+      <div className="controls-row">
+        <div className="view-toggle">
+          <button
+            className={view === 'settings' ? 'active' : ''}
+            onClick={() => setView('settings')}
+          >
+            Settings
+          </button>
+          <button
+            className={view === 'env' ? 'active' : ''}
+            onClick={() => setView('env')}
+          >
+            Environment
+          </button>
+          <button
+            className={view === 'runtime' ? 'active' : ''}
+            onClick={() => setView('runtime')}
+          >
+            Runtime
+          </button>
+          <button
+            className={view === 'validation' ? 'active' : ''}
+            onClick={() => setView('validation')}
+          >
+            Validation
+          </button>
+        </div>
+
+        {view === 'env' && (
+          <input
+            type="text"
+            placeholder="Search env vars..."
+            value={searchQuery}
+            onChange={(e) => setSearchQuery(e.target.value)}
+            className="search-input"
+          />
+        )}
+      </div>
+
+      {/* Settings View */}
+      {view === 'settings' && (
+        <div className="settings-view">
+          {Object.entries(settingsByCategory).map(([category, categorySettings]) => (
+            <div key={category} className="settings-category">
+              <div
+                className="category-header"
+                onClick={() => setExpandedCategory(
+                  expandedCategory === category ? null : category
+                )}
+              >
+                <div className="category-title">
+                  <span className="category-icon">{CATEGORY_ICONS[category] || '📁'}</span>
+                  <span>{category}</span>
+                  <span className="category-count-badge">{categorySettings.length}</span>
+                </div>
+                <span className="expand-icon">
+                  {expandedCategory === category ? '▼' : '▶'}
+                </span>
+              </div>
+
+              {expandedCategory === category && (
+                <div className="settings-list">
+                  {categorySettings.map((setting) => (
+                    <div key={setting.key} className="setting-item">
+                      <div className="setting-info">
+                        <div className="setting-key">
+                          <code>{setting.key}</code>
+                          {setting.is_sensitive && (
+                            <span className="sensitive-badge">sensitive</span>
+                          )}
+                        </div>
+                        {setting.description && (
+                          <div className="setting-description">{setting.description}</div>
+                        )}
+                      </div>
+                      <div className="setting-value-wrapper">
+                        <code className="setting-value">
+                          {setting.is_sensitive && revealedKeys.has(setting.key)
+                            ? revealedValues[setting.key]
+                            : setting.value}
+                        </code>
+                        {setting.is_sensitive && (
+                          <button
+                            className="reveal-btn"
+                            onClick={() => revealValue(setting.key)}
+                            title={revealedKeys.has(setting.key) ? 'Hide' : 'Reveal'}
+                          >
+                            {revealedKeys.has(setting.key) ? '🙈' : '👁'}
+                          </button>
+                        )}
+                        <button
+                          className="copy-btn"
+                          onClick={() => copyToClipboard(
+                            setting.is_sensitive && revealedKeys.has(setting.key)
+                              ? revealedValues[setting.key]
+                              : setting.value
+                          )}
+                          title="Copy"
+                        >
+                          📋
+                        </button>
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              )}
+            </div>
+          ))}
+
+          {/* Connection Strings */}
+          {connections && (
+            <div className="settings-category">
+              <div
+                className="category-header"
+                onClick={() => setExpandedCategory(
+                  expandedCategory === 'Connections' ? null : 'Connections'
+                )}
+              >
+                <div className="category-title">
+                  <span className="category-icon">🔗</span>
+                  <span>Connection Strings</span>
+                  <span className="category-count-badge">3</span>
+                </div>
+                <span className="expand-icon">
+                  {expandedCategory === 'Connections' ? '▼' : '▶'}
+                </span>
+              </div>
+
+              {expandedCategory === 'Connections' && (
+                <div className="settings-list">
+                  {Object.entries(connections).map(([key, value]) => (
+                    <div key={key} className="setting-item">
+                      <div className="setting-info">
+                        <div className="setting-key">
+                          <code>{key}</code>
+                          <span className="sensitive-badge">sensitive</span>
+                        </div>
+                      </div>
+                      <div className="setting-value-wrapper">
+                        <code className="setting-value">
+                          {revealedKeys.has(key) ? revealedValues[key] : value}
+                        </code>
+                        <button
+                          className="reveal-btn"
+                          onClick={() => revealValue(key)}
+                          title={revealedKeys.has(key) ? 'Hide' : 'Reveal'}
+                        >
+                          {revealedKeys.has(key) ? '🙈' : '👁'}
+                        </button>
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              )}
+            </div>
+          )}
+        </div>
+      )}
+
+      {/* Environment View */}
+      {view === 'env' && (
+        <div className="env-view">
+          {filteredEnvVars.length === 0 ? (
+            <div className="no-data">
+              <p>No environment variables found</p>
+            </div>
+          ) : (
+            <div className="env-list">
+              {filteredEnvVars.map((envVar) => (
+                <div key={envVar.key} className="env-item">
+                  <div className="env-key">
+                    <code>{envVar.key}</code>
+                    {envVar.is_sensitive && (
+                      <span className="sensitive-badge">sensitive</span>
+                    )}
+                  </div>
+                  <div className="env-value-wrapper">
+                    <code className="env-value">{envVar.value}</code>
+                    <button
+                      className="copy-btn"
+                      onClick={() => copyToClipboard(envVar.value)}
+                      title="Copy"
+                    >
+                      📋
+                    </button>
+                  </div>
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+      )}
+
+      {/* Runtime View */}
+      {view === 'runtime' && runtime && (
+        <div className="runtime-view">
+          <div className="runtime-grid">
+            <div className="runtime-card">
+              <div className="runtime-icon">🐍</div>
+              <div className="runtime-label">Python Version</div>
+              <div className="runtime-value">{runtime.python_version.split(' ')[0]}</div>
+            </div>
+            <div className="runtime-card">
+              <div className="runtime-icon">💻</div>
+              <div className="runtime-label">Platform</div>
+              <div className="runtime-value">{runtime.platform} {runtime.platform_release}</div>
+            </div>
+            <div className="runtime-card">
+              <div className="runtime-icon">🏗️</div>
+              <div className="runtime-label">Architecture</div>
+              <div className="runtime-value">{runtime.architecture}</div>
+            </div>
+            <div className="runtime-card">
+              <div className="runtime-icon">🖥️</div>
+              <div className="runtime-label">Hostname</div>
+              <div className="runtime-value">{runtime.hostname}</div>
+            </div>
+            <div className="runtime-card">
+              <div className="runtime-icon">⚙️</div>
+              <div className="runtime-label">CPU Cores</div>
+              <div className="runtime-value">{runtime.cpu_count || 'Unknown'}</div>
+            </div>
+            <div className="runtime-card">
+              <div className="runtime-icon">🔢</div>
+              <div className="runtime-label">Process ID</div>
+              <div className="runtime-value">{runtime.pid}</div>
+            </div>
+          </div>
+
+          <div className="runtime-details">
+            <div className="detail-row">
+              <span className="detail-label">Working Directory</span>
+              <code className="detail-value">{runtime.cwd}</code>
+            </div>
+            <div className="detail-row">
+              <span className="detail-label">Platform Version</span>
+              <code className="detail-value small">{runtime.platform_version}</code>
+            </div>
+            <div className="detail-row">
+              <span className="detail-label">Full Python Version</span>
+              <code className="detail-value small">{runtime.python_version}</code>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* Validation View */}
+      {view === 'validation' && validation && (
+        <div className="validation-view">
+          <div className={`validation-status ${validation.valid ? 'valid' : 'invalid'}`}>
+            <div className="status-icon">{validation.valid ? '✅' : '⚠️'}</div>
+            <div className="status-text">
+              {validation.valid
+                ? 'Configuration is valid'
+                : `${validation.total_issues} issue(s) found`}
+            </div>
+          </div>
+
+          {validation.issues.length > 0 && (
+            <div className="validation-section">
+              <h3>Issues</h3>
+              <div className="validation-items">
+                {validation.issues.map((issue, i) => (
+                  <div
+                    key={i}
+                    className="validation-item"
+                    style={{ borderLeftColor: SEVERITY_COLORS[issue.severity] }}
+                  >
+                    <div className="validation-item-header">
+                      <code className="validation-key">{issue.key}</code>
+                      <span
+                        className="severity-badge"
+                        style={{ background: SEVERITY_COLORS[issue.severity] + '22', color: SEVERITY_COLORS[issue.severity] }}
+                      >
+                        {issue.severity}
+                      </span>
+                    </div>
+                    <div className="validation-message">{issue.message}</div>
+                  </div>
+                ))}
+              </div>
+            </div>
+          )}
+
+          {validation.warnings.length > 0 && (
+            <div className="validation-section">
+              <h3>Warnings</h3>
+              <div className="validation-items">
+                {validation.warnings.map((warning, i) => (
+                  <div
+                    key={i}
+                    className="validation-item"
+                    style={{ borderLeftColor: SEVERITY_COLORS[warning.severity] }}
+                  >
+                    <div className="validation-item-header">
+                      <code className="validation-key">{warning.key}</code>
+                      <span
+                        className="severity-badge"
+                        style={{ background: SEVERITY_COLORS[warning.severity] + '22', color: SEVERITY_COLORS[warning.severity] }}
+                      >
+                        {warning.severity}
+                      </span>
+                    </div>
+                    <div className="validation-message">{warning.message}</div>
+                  </div>
+                ))}
+              </div>
+            </div>
+          )}
+
+          {validation.issues.length === 0 && validation.warnings.length === 0 && (
+            <div className="no-issues">
+              <div className="no-issues-icon">🎉</div>
+              <p>No issues or warnings found</p>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default EnvConfig;

--- a/web/src/pages/index.ts
+++ b/web/src/pages/index.ts
@@ -28,3 +28,4 @@ export { ErrorTracker } from './ErrorTracker';
 export { PerformanceProfiler } from './PerformanceProfiler';
 export { SessionInspector } from './SessionInspector';
 export { FeatureFlags } from './FeatureFlags';
+export { EnvConfig } from './EnvConfig';


### PR DESCRIPTION
## Summary
- Backend API for viewing application configuration
- Settings organized by category (Application, Server, Database, Redis, Auth)
- Sensitive values masked by default with reveal button
- Environment variables display (system vars hidden)
- Runtime info (Python version, platform, CPU, etc.)
- Configuration validation with issues and warnings
- Connection strings viewer (database URL, Redis URL)

## Test plan
- [ ] Navigate to Dev Tools > Env Config
- [ ] Verify settings display in collapsible categories
- [ ] Click reveal button to show sensitive values
- [ ] Switch to Environment tab and search env vars
- [ ] Check Runtime tab for system info
- [ ] Review Validation tab for config issues/warnings
- [ ] Test copy to clipboard functionality

🤖 Generated with [Claude Code](https://claude.com/claude-code)