### PR TITLE
feat(dev-tools): add Dependency Viewer

### DIFF
--- a/server/app/api/dependencies.py
+++ b/server/app/api/dependencies.py
@@ -1,0 +1,331 @@
+"""
+Dependency Viewer API - View project dependencies.
+
+Features:
+- Python dependencies from requirements.txt
+- Frontend dependencies from package.json
+- Categorized by type (production, dev, etc.)
+- Version information and descriptions
+"""
+
+import json
+import re
+from pathlib import Path
+from typing import Optional
+
+from fastapi import APIRouter, Depends
+from pydantic import BaseModel
+
+from ..api.dbexplorer import require_debug
+
+router = APIRouter(prefix="/api/dependencies", tags=["dependencies"])
+
+# Project root paths
+SERVER_ROOT = Path(__file__).parent.parent.parent
+PROJECT_ROOT = SERVER_ROOT.parent
+WEB_ROOT = PROJECT_ROOT / "web"
+
+
+class Dependency(BaseModel):
+    """A project dependency."""
+    name: str
+    version: str
+    required_version: Optional[str] = None
+    category: str
+    description: Optional[str] = None
+    homepage: Optional[str] = None
+    is_dev: bool = False
+
+
+class DependencyStats(BaseModel):
+    """Dependency statistics."""
+    python_total: int
+    python_categories: dict[str, int]
+    frontend_total: int
+    frontend_prod: int
+    frontend_dev: int
+
+
+# Python package descriptions
+PYTHON_DESCRIPTIONS = {
+    "fastapi": "Modern, fast web framework for building APIs",
+    "uvicorn": "Lightning-fast ASGI server",
+    "python-multipart": "Streaming multipart parser for Python",
+    "sqlalchemy": "Python SQL toolkit and ORM",
+    "asyncpg": "Fast PostgreSQL client library for Python/asyncio",
+    "alembic": "Database migration tool for SQLAlchemy",
+    "redis": "Python client for Redis",
+    "python-jose": "JavaScript Object Signing and Encryption (JOSE)",
+    "passlib": "Comprehensive password hashing framework",
+    "bcrypt": "Modern password hashing library",
+    "pydantic": "Data validation using Python type hints",
+    "pydantic-settings": "Settings management with Pydantic",
+    "email-validator": "Email syntax and deliverability validation",
+    "websockets": "Library for building WebSocket servers and clients",
+    "psutil": "Cross-platform process and system monitoring",
+    "python-dotenv": "Read key-value pairs from .env file",
+}
+
+# Python package homepages
+PYTHON_HOMEPAGES = {
+    "fastapi": "https://fastapi.tiangolo.com/",
+    "uvicorn": "https://www.uvicorn.org/",
+    "sqlalchemy": "https://www.sqlalchemy.org/",
+    "alembic": "https://alembic.sqlalchemy.org/",
+    "redis": "https://redis.io/",
+    "pydantic": "https://docs.pydantic.dev/",
+    "websockets": "https://websockets.readthedocs.io/",
+    "psutil": "https://psutil.readthedocs.io/",
+}
+
+# Frontend package descriptions
+FRONTEND_DESCRIPTIONS = {
+    "react": "A JavaScript library for building user interfaces",
+    "react-dom": "React package for working with the DOM",
+    "react-router-dom": "Declarative routing for React web applications",
+    "three": "JavaScript 3D library",
+    "howler": "Audio library for the modern web",
+    "@xterm/xterm": "Terminal emulator for the web",
+    "@xterm/addon-fit": "Xterm.js addon to fit terminal to container",
+    "@xterm/addon-web-links": "Xterm.js addon for clickable web links",
+    "vite": "Next generation frontend tooling",
+    "typescript": "TypeScript language",
+    "eslint": "Pluggable JavaScript linter",
+    "sass": "Mature, stable CSS extension language",
+}
+
+# Frontend package homepages
+FRONTEND_HOMEPAGES = {
+    "react": "https://react.dev/",
+    "react-router-dom": "https://reactrouter.com/",
+    "three": "https://threejs.org/",
+    "howler": "https://howlerjs.com/",
+    "vite": "https://vitejs.dev/",
+    "typescript": "https://www.typescriptlang.org/",
+    "eslint": "https://eslint.org/",
+}
+
+
+def parse_requirements_txt() -> list[Dependency]:
+    """Parse Python dependencies from requirements.txt."""
+    requirements_path = SERVER_ROOT / "requirements.txt"
+    deps = []
+    current_category = "General"
+
+    if not requirements_path.exists():
+        return deps
+
+    content = requirements_path.read_text()
+
+    for line in content.split("\n"):
+        line = line.strip()
+
+        # Skip empty lines
+        if not line:
+            continue
+
+        # Category comment
+        if line.startswith("#"):
+            category = line.lstrip("#").strip()
+            if category:
+                current_category = category
+            continue
+
+        # Parse package line
+        # Handle formats: package==version, package[extras]==version, package>=version
+        match = re.match(r'^([a-zA-Z0-9_-]+)(?:\[[^\]]+\])?(?:([=<>!]+)(.+))?', line)
+        if match:
+            name = match.group(1)
+            version = match.group(3) if match.group(3) else "any"
+
+            deps.append(Dependency(
+                name=name,
+                version=version,
+                required_version=version,
+                category=current_category,
+                description=PYTHON_DESCRIPTIONS.get(name),
+                homepage=PYTHON_HOMEPAGES.get(name),
+                is_dev="Development" in current_category or "dev" in current_category.lower(),
+            ))
+
+    return deps
+
+
+def parse_package_json() -> list[Dependency]:
+    """Parse frontend dependencies from package.json."""
+    package_path = WEB_ROOT / "package.json"
+    deps = []
+
+    if not package_path.exists():
+        return deps
+
+    try:
+        content = json.loads(package_path.read_text())
+    except json.JSONDecodeError:
+        return deps
+
+    # Production dependencies
+    for name, version in content.get("dependencies", {}).items():
+        clean_version = version.lstrip("^~>=<")
+        clean_name = name.lstrip("@").replace("/", "-")
+
+        deps.append(Dependency(
+            name=name,
+            version=clean_version,
+            required_version=version,
+            category="Production",
+            description=FRONTEND_DESCRIPTIONS.get(name) or FRONTEND_DESCRIPTIONS.get(clean_name),
+            homepage=FRONTEND_HOMEPAGES.get(name) or FRONTEND_HOMEPAGES.get(clean_name),
+            is_dev=False,
+        ))
+
+    # Dev dependencies
+    for name, version in content.get("devDependencies", {}).items():
+        clean_version = version.lstrip("^~>=<")
+        clean_name = name.lstrip("@").replace("/", "-")
+
+        deps.append(Dependency(
+            name=name,
+            version=clean_version,
+            required_version=version,
+            category="Development",
+            description=FRONTEND_DESCRIPTIONS.get(name) or FRONTEND_DESCRIPTIONS.get(clean_name),
+            homepage=FRONTEND_HOMEPAGES.get(name) or FRONTEND_HOMEPAGES.get(clean_name),
+            is_dev=True,
+        ))
+
+    return deps
+
+
+@router.get("")
+async def get_all_dependencies(_: None = Depends(require_debug)):
+    """Get all project dependencies."""
+    python_deps = parse_requirements_txt()
+    frontend_deps = parse_package_json()
+
+    return {
+        "python": [d.model_dump() for d in python_deps],
+        "frontend": [d.model_dump() for d in frontend_deps],
+        "python_count": len(python_deps),
+        "frontend_count": len(frontend_deps),
+    }
+
+
+@router.get("/python")
+async def get_python_dependencies(_: None = Depends(require_debug)):
+    """Get Python dependencies from requirements.txt."""
+    deps = parse_requirements_txt()
+
+    # Group by category
+    by_category: dict[str, list] = {}
+    for dep in deps:
+        if dep.category not in by_category:
+            by_category[dep.category] = []
+        by_category[dep.category].append(dep.model_dump())
+
+    return {
+        "dependencies": [d.model_dump() for d in deps],
+        "by_category": by_category,
+        "total": len(deps),
+        "categories": list(by_category.keys()),
+    }
+
+
+@router.get("/frontend")
+async def get_frontend_dependencies(_: None = Depends(require_debug)):
+    """Get frontend dependencies from package.json."""
+    deps = parse_package_json()
+
+    prod = [d.model_dump() for d in deps if not d.is_dev]
+    dev = [d.model_dump() for d in deps if d.is_dev]
+
+    return {
+        "dependencies": [d.model_dump() for d in deps],
+        "production": prod,
+        "development": dev,
+        "total": len(deps),
+        "prod_count": len(prod),
+        "dev_count": len(dev),
+    }
+
+
+@router.get("/stats")
+async def get_dependency_stats(_: None = Depends(require_debug)):
+    """Get dependency statistics."""
+    python_deps = parse_requirements_txt()
+    frontend_deps = parse_package_json()
+
+    # Python categories
+    python_cats: dict[str, int] = {}
+    for dep in python_deps:
+        python_cats[dep.category] = python_cats.get(dep.category, 0) + 1
+
+    frontend_prod = sum(1 for d in frontend_deps if not d.is_dev)
+    frontend_dev = sum(1 for d in frontend_deps if d.is_dev)
+
+    return DependencyStats(
+        python_total=len(python_deps),
+        python_categories=python_cats,
+        frontend_total=len(frontend_deps),
+        frontend_prod=frontend_prod,
+        frontend_dev=frontend_dev,
+    )
+
+
+@router.get("/search")
+async def search_dependencies(
+    q: str,
+    _: None = Depends(require_debug),
+):
+    """Search dependencies by name."""
+    python_deps = parse_requirements_txt()
+    frontend_deps = parse_package_json()
+
+    q_lower = q.lower()
+
+    python_matches = [
+        d.model_dump() for d in python_deps
+        if q_lower in d.name.lower()
+    ]
+
+    frontend_matches = [
+        d.model_dump() for d in frontend_deps
+        if q_lower in d.name.lower()
+    ]
+
+    return {
+        "query": q,
+        "python": python_matches,
+        "frontend": frontend_matches,
+        "total": len(python_matches) + len(frontend_matches),
+    }
+
+
+@router.get("/files")
+async def get_dependency_files(_: None = Depends(require_debug)):
+    """Get raw dependency file contents."""
+    result = {}
+
+    # requirements.txt
+    requirements_path = SERVER_ROOT / "requirements.txt"
+    if requirements_path.exists():
+        result["requirements_txt"] = {
+            "path": str(requirements_path),
+            "content": requirements_path.read_text(),
+            "exists": True,
+        }
+    else:
+        result["requirements_txt"] = {"exists": False}
+
+    # package.json
+    package_path = WEB_ROOT / "package.json"
+    if package_path.exists():
+        result["package_json"] = {
+            "path": str(package_path),
+            "content": package_path.read_text(),
+            "exists": True,
+        }
+    else:
+        result["package_json"] = {"exists": False}
+
+    return result

--- a/server/app/main.py
+++ b/server/app/main.py
@@ -26,6 +26,7 @@ from .api.profiler import router as profiler_router, ProfilingMiddleware
 from .api.sessions import router as sessions_router
 from .api.flags import router as flags_router
 from .api.config import router as config_router
+from .api.dependencies import router as dependencies_router
 
 
 @asynccontextmanager
@@ -97,6 +98,7 @@ def create_app() -> FastAPI:
     app.include_router(sessions_router, tags=["dev-tools"])
     app.include_router(flags_router, tags=["dev-tools"])
     app.include_router(config_router, tags=["dev-tools"])
+    app.include_router(dependencies_router, tags=["dev-tools"])
 
     # Add exception handler to capture errors (only in debug mode)
     if settings.debug:

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,6 +1,6 @@
 import { Routes, Route } from 'react-router-dom';
 import { Layout } from './components/Layout';
-import { Home, Login, Register, Play, Features, About, PlayScene, SceneDemo, Leaderboard, Ghosts, Profile, Achievements, Spectate, Friends, Presentation, Roadmap, CodebaseHealth, Changelog, DatabaseExplorer, CacheInspector, AudioJukebox, SystemStatus, ApiPlayground, WebSocketMonitor, BuildInfo, LogViewer, ErrorTracker, PerformanceProfiler, SessionInspector, FeatureFlags, EnvConfig } from './pages';
+import { Home, Login, Register, Play, Features, About, PlayScene, SceneDemo, Leaderboard, Ghosts, Profile, Achievements, Spectate, Friends, Presentation, Roadmap, CodebaseHealth, Changelog, DatabaseExplorer, CacheInspector, AudioJukebox, SystemStatus, ApiPlayground, WebSocketMonitor, BuildInfo, LogViewer, ErrorTracker, PerformanceProfiler, SessionInspector, FeatureFlags, EnvConfig, DependencyViewer } from './pages';
 import { FirstPersonDemo } from './pages/FirstPersonDemo';
 import { FirstPersonTestPage } from './pages/FirstPersonTestPage';
 import { Debug3DPage } from './pages/Debug3DPage';
@@ -46,6 +46,7 @@ function App() {
         <Route path="session-inspector" element={<SessionInspector />} />
         <Route path="feature-flags" element={<FeatureFlags />} />
         <Route path="env-config" element={<EnvConfig />} />
+        <Route path="dependencies" element={<DependencyViewer />} />
       </Route>
     </Routes>
   );

--- a/web/src/components/Layout.tsx
+++ b/web/src/components/Layout.tsx
@@ -176,6 +176,10 @@ export function Layout() {
                     <span className="menu-icon">⚙️</span>
                     Env Config
                   </Link>
+                  <Link to="/dependencies" onClick={closeDropdown}>
+                    <span className="menu-icon">📦</span>
+                    Dependencies
+                  </Link>
                   <Link to="/codebase-health" onClick={closeDropdown}>
                     <span className="menu-icon">🩺</span>
                     Codebase Health

--- a/web/src/pages/DependencyViewer.css
+++ b/web/src/pages/DependencyViewer.css
@@ -1,0 +1,415 @@
+/**
+ * Dependency Viewer Styles - Orange/package theme
+ */
+
+.dependency-viewer {
+  min-height: 100vh;
+  background: #0d1117;
+  color: #e6edf3;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+}
+
+/* Loading State */
+.deps-loading {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  min-height: 60vh;
+  gap: 1rem;
+}
+
+.loading-spinner {
+  width: 40px;
+  height: 40px;
+  border: 3px solid #21262d;
+  border-top-color: #f97316;
+  border-radius: 50%;
+  animation: spin 1s linear infinite;
+}
+
+@keyframes spin {
+  to { transform: rotate(360deg); }
+}
+
+/* Header */
+.deps-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 1rem 1.5rem;
+  background: #161b22;
+  border-bottom: 1px solid #30363d;
+}
+
+.deps-header .header-left {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+}
+
+.deps-header h1 {
+  margin: 0;
+  font-size: 1.25rem;
+  font-weight: 600;
+}
+
+.header-badge {
+  font-size: 0.75rem;
+  font-weight: 600;
+  padding: 0.25rem 0.75rem;
+  background: #f9731622;
+  color: #f97316;
+  border-radius: 12px;
+}
+
+/* Stats Row */
+.stats-row {
+  display: flex;
+  gap: 1rem;
+  padding: 1rem 1.5rem;
+  background: #161b22;
+  border-bottom: 1px solid #21262d;
+  overflow-x: auto;
+}
+
+.stat-card {
+  flex: 1;
+  min-width: 90px;
+  background: #0d1117;
+  border: 1px solid #30363d;
+  border-radius: 8px;
+  padding: 0.75rem 1rem;
+  text-align: center;
+}
+
+.stat-card.python {
+  border-color: #3b82f655;
+}
+
+.stat-card.python .stat-value {
+  color: #3b82f6;
+}
+
+.stat-card.frontend {
+  border-color: #06b6d455;
+}
+
+.stat-card.frontend .stat-value {
+  color: #06b6d4;
+}
+
+.stat-card.prod .stat-value {
+  color: #22c55e;
+}
+
+.stat-card.dev .stat-value {
+  color: #d29922;
+}
+
+.stat-icon {
+  font-size: 1.25rem;
+  margin-bottom: 0.25rem;
+}
+
+.stat-value {
+  font-size: 1.5rem;
+  font-weight: 700;
+  color: #e6edf3;
+}
+
+.stat-label {
+  font-size: 0.7rem;
+  color: #8b949e;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  margin-top: 0.25rem;
+}
+
+/* Controls Row */
+.controls-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 0.75rem 1.5rem;
+  background: #161b22;
+  border-bottom: 1px solid #21262d;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+.view-toggle {
+  display: flex;
+  gap: 0;
+}
+
+.view-toggle button {
+  padding: 0.5rem 1rem;
+  background: transparent;
+  border: 1px solid #30363d;
+  color: #8b949e;
+  font-size: 0.85rem;
+  cursor: pointer;
+  transition: all 0.15s;
+}
+
+.view-toggle button:first-child {
+  border-radius: 6px 0 0 6px;
+}
+
+.view-toggle button:last-child {
+  border-radius: 0 6px 6px 0;
+}
+
+.view-toggle button:not(:first-child) {
+  border-left: none;
+}
+
+.view-toggle button:hover {
+  color: #e6edf3;
+  background: #21262d;
+}
+
+.view-toggle button.active {
+  color: #f97316;
+  background: #f9731622;
+  border-color: #f9731655;
+}
+
+.filters {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+}
+
+.search-input {
+  padding: 0.4rem 0.75rem;
+  background: #0d1117;
+  border: 1px solid #30363d;
+  border-radius: 6px;
+  color: #e6edf3;
+  font-size: 0.85rem;
+  min-width: 200px;
+}
+
+.search-input:focus {
+  outline: none;
+  border-color: #f97316;
+}
+
+.dev-toggle {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.85rem;
+  color: #8b949e;
+  cursor: pointer;
+}
+
+.dev-toggle input {
+  accent-color: #f97316;
+}
+
+/* Content */
+.deps-content {
+  padding: 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+}
+
+.deps-section {
+  background: #161b22;
+  border: 1px solid #30363d;
+  border-radius: 8px;
+  overflow: hidden;
+}
+
+.section-header {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 1rem;
+  background: #21262d;
+  border-bottom: 1px solid #30363d;
+}
+
+.section-icon {
+  font-size: 1.25rem;
+}
+
+.section-header h2 {
+  margin: 0;
+  font-size: 1rem;
+  font-weight: 600;
+}
+
+.section-count {
+  font-size: 0.75rem;
+  padding: 0.15rem 0.5rem;
+  background: #0d1117;
+  border-radius: 10px;
+  color: #8b949e;
+  margin-left: auto;
+}
+
+/* Category Group */
+.category-group {
+  border-bottom: 1px solid #21262d;
+}
+
+.category-group:last-child {
+  border-bottom: none;
+}
+
+.category-title {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.75rem 1rem;
+  background: #161b22;
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: #e6edf3;
+}
+
+.category-icon {
+  font-size: 1rem;
+}
+
+.category-count {
+  font-size: 0.7rem;
+  padding: 0.1rem 0.4rem;
+  background: #21262d;
+  border-radius: 8px;
+  color: #8b949e;
+  margin-left: auto;
+}
+
+/* Dependencies Grid */
+.deps-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+  gap: 0.75rem;
+  padding: 1rem;
+  background: #0d1117;
+}
+
+.dep-card {
+  background: #161b22;
+  border: 1px solid #30363d;
+  border-radius: 6px;
+  padding: 0.75rem;
+  transition: all 0.15s;
+}
+
+.dep-card:hover {
+  border-color: #f9731655;
+}
+
+.dep-card.dev {
+  border-left: 3px solid #d29922;
+}
+
+.dep-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  margin-bottom: 0.5rem;
+}
+
+.dep-name {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: #f97316;
+  word-break: break-word;
+}
+
+.dep-version {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.75rem;
+  background: #21262d;
+  padding: 0.15rem 0.4rem;
+  border-radius: 4px;
+  color: #8b949e;
+  flex-shrink: 0;
+  margin-left: 0.5rem;
+}
+
+.dep-description {
+  font-size: 0.8rem;
+  color: #8b949e;
+  line-height: 1.4;
+  margin-bottom: 0.5rem;
+}
+
+.dep-footer {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.dev-badge {
+  font-size: 0.65rem;
+  font-weight: 600;
+  padding: 0.1rem 0.4rem;
+  background: #d2992222;
+  color: #d29922;
+  border-radius: 4px;
+  text-transform: uppercase;
+}
+
+.dep-link {
+  font-size: 0.75rem;
+  color: #3b82f6;
+  text-decoration: none;
+  margin-left: auto;
+}
+
+.dep-link:hover {
+  text-decoration: underline;
+}
+
+/* No Dependencies */
+.no-deps {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 2rem;
+  color: #6b7280;
+}
+
+/* Responsive */
+@media (max-width: 768px) {
+  .stats-row {
+    flex-wrap: nowrap;
+    overflow-x: auto;
+  }
+
+  .controls-row {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .view-toggle {
+    width: 100%;
+  }
+
+  .view-toggle button {
+    flex: 1;
+  }
+
+  .filters {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .search-input {
+    min-width: 100%;
+  }
+
+  .deps-grid {
+    grid-template-columns: 1fr;
+  }
+}

--- a/web/src/pages/DependencyViewer.tsx
+++ b/web/src/pages/DependencyViewer.tsx
@@ -1,0 +1,344 @@
+/**
+ * Dependency Viewer - View project dependencies
+ *
+ * Features:
+ * - Python dependencies from requirements.txt
+ * - Frontend dependencies from package.json
+ * - Categorized view
+ * - Search functionality
+ * - Version information
+ */
+
+import { useState, useEffect, useCallback } from 'react';
+import './DependencyViewer.css';
+
+const API_BASE = 'http://localhost:8000/api/dependencies';
+
+interface Dependency {
+  name: string;
+  version: string;
+  required_version?: string;
+  category: string;
+  description?: string;
+  homepage?: string;
+  is_dev: boolean;
+}
+
+interface DependencyStats {
+  python_total: number;
+  python_categories: Record<string, number>;
+  frontend_total: number;
+  frontend_prod: number;
+  frontend_dev: number;
+}
+
+const CATEGORY_ICONS: Record<string, string> = {
+  'FastAPI and server': '🚀',
+  'Database': '🗄️',
+  'Redis': '⚡',
+  'Authentication': '🔐',
+  'Validation': '✅',
+  'WebSockets': '🔌',
+  'System monitoring': '📊',
+  'Development': '🛠️',
+  'Production': '📦',
+  'General': '📁',
+};
+
+export function DependencyViewer() {
+  const [pythonDeps, setPythonDeps] = useState<Dependency[]>([]);
+  const [frontendDeps, setFrontendDeps] = useState<Dependency[]>([]);
+  const [stats, setStats] = useState<DependencyStats | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  // View state
+  const [view, setView] = useState<'python' | 'frontend' | 'all'>('all');
+  const [searchQuery, setSearchQuery] = useState('');
+  const [showDevOnly, setShowDevOnly] = useState(false);
+
+  // Fetch all dependencies
+  const fetchDependencies = useCallback(async () => {
+    try {
+      const res = await fetch(API_BASE);
+      if (res.ok) {
+        const data = await res.json();
+        setPythonDeps(data.python);
+        setFrontendDeps(data.frontend);
+      }
+    } catch {
+      // Silently fail
+    }
+  }, []);
+
+  // Fetch stats
+  const fetchStats = useCallback(async () => {
+    try {
+      const res = await fetch(`${API_BASE}/stats`);
+      if (res.ok) {
+        const data = await res.json();
+        setStats(data);
+      }
+    } catch {
+      // Silently fail
+    }
+  }, []);
+
+  // Initial fetch
+  useEffect(() => {
+    const loadData = async () => {
+      setLoading(true);
+      await Promise.all([fetchDependencies(), fetchStats()]);
+      setLoading(false);
+    };
+    loadData();
+  }, [fetchDependencies, fetchStats]);
+
+  // Filter dependencies
+  const filterDeps = (deps: Dependency[]) => {
+    let filtered = deps;
+
+    if (searchQuery) {
+      const query = searchQuery.toLowerCase();
+      filtered = filtered.filter(
+        (d) =>
+          d.name.toLowerCase().includes(query) ||
+          d.description?.toLowerCase().includes(query)
+      );
+    }
+
+    if (showDevOnly) {
+      filtered = filtered.filter((d) => d.is_dev);
+    }
+
+    return filtered;
+  };
+
+  // Group by category
+  const groupByCategory = (deps: Dependency[]) => {
+    return deps.reduce((acc, dep) => {
+      if (!acc[dep.category]) {
+        acc[dep.category] = [];
+      }
+      acc[dep.category].push(dep);
+      return acc;
+    }, {} as Record<string, Dependency[]>);
+  };
+
+  const filteredPython = filterDeps(pythonDeps);
+  const filteredFrontend = filterDeps(frontendDeps);
+
+  const pythonByCategory = groupByCategory(filteredPython);
+  const frontendByCategory = groupByCategory(filteredFrontend);
+
+  if (loading) {
+    return (
+      <div className="dependency-viewer">
+        <div className="deps-loading">
+          <div className="loading-spinner" />
+          <p>Loading dependencies...</p>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="dependency-viewer">
+      {/* Header */}
+      <header className="deps-header">
+        <div className="header-left">
+          <h1>Dependencies</h1>
+          <span className="header-badge">
+            {(stats?.python_total || 0) + (stats?.frontend_total || 0)} total
+          </span>
+        </div>
+      </header>
+
+      {/* Stats Cards */}
+      {stats && (
+        <div className="stats-row">
+          <div className="stat-card python">
+            <div className="stat-icon">🐍</div>
+            <div className="stat-value">{stats.python_total}</div>
+            <div className="stat-label">Python</div>
+          </div>
+          <div className="stat-card frontend">
+            <div className="stat-icon">⚛️</div>
+            <div className="stat-value">{stats.frontend_total}</div>
+            <div className="stat-label">Frontend</div>
+          </div>
+          <div className="stat-card prod">
+            <div className="stat-value">{stats.frontend_prod}</div>
+            <div className="stat-label">Production</div>
+          </div>
+          <div className="stat-card dev">
+            <div className="stat-value">{stats.frontend_dev}</div>
+            <div className="stat-label">Dev Only</div>
+          </div>
+          <div className="stat-card categories">
+            <div className="stat-value">
+              {Object.keys(stats.python_categories).length + 2}
+            </div>
+            <div className="stat-label">Categories</div>
+          </div>
+        </div>
+      )}
+
+      {/* Controls */}
+      <div className="controls-row">
+        <div className="view-toggle">
+          <button
+            className={view === 'all' ? 'active' : ''}
+            onClick={() => setView('all')}
+          >
+            All
+          </button>
+          <button
+            className={view === 'python' ? 'active' : ''}
+            onClick={() => setView('python')}
+          >
+            Python
+          </button>
+          <button
+            className={view === 'frontend' ? 'active' : ''}
+            onClick={() => setView('frontend')}
+          >
+            Frontend
+          </button>
+        </div>
+
+        <div className="filters">
+          <input
+            type="text"
+            placeholder="Search packages..."
+            value={searchQuery}
+            onChange={(e) => setSearchQuery(e.target.value)}
+            className="search-input"
+          />
+          <label className="dev-toggle">
+            <input
+              type="checkbox"
+              checked={showDevOnly}
+              onChange={(e) => setShowDevOnly(e.target.checked)}
+            />
+            Dev only
+          </label>
+        </div>
+      </div>
+
+      {/* Dependencies List */}
+      <div className="deps-content">
+        {/* Python Dependencies */}
+        {(view === 'all' || view === 'python') && (
+          <div className="deps-section">
+            <div className="section-header">
+              <span className="section-icon">🐍</span>
+              <h2>Python Dependencies</h2>
+              <span className="section-count">{filteredPython.length}</span>
+            </div>
+
+            {Object.keys(pythonByCategory).length === 0 ? (
+              <div className="no-deps">
+                <p>No Python dependencies found</p>
+              </div>
+            ) : (
+              Object.entries(pythonByCategory).map(([category, deps]) => (
+                <div key={category} className="category-group">
+                  <div className="category-title">
+                    <span className="category-icon">
+                      {CATEGORY_ICONS[category] || '📁'}
+                    </span>
+                    <span>{category}</span>
+                    <span className="category-count">{deps.length}</span>
+                  </div>
+                  <div className="deps-grid">
+                    {deps.map((dep) => (
+                      <div key={dep.name} className={`dep-card ${dep.is_dev ? 'dev' : ''}`}>
+                        <div className="dep-header">
+                          <span className="dep-name">{dep.name}</span>
+                          <span className="dep-version">{dep.version}</span>
+                        </div>
+                        {dep.description && (
+                          <div className="dep-description">{dep.description}</div>
+                        )}
+                        <div className="dep-footer">
+                          {dep.is_dev && <span className="dev-badge">dev</span>}
+                          {dep.homepage && (
+                            <a
+                              href={dep.homepage}
+                              target="_blank"
+                              rel="noopener noreferrer"
+                              className="dep-link"
+                            >
+                              Docs
+                            </a>
+                          )}
+                        </div>
+                      </div>
+                    ))}
+                  </div>
+                </div>
+              ))
+            )}
+          </div>
+        )}
+
+        {/* Frontend Dependencies */}
+        {(view === 'all' || view === 'frontend') && (
+          <div className="deps-section">
+            <div className="section-header">
+              <span className="section-icon">⚛️</span>
+              <h2>Frontend Dependencies</h2>
+              <span className="section-count">{filteredFrontend.length}</span>
+            </div>
+
+            {Object.keys(frontendByCategory).length === 0 ? (
+              <div className="no-deps">
+                <p>No frontend dependencies found</p>
+              </div>
+            ) : (
+              Object.entries(frontendByCategory).map(([category, deps]) => (
+                <div key={category} className="category-group">
+                  <div className="category-title">
+                    <span className="category-icon">
+                      {CATEGORY_ICONS[category] || '📁'}
+                    </span>
+                    <span>{category}</span>
+                    <span className="category-count">{deps.length}</span>
+                  </div>
+                  <div className="deps-grid">
+                    {deps.map((dep) => (
+                      <div key={dep.name} className={`dep-card ${dep.is_dev ? 'dev' : ''}`}>
+                        <div className="dep-header">
+                          <span className="dep-name">{dep.name}</span>
+                          <span className="dep-version">{dep.version}</span>
+                        </div>
+                        {dep.description && (
+                          <div className="dep-description">{dep.description}</div>
+                        )}
+                        <div className="dep-footer">
+                          {dep.is_dev && <span className="dev-badge">dev</span>}
+                          {dep.homepage && (
+                            <a
+                              href={dep.homepage}
+                              target="_blank"
+                              rel="noopener noreferrer"
+                              className="dep-link"
+                            >
+                              Docs
+                            </a>
+                          )}
+                        </div>
+                      </div>
+                    ))}
+                  </div>
+                </div>
+              ))
+            )}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export default DependencyViewer;

--- a/web/src/pages/index.ts
+++ b/web/src/pages/index.ts
@@ -29,3 +29,4 @@ export { PerformanceProfiler } from './PerformanceProfiler';
 export { SessionInspector } from './SessionInspector';
 export { FeatureFlags } from './FeatureFlags';
 export { EnvConfig } from './EnvConfig';
+export { DependencyViewer } from './DependencyViewer';


### PR DESCRIPTION
## Summary
- Backend API for parsing dependency files
- Python dependencies from requirements.txt with category grouping
- Frontend dependencies from package.json (prod/dev split)
- Package descriptions and documentation links
- Search and filter functionality
- Statistics overview (total, prod, dev counts)

## Test plan
- [ ] Navigate to Dev Tools > Dependencies
- [ ] Verify Python dependencies show with categories
- [ ] Verify frontend dependencies show production/dev split
- [ ] Test search by package name
- [ ] Toggle "Dev only" filter
- [ ] Switch between All/Python/Frontend views
- [ ] Click docs links to verify they work
- [ ] Check stats cards show correct counts

🤖 Generated with [Claude Code](https://claude.com/claude-code)