### PR TITLE
feat(dev-tools): add Route Explorer

### DIFF
--- a/server/app/api/routes.py
+++ b/server/app/api/routes.py
@@ -1,0 +1,308 @@
+"""
+Route Explorer API - View all application routes.
+
+Features:
+- List all FastAPI routes with methods and paths
+- Route details (parameters, response types, tags)
+- Group by tag/router
+- Search functionality
+"""
+
+from typing import Optional
+
+from fastapi import APIRouter, Depends, Request
+from pydantic import BaseModel
+
+from ..api.dbexplorer import require_debug
+
+router = APIRouter(prefix="/api/routes", tags=["routes"])
+
+
+class RouteInfo(BaseModel):
+    """Information about an API route."""
+    path: str
+    method: str
+    name: Optional[str] = None
+    summary: Optional[str] = None
+    description: Optional[str] = None
+    tags: list[str] = []
+    parameters: list[dict] = []
+    deprecated: bool = False
+
+
+class RouteStats(BaseModel):
+    """Route statistics."""
+    total_routes: int
+    by_method: dict[str, int]
+    by_tag: dict[str, int]
+    deprecated_count: int
+
+
+# Frontend routes (manually defined since we can't introspect React Router)
+FRONTEND_ROUTES = [
+    {"path": "/", "name": "Home", "description": "Landing page"},
+    {"path": "/features", "name": "Features", "description": "Game features overview"},
+    {"path": "/about", "name": "About", "description": "About the project"},
+    {"path": "/login", "name": "Login", "description": "User login page"},
+    {"path": "/register", "name": "Register", "description": "User registration"},
+    {"path": "/play", "name": "Play", "description": "Main game interface", "auth_required": True},
+    {"path": "/character-creation", "name": "Character Creation", "description": "Create new character"},
+    {"path": "/play-scene", "name": "Play Scene", "description": "3D game scene"},
+    {"path": "/scene-demo", "name": "Scene Demo", "description": "3D scene demonstration"},
+    {"path": "/first-person-demo", "name": "First Person Demo", "description": "First person view demo"},
+    {"path": "/first-person-test", "name": "First Person Test", "description": "First person testing"},
+    {"path": "/debug-3d", "name": "Debug 3D", "description": "3D debugging tools"},
+    {"path": "/spectate", "name": "Spectate", "description": "Watch other players"},
+    {"path": "/leaderboard", "name": "Leaderboard", "description": "High scores"},
+    {"path": "/ghosts", "name": "Ghosts", "description": "Ghost replays"},
+    {"path": "/profile", "name": "Profile", "description": "User profile"},
+    {"path": "/profile/:userId", "name": "User Profile", "description": "View other user profiles"},
+    {"path": "/achievements", "name": "Achievements", "description": "Achievement tracking"},
+    {"path": "/friends", "name": "Friends", "description": "Friends list", "auth_required": True},
+    {"path": "/presentation", "name": "Presentation", "description": "Project case study"},
+    {"path": "/roadmap", "name": "Roadmap", "description": "Development roadmap"},
+    {"path": "/codebase-health", "name": "Codebase Health", "description": "Code statistics"},
+    {"path": "/changelog", "name": "Changelog", "description": "Patch notes"},
+    {"path": "/db-explorer", "name": "DB Explorer", "description": "Database browser", "dev_tool": True},
+    {"path": "/cache-inspector", "name": "Cache Inspector", "description": "Cache viewer", "dev_tool": True},
+    {"path": "/audio-jukebox", "name": "Audio Jukebox", "description": "Sound testing", "dev_tool": True},
+    {"path": "/system-status", "name": "System Status", "description": "Service health", "dev_tool": True},
+    {"path": "/api-playground", "name": "API Playground", "description": "API testing", "dev_tool": True},
+    {"path": "/ws-monitor", "name": "WS Monitor", "description": "WebSocket monitor", "dev_tool": True},
+    {"path": "/build-info", "name": "Build Info", "description": "Build details", "dev_tool": True},
+    {"path": "/log-viewer", "name": "Log Viewer", "description": "Application logs", "dev_tool": True},
+    {"path": "/error-tracker", "name": "Error Tracker", "description": "Error monitoring", "dev_tool": True},
+    {"path": "/profiler", "name": "Profiler", "description": "Performance profiling", "dev_tool": True},
+    {"path": "/session-inspector", "name": "Sessions", "description": "Session management", "dev_tool": True},
+    {"path": "/feature-flags", "name": "Feature Flags", "description": "Feature toggles", "dev_tool": True},
+    {"path": "/env-config", "name": "Env Config", "description": "Configuration viewer", "dev_tool": True},
+    {"path": "/dependencies", "name": "Dependencies", "description": "Package dependencies", "dev_tool": True},
+    {"path": "/routes", "name": "Route Explorer", "description": "API routes viewer", "dev_tool": True},
+]
+
+
+def get_all_routes(app) -> list[RouteInfo]:
+    """Extract all routes from the FastAPI application."""
+    routes = []
+
+    for route in app.routes:
+        # Skip non-API routes
+        if not hasattr(route, 'methods'):
+            continue
+
+        path = route.path
+        methods = list(route.methods - {'HEAD', 'OPTIONS'})
+
+        for method in methods:
+            # Get route info
+            name = route.name if hasattr(route, 'name') else None
+            summary = None
+            description = None
+            tags = []
+            deprecated = False
+            parameters = []
+
+            # Extract from endpoint if available
+            if hasattr(route, 'endpoint'):
+                endpoint = route.endpoint
+                if hasattr(endpoint, '__doc__') and endpoint.__doc__:
+                    description = endpoint.__doc__.strip()
+
+            # Extract tags from route
+            if hasattr(route, 'tags'):
+                tags = list(route.tags) if route.tags else []
+
+            # Extract path parameters
+            if hasattr(route, 'param_convertors'):
+                for param_name, convertor in route.param_convertors.items():
+                    parameters.append({
+                        "name": param_name,
+                        "in": "path",
+                        "type": convertor.__class__.__name__.replace('Convertor', '').lower(),
+                    })
+
+            routes.append(RouteInfo(
+                path=path,
+                method=method,
+                name=name,
+                summary=summary,
+                description=description,
+                tags=tags,
+                parameters=parameters,
+                deprecated=deprecated,
+            ))
+
+    # Sort by path, then method
+    routes.sort(key=lambda r: (r.path, r.method))
+
+    return routes
+
+
+@router.get("")
+async def get_routes(
+    request: Request,
+    _: None = Depends(require_debug),
+    tag: Optional[str] = None,
+    method: Optional[str] = None,
+    search: Optional[str] = None,
+):
+    """Get all API routes."""
+    app = request.app
+    routes = get_all_routes(app)
+
+    # Filter by tag
+    if tag:
+        routes = [r for r in routes if tag in r.tags]
+
+    # Filter by method
+    if method:
+        routes = [r for r in routes if r.method.upper() == method.upper()]
+
+    # Search
+    if search:
+        search_lower = search.lower()
+        routes = [
+            r for r in routes
+            if search_lower in r.path.lower()
+            or (r.name and search_lower in r.name.lower())
+            or (r.description and search_lower in r.description.lower())
+        ]
+
+    return {
+        "routes": [r.model_dump() for r in routes],
+        "total": len(routes),
+    }
+
+
+@router.get("/stats")
+async def get_route_stats(
+    request: Request,
+    _: None = Depends(require_debug),
+):
+    """Get route statistics."""
+    app = request.app
+    routes = get_all_routes(app)
+
+    by_method: dict[str, int] = {}
+    by_tag: dict[str, int] = {}
+    deprecated_count = 0
+
+    for route in routes:
+        # Count by method
+        by_method[route.method] = by_method.get(route.method, 0) + 1
+
+        # Count by tag
+        for tag in route.tags:
+            by_tag[tag] = by_tag.get(tag, 0) + 1
+
+        # Count deprecated
+        if route.deprecated:
+            deprecated_count += 1
+
+    return RouteStats(
+        total_routes=len(routes),
+        by_method=by_method,
+        by_tag=by_tag,
+        deprecated_count=deprecated_count,
+    )
+
+
+@router.get("/tags")
+async def get_route_tags(
+    request: Request,
+    _: None = Depends(require_debug),
+):
+    """Get all unique route tags."""
+    app = request.app
+    routes = get_all_routes(app)
+
+    tags = set()
+    for route in routes:
+        tags.update(route.tags)
+
+    return {
+        "tags": sorted(tags),
+        "total": len(tags),
+    }
+
+
+@router.get("/frontend")
+async def get_frontend_routes(
+    _: None = Depends(require_debug),
+    search: Optional[str] = None,
+    dev_tools: Optional[bool] = None,
+):
+    """Get frontend routes."""
+    routes = FRONTEND_ROUTES.copy()
+
+    # Filter dev tools
+    if dev_tools is not None:
+        routes = [r for r in routes if r.get("dev_tool", False) == dev_tools]
+
+    # Search
+    if search:
+        search_lower = search.lower()
+        routes = [
+            r for r in routes
+            if search_lower in r["path"].lower()
+            or search_lower in r["name"].lower()
+            or search_lower in r.get("description", "").lower()
+        ]
+
+    return {
+        "routes": routes,
+        "total": len(routes),
+        "dev_tools_count": sum(1 for r in FRONTEND_ROUTES if r.get("dev_tool")),
+    }
+
+
+@router.get("/grouped")
+async def get_routes_grouped(
+    request: Request,
+    _: None = Depends(require_debug),
+):
+    """Get routes grouped by tag."""
+    app = request.app
+    routes = get_all_routes(app)
+
+    grouped: dict[str, list] = {"untagged": []}
+
+    for route in routes:
+        if route.tags:
+            for tag in route.tags:
+                if tag not in grouped:
+                    grouped[tag] = []
+                grouped[tag].append(route.model_dump())
+        else:
+            grouped["untagged"].append(route.model_dump())
+
+    # Remove empty untagged
+    if not grouped["untagged"]:
+        del grouped["untagged"]
+
+    return {
+        "grouped": grouped,
+        "tags": list(grouped.keys()),
+    }
+
+
+@router.get("/methods")
+async def get_route_methods(
+    request: Request,
+    _: None = Depends(require_debug),
+):
+    """Get routes grouped by HTTP method."""
+    app = request.app
+    routes = get_all_routes(app)
+
+    by_method: dict[str, list] = {}
+
+    for route in routes:
+        if route.method not in by_method:
+            by_method[route.method] = []
+        by_method[route.method].append(route.model_dump())
+
+    return {
+        "by_method": by_method,
+        "methods": list(by_method.keys()),
+    }

--- a/server/app/main.py
+++ b/server/app/main.py
@@ -27,6 +27,7 @@ from .api.sessions import router as sessions_router
 from .api.flags import router as flags_router
 from .api.config import router as config_router
 from .api.dependencies import router as dependencies_router
+from .api.routes import router as routes_router
 
 
 @asynccontextmanager
@@ -99,6 +100,7 @@ def create_app() -> FastAPI:
     app.include_router(flags_router, tags=["dev-tools"])
     app.include_router(config_router, tags=["dev-tools"])
     app.include_router(dependencies_router, tags=["dev-tools"])
+    app.include_router(routes_router, tags=["dev-tools"])
 
     # Add exception handler to capture errors (only in debug mode)
     if settings.debug:

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,6 +1,6 @@
 import { Routes, Route } from 'react-router-dom';
 import { Layout } from './components/Layout';
-import { Home, Login, Register, Play, Features, About, PlayScene, SceneDemo, Leaderboard, Ghosts, Profile, Achievements, Spectate, Friends, Presentation, Roadmap, CodebaseHealth, Changelog, DatabaseExplorer, CacheInspector, AudioJukebox, SystemStatus, ApiPlayground, WebSocketMonitor, BuildInfo, LogViewer, ErrorTracker, PerformanceProfiler, SessionInspector, FeatureFlags, EnvConfig, DependencyViewer } from './pages';
+import { Home, Login, Register, Play, Features, About, PlayScene, SceneDemo, Leaderboard, Ghosts, Profile, Achievements, Spectate, Friends, Presentation, Roadmap, CodebaseHealth, Changelog, DatabaseExplorer, CacheInspector, AudioJukebox, SystemStatus, ApiPlayground, WebSocketMonitor, BuildInfo, LogViewer, ErrorTracker, PerformanceProfiler, SessionInspector, FeatureFlags, EnvConfig, DependencyViewer, RouteExplorer } from './pages';
 import { FirstPersonDemo } from './pages/FirstPersonDemo';
 import { FirstPersonTestPage } from './pages/FirstPersonTestPage';
 import { Debug3DPage } from './pages/Debug3DPage';
@@ -47,6 +47,7 @@ function App() {
         <Route path="feature-flags" element={<FeatureFlags />} />
         <Route path="env-config" element={<EnvConfig />} />
         <Route path="dependencies" element={<DependencyViewer />} />
+        <Route path="routes" element={<RouteExplorer />} />
       </Route>
     </Routes>
   );

--- a/web/src/components/Layout.tsx
+++ b/web/src/components/Layout.tsx
@@ -180,6 +180,10 @@ export function Layout() {
                     <span className="menu-icon">📦</span>
                     Dependencies
                   </Link>
+                  <Link to="/routes" onClick={closeDropdown}>
+                    <span className="menu-icon">🔀</span>
+                    Route Explorer
+                  </Link>
                   <Link to="/codebase-health" onClick={closeDropdown}>
                     <span className="menu-icon">🩺</span>
                     Codebase Health

--- a/web/src/pages/RouteExplorer.css
+++ b/web/src/pages/RouteExplorer.css
@@ -1,0 +1,530 @@
+/**
+ * Route Explorer Styles - Blue/network theme
+ */
+
+.route-explorer {
+  min-height: 100vh;
+  background: #0d1117;
+  color: #e6edf3;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+}
+
+/* Loading State */
+.routes-loading {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  min-height: 60vh;
+  gap: 1rem;
+}
+
+.loading-spinner {
+  width: 40px;
+  height: 40px;
+  border: 3px solid #21262d;
+  border-top-color: #3b82f6;
+  border-radius: 50%;
+  animation: spin 1s linear infinite;
+}
+
+@keyframes spin {
+  to { transform: rotate(360deg); }
+}
+
+/* Header */
+.routes-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 1rem 1.5rem;
+  background: #161b22;
+  border-bottom: 1px solid #30363d;
+}
+
+.routes-header .header-left {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+}
+
+.routes-header h1 {
+  margin: 0;
+  font-size: 1.25rem;
+  font-weight: 600;
+}
+
+.header-badge {
+  font-size: 0.75rem;
+  font-weight: 600;
+  padding: 0.25rem 0.75rem;
+  background: #3b82f622;
+  color: #3b82f6;
+  border-radius: 12px;
+}
+
+/* Stats Row */
+.stats-row {
+  display: flex;
+  gap: 1rem;
+  padding: 1rem 1.5rem;
+  background: #161b22;
+  border-bottom: 1px solid #21262d;
+  overflow-x: auto;
+}
+
+.stat-card {
+  flex: 1;
+  min-width: 100px;
+  background: #0d1117;
+  border: 1px solid #30363d;
+  border-radius: 8px;
+  padding: 0.75rem 1rem;
+  text-align: center;
+}
+
+.stat-card.api {
+  border-color: #3b82f655;
+}
+
+.stat-card.api .stat-value {
+  color: #3b82f6;
+}
+
+.stat-card.frontend .stat-value {
+  color: #06b6d4;
+}
+
+.stat-value {
+  font-size: 1.5rem;
+  font-weight: 700;
+  color: #e6edf3;
+}
+
+.stat-label {
+  font-size: 0.7rem;
+  color: #8b949e;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  margin-top: 0.25rem;
+}
+
+.stat-card.methods {
+  min-width: 200px;
+}
+
+.method-badges {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 0.25rem;
+}
+
+.method-badge {
+  font-size: 0.65rem;
+  font-weight: 600;
+  padding: 0.1rem 0.4rem;
+  border-radius: 4px;
+}
+
+/* Controls Row */
+.controls-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 0.75rem 1.5rem;
+  background: #161b22;
+  border-bottom: 1px solid #21262d;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+.view-toggle {
+  display: flex;
+  gap: 0;
+}
+
+.view-toggle button {
+  padding: 0.5rem 1rem;
+  background: transparent;
+  border: 1px solid #30363d;
+  color: #8b949e;
+  font-size: 0.85rem;
+  cursor: pointer;
+  transition: all 0.15s;
+}
+
+.view-toggle button:first-child {
+  border-radius: 6px 0 0 6px;
+}
+
+.view-toggle button:last-child {
+  border-radius: 0 6px 6px 0;
+}
+
+.view-toggle button:not(:first-child) {
+  border-left: none;
+}
+
+.view-toggle button:hover {
+  color: #e6edf3;
+  background: #21262d;
+}
+
+.view-toggle button.active {
+  color: #3b82f6;
+  background: #3b82f622;
+  border-color: #3b82f655;
+}
+
+.filters {
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
+.search-input {
+  padding: 0.4rem 0.75rem;
+  background: #0d1117;
+  border: 1px solid #30363d;
+  border-radius: 6px;
+  color: #e6edf3;
+  font-size: 0.85rem;
+  min-width: 180px;
+}
+
+.search-input:focus {
+  outline: none;
+  border-color: #3b82f6;
+}
+
+.filter-select {
+  padding: 0.4rem 0.75rem;
+  background: #0d1117;
+  border: 1px solid #30363d;
+  border-radius: 6px;
+  color: #e6edf3;
+  font-size: 0.85rem;
+  cursor: pointer;
+}
+
+.filter-select:focus {
+  outline: none;
+  border-color: #3b82f6;
+}
+
+/* Content */
+.routes-content {
+  padding: 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+}
+
+.routes-section {
+  background: #161b22;
+  border: 1px solid #30363d;
+  border-radius: 8px;
+  overflow: hidden;
+}
+
+.section-header {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 1rem;
+  background: #21262d;
+  border-bottom: 1px solid #30363d;
+}
+
+.section-icon {
+  font-size: 1.25rem;
+}
+
+.section-header h2 {
+  margin: 0;
+  font-size: 1rem;
+  font-weight: 600;
+}
+
+.section-count {
+  font-size: 0.75rem;
+  padding: 0.15rem 0.5rem;
+  background: #0d1117;
+  border-radius: 10px;
+  color: #8b949e;
+  margin-left: auto;
+}
+
+/* Tag Group */
+.tag-group {
+  border-bottom: 1px solid #21262d;
+}
+
+.tag-group:last-child {
+  border-bottom: none;
+}
+
+.tag-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.6rem 1rem;
+  background: #161b22;
+  border-bottom: 1px solid #21262d;
+}
+
+.tag-name {
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: #3b82f6;
+}
+
+.tag-count {
+  font-size: 0.7rem;
+  padding: 0.1rem 0.4rem;
+  background: #21262d;
+  border-radius: 8px;
+  color: #8b949e;
+}
+
+/* Routes List */
+.routes-list {
+  background: #0d1117;
+}
+
+.route-item {
+  border-bottom: 1px solid #21262d;
+}
+
+.route-item:last-child {
+  border-bottom: none;
+}
+
+.route-header {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.6rem 1rem;
+  cursor: pointer;
+  transition: background 0.15s;
+}
+
+.route-header:hover {
+  background: #161b22;
+}
+
+.route-method {
+  font-size: 0.65rem;
+  font-weight: 700;
+  padding: 0.2rem 0.5rem;
+  border-radius: 4px;
+  min-width: 50px;
+  text-align: center;
+}
+
+.route-path {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.85rem;
+  color: #e6edf3;
+}
+
+.route-name {
+  font-size: 0.8rem;
+  color: #8b949e;
+  margin-left: auto;
+}
+
+.deprecated-badge {
+  font-size: 0.65rem;
+  font-weight: 600;
+  padding: 0.1rem 0.4rem;
+  background: #f8514922;
+  color: #f85149;
+  border-radius: 4px;
+  text-transform: uppercase;
+}
+
+.expand-icon {
+  color: #6b7280;
+  font-size: 0.75rem;
+  margin-left: 0.5rem;
+}
+
+/* Route Details */
+.route-details {
+  padding: 1rem;
+  background: #161b22;
+  border-top: 1px solid #21262d;
+}
+
+.detail-item {
+  margin-bottom: 0.75rem;
+}
+
+.detail-item:last-child {
+  margin-bottom: 0;
+}
+
+.detail-label {
+  display: block;
+  font-size: 0.7rem;
+  font-weight: 600;
+  color: #8b949e;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  margin-bottom: 0.25rem;
+}
+
+.detail-value {
+  font-size: 0.85rem;
+  color: #e6edf3;
+}
+
+.params-list,
+.tags-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.param-badge {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.75rem;
+  padding: 0.2rem 0.5rem;
+  background: #21262d;
+  border-radius: 4px;
+  color: #d29922;
+}
+
+.tag-badge {
+  font-size: 0.7rem;
+  padding: 0.15rem 0.5rem;
+  background: #3b82f622;
+  color: #3b82f6;
+  border-radius: 4px;
+}
+
+/* Frontend Routes Grid */
+.frontend-routes-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+  gap: 0.75rem;
+  padding: 1rem;
+  background: #0d1117;
+}
+
+.frontend-route-card {
+  background: #161b22;
+  border: 1px solid #30363d;
+  border-radius: 6px;
+  padding: 0.75rem;
+  transition: all 0.15s;
+}
+
+.frontend-route-card:hover {
+  border-color: #3b82f655;
+}
+
+.frontend-route-card.dev-tool {
+  border-left: 3px solid #a855f7;
+}
+
+.frontend-route-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 0.5rem;
+}
+
+.frontend-path {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.8rem;
+  color: #06b6d4;
+}
+
+.auth-badge {
+  font-size: 0.6rem;
+  font-weight: 600;
+  padding: 0.1rem 0.3rem;
+  background: #d2992222;
+  color: #d29922;
+  border-radius: 3px;
+  text-transform: uppercase;
+}
+
+.dev-badge {
+  font-size: 0.6rem;
+  font-weight: 600;
+  padding: 0.1rem 0.3rem;
+  background: #a855f722;
+  color: #a855f7;
+  border-radius: 3px;
+  text-transform: uppercase;
+}
+
+.frontend-route-name {
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: #e6edf3;
+  margin-bottom: 0.25rem;
+}
+
+.frontend-route-desc {
+  font-size: 0.75rem;
+  color: #8b949e;
+}
+
+/* No Routes */
+.no-routes {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 2rem;
+  color: #6b7280;
+  background: #0d1117;
+}
+
+/* Responsive */
+@media (max-width: 768px) {
+  .stats-row {
+    flex-wrap: nowrap;
+    overflow-x: auto;
+  }
+
+  .controls-row {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .view-toggle {
+    width: 100%;
+  }
+
+  .view-toggle button {
+    flex: 1;
+  }
+
+  .filters {
+    flex-direction: column;
+  }
+
+  .search-input,
+  .filter-select {
+    min-width: 100%;
+  }
+
+  .route-header {
+    flex-wrap: wrap;
+  }
+
+  .route-name {
+    margin-left: 0;
+    width: 100%;
+    margin-top: 0.25rem;
+  }
+
+  .frontend-routes-grid {
+    grid-template-columns: 1fr;
+  }
+}

--- a/web/src/pages/RouteExplorer.tsx
+++ b/web/src/pages/RouteExplorer.tsx
@@ -1,0 +1,454 @@
+/**
+ * Route Explorer - View all application routes
+ *
+ * Features:
+ * - List all backend API routes
+ * - List all frontend routes
+ * - Filter by method, tag, search
+ * - Route details and parameters
+ */
+
+import { useState, useEffect, useCallback } from 'react';
+import './RouteExplorer.css';
+
+const API_BASE = 'http://localhost:8000/api/routes';
+
+interface ApiRoute {
+  path: string;
+  method: string;
+  name?: string;
+  summary?: string;
+  description?: string;
+  tags: string[];
+  parameters: Array<{ name: string; in: string; type: string }>;
+  deprecated: boolean;
+}
+
+interface FrontendRoute {
+  path: string;
+  name: string;
+  description?: string;
+  auth_required?: boolean;
+  dev_tool?: boolean;
+}
+
+interface RouteStats {
+  total_routes: number;
+  by_method: Record<string, number>;
+  by_tag: Record<string, number>;
+  deprecated_count: number;
+}
+
+const METHOD_COLORS: Record<string, string> = {
+  GET: '#22c55e',
+  POST: '#3b82f6',
+  PUT: '#d29922',
+  PATCH: '#a855f7',
+  DELETE: '#f85149',
+};
+
+export function RouteExplorer() {
+  const [apiRoutes, setApiRoutes] = useState<ApiRoute[]>([]);
+  const [frontendRoutes, setFrontendRoutes] = useState<FrontendRoute[]>([]);
+  const [stats, setStats] = useState<RouteStats | null>(null);
+  const [tags, setTags] = useState<string[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  // View state
+  const [view, setView] = useState<'api' | 'frontend' | 'all'>('all');
+  const [searchQuery, setSearchQuery] = useState('');
+  const [filterMethod, setFilterMethod] = useState('');
+  const [filterTag, setFilterTag] = useState('');
+  const [expandedRoute, setExpandedRoute] = useState<string | null>(null);
+
+  // Fetch API routes
+  const fetchApiRoutes = useCallback(async () => {
+    try {
+      const res = await fetch(API_BASE);
+      if (res.ok) {
+        const data = await res.json();
+        setApiRoutes(data.routes);
+      }
+    } catch {
+      // Silently fail
+    }
+  }, []);
+
+  // Fetch frontend routes
+  const fetchFrontendRoutes = useCallback(async () => {
+    try {
+      const res = await fetch(`${API_BASE}/frontend`);
+      if (res.ok) {
+        const data = await res.json();
+        setFrontendRoutes(data.routes);
+      }
+    } catch {
+      // Silently fail
+    }
+  }, []);
+
+  // Fetch stats
+  const fetchStats = useCallback(async () => {
+    try {
+      const res = await fetch(`${API_BASE}/stats`);
+      if (res.ok) {
+        const data = await res.json();
+        setStats(data);
+      }
+    } catch {
+      // Silently fail
+    }
+  }, []);
+
+  // Fetch tags
+  const fetchTags = useCallback(async () => {
+    try {
+      const res = await fetch(`${API_BASE}/tags`);
+      if (res.ok) {
+        const data = await res.json();
+        setTags(data.tags);
+      }
+    } catch {
+      // Silently fail
+    }
+  }, []);
+
+  // Initial fetch
+  useEffect(() => {
+    const loadData = async () => {
+      setLoading(true);
+      await Promise.all([
+        fetchApiRoutes(),
+        fetchFrontendRoutes(),
+        fetchStats(),
+        fetchTags(),
+      ]);
+      setLoading(false);
+    };
+    loadData();
+  }, [fetchApiRoutes, fetchFrontendRoutes, fetchStats, fetchTags]);
+
+  // Filter API routes
+  const filteredApiRoutes = apiRoutes.filter((route) => {
+    if (filterMethod && route.method !== filterMethod) return false;
+    if (filterTag && !route.tags.includes(filterTag)) return false;
+    if (searchQuery) {
+      const query = searchQuery.toLowerCase();
+      if (
+        !route.path.toLowerCase().includes(query) &&
+        !route.name?.toLowerCase().includes(query) &&
+        !route.description?.toLowerCase().includes(query)
+      ) {
+        return false;
+      }
+    }
+    return true;
+  });
+
+  // Filter frontend routes
+  const filteredFrontendRoutes = frontendRoutes.filter((route) => {
+    if (searchQuery) {
+      const query = searchQuery.toLowerCase();
+      if (
+        !route.path.toLowerCase().includes(query) &&
+        !route.name.toLowerCase().includes(query) &&
+        !route.description?.toLowerCase().includes(query)
+      ) {
+        return false;
+      }
+    }
+    return true;
+  });
+
+  // Group API routes by tag
+  const groupedApiRoutes = filteredApiRoutes.reduce((acc, route) => {
+    const tag = route.tags[0] || 'untagged';
+    if (!acc[tag]) {
+      acc[tag] = [];
+    }
+    acc[tag].push(route);
+    return acc;
+  }, {} as Record<string, ApiRoute[]>);
+
+  // Group frontend routes
+  const devToolRoutes = filteredFrontendRoutes.filter((r) => r.dev_tool);
+  const pageRoutes = filteredFrontendRoutes.filter((r) => !r.dev_tool);
+
+  if (loading) {
+    return (
+      <div className="route-explorer">
+        <div className="routes-loading">
+          <div className="loading-spinner" />
+          <p>Loading routes...</p>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="route-explorer">
+      {/* Header */}
+      <header className="routes-header">
+        <div className="header-left">
+          <h1>Route Explorer</h1>
+          <span className="header-badge">
+            {apiRoutes.length + frontendRoutes.length} routes
+          </span>
+        </div>
+      </header>
+
+      {/* Stats Cards */}
+      {stats && (
+        <div className="stats-row">
+          <div className="stat-card api">
+            <div className="stat-value">{stats.total_routes}</div>
+            <div className="stat-label">API Routes</div>
+          </div>
+          <div className="stat-card frontend">
+            <div className="stat-value">{frontendRoutes.length}</div>
+            <div className="stat-label">Frontend</div>
+          </div>
+          <div className="stat-card methods">
+            <div className="method-badges">
+              {Object.entries(stats.by_method).map(([method, count]) => (
+                <span
+                  key={method}
+                  className="method-badge"
+                  style={{ background: METHOD_COLORS[method] + '22', color: METHOD_COLORS[method] }}
+                >
+                  {method} {count}
+                </span>
+              ))}
+            </div>
+            <div className="stat-label">By Method</div>
+          </div>
+          <div className="stat-card tags">
+            <div className="stat-value">{tags.length}</div>
+            <div className="stat-label">Tags</div>
+          </div>
+        </div>
+      )}
+
+      {/* Controls */}
+      <div className="controls-row">
+        <div className="view-toggle">
+          <button
+            className={view === 'all' ? 'active' : ''}
+            onClick={() => setView('all')}
+          >
+            All
+          </button>
+          <button
+            className={view === 'api' ? 'active' : ''}
+            onClick={() => setView('api')}
+          >
+            API
+          </button>
+          <button
+            className={view === 'frontend' ? 'active' : ''}
+            onClick={() => setView('frontend')}
+          >
+            Frontend
+          </button>
+        </div>
+
+        <div className="filters">
+          <input
+            type="text"
+            placeholder="Search routes..."
+            value={searchQuery}
+            onChange={(e) => setSearchQuery(e.target.value)}
+            className="search-input"
+          />
+          {(view === 'all' || view === 'api') && (
+            <>
+              <select
+                value={filterMethod}
+                onChange={(e) => setFilterMethod(e.target.value)}
+                className="filter-select"
+              >
+                <option value="">All Methods</option>
+                <option value="GET">GET</option>
+                <option value="POST">POST</option>
+                <option value="PUT">PUT</option>
+                <option value="PATCH">PATCH</option>
+                <option value="DELETE">DELETE</option>
+              </select>
+              <select
+                value={filterTag}
+                onChange={(e) => setFilterTag(e.target.value)}
+                className="filter-select"
+              >
+                <option value="">All Tags</option>
+                {tags.map((tag) => (
+                  <option key={tag} value={tag}>{tag}</option>
+                ))}
+              </select>
+            </>
+          )}
+        </div>
+      </div>
+
+      {/* Routes Content */}
+      <div className="routes-content">
+        {/* API Routes */}
+        {(view === 'all' || view === 'api') && (
+          <div className="routes-section">
+            <div className="section-header">
+              <span className="section-icon">🔌</span>
+              <h2>API Routes</h2>
+              <span className="section-count">{filteredApiRoutes.length}</span>
+            </div>
+
+            {Object.keys(groupedApiRoutes).length === 0 ? (
+              <div className="no-routes">
+                <p>No API routes found</p>
+              </div>
+            ) : (
+              Object.entries(groupedApiRoutes).map(([tag, routes]) => (
+                <div key={tag} className="tag-group">
+                  <div className="tag-header">
+                    <span className="tag-name">{tag}</span>
+                    <span className="tag-count">{routes.length}</span>
+                  </div>
+                  <div className="routes-list">
+                    {routes.map((route, idx) => {
+                      const routeKey = `${route.method}-${route.path}-${idx}`;
+                      return (
+                        <div
+                          key={routeKey}
+                          className={`route-item ${expandedRoute === routeKey ? 'expanded' : ''}`}
+                        >
+                          <div
+                            className="route-header"
+                            onClick={() => setExpandedRoute(
+                              expandedRoute === routeKey ? null : routeKey
+                            )}
+                          >
+                            <span
+                              className="route-method"
+                              style={{
+                                background: METHOD_COLORS[route.method] + '22',
+                                color: METHOD_COLORS[route.method],
+                              }}
+                            >
+                              {route.method}
+                            </span>
+                            <code className="route-path">{route.path}</code>
+                            {route.name && (
+                              <span className="route-name">{route.name}</span>
+                            )}
+                            {route.deprecated && (
+                              <span className="deprecated-badge">deprecated</span>
+                            )}
+                            <span className="expand-icon">
+                              {expandedRoute === routeKey ? '▼' : '▶'}
+                            </span>
+                          </div>
+
+                          {expandedRoute === routeKey && (
+                            <div className="route-details">
+                              {route.description && (
+                                <div className="detail-item">
+                                  <span className="detail-label">Description</span>
+                                  <span className="detail-value">{route.description}</span>
+                                </div>
+                              )}
+                              {route.parameters.length > 0 && (
+                                <div className="detail-item">
+                                  <span className="detail-label">Parameters</span>
+                                  <div className="params-list">
+                                    {route.parameters.map((param, i) => (
+                                      <span key={i} className="param-badge">
+                                        {param.name}: {param.type}
+                                      </span>
+                                    ))}
+                                  </div>
+                                </div>
+                              )}
+                              <div className="detail-item">
+                                <span className="detail-label">Tags</span>
+                                <div className="tags-list">
+                                  {route.tags.map((t) => (
+                                    <span key={t} className="tag-badge">{t}</span>
+                                  ))}
+                                </div>
+                              </div>
+                            </div>
+                          )}
+                        </div>
+                      );
+                    })}
+                  </div>
+                </div>
+              ))
+            )}
+          </div>
+        )}
+
+        {/* Frontend Routes */}
+        {(view === 'all' || view === 'frontend') && (
+          <div className="routes-section">
+            <div className="section-header">
+              <span className="section-icon">⚛️</span>
+              <h2>Frontend Routes</h2>
+              <span className="section-count">{filteredFrontendRoutes.length}</span>
+            </div>
+
+            {/* Page Routes */}
+            {pageRoutes.length > 0 && (
+              <div className="tag-group">
+                <div className="tag-header">
+                  <span className="tag-name">Pages</span>
+                  <span className="tag-count">{pageRoutes.length}</span>
+                </div>
+                <div className="frontend-routes-grid">
+                  {pageRoutes.map((route) => (
+                    <div key={route.path} className="frontend-route-card">
+                      <div className="frontend-route-header">
+                        <code className="frontend-path">{route.path}</code>
+                        {route.auth_required && (
+                          <span className="auth-badge">auth</span>
+                        )}
+                      </div>
+                      <div className="frontend-route-name">{route.name}</div>
+                      {route.description && (
+                        <div className="frontend-route-desc">{route.description}</div>
+                      )}
+                    </div>
+                  ))}
+                </div>
+              </div>
+            )}
+
+            {/* Dev Tool Routes */}
+            {devToolRoutes.length > 0 && (
+              <div className="tag-group">
+                <div className="tag-header">
+                  <span className="tag-name">Dev Tools</span>
+                  <span className="tag-count">{devToolRoutes.length}</span>
+                </div>
+                <div className="frontend-routes-grid">
+                  {devToolRoutes.map((route) => (
+                    <div key={route.path} className="frontend-route-card dev-tool">
+                      <div className="frontend-route-header">
+                        <code className="frontend-path">{route.path}</code>
+                        <span className="dev-badge">dev</span>
+                      </div>
+                      <div className="frontend-route-name">{route.name}</div>
+                      {route.description && (
+                        <div className="frontend-route-desc">{route.description}</div>
+                      )}
+                    </div>
+                  ))}
+                </div>
+              </div>
+            )}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export default RouteExplorer;

--- a/web/src/pages/index.ts
+++ b/web/src/pages/index.ts
@@ -30,3 +30,4 @@ export { SessionInspector } from './SessionInspector';
 export { FeatureFlags } from './FeatureFlags';
 export { EnvConfig } from './EnvConfig';
 export { DependencyViewer } from './DependencyViewer';
+export { RouteExplorer } from './RouteExplorer';


### PR DESCRIPTION
## Summary
- Add Route Explorer dev tool for viewing all API and frontend routes
- Backend API with FastAPI route introspection (method, path, tags, parameters)
- Frontend routes manually defined for React Router visibility
- Search, filter by method/tag, expandable route details
- Blue/network themed styling consistent with other dev tools

## Test plan
- [ ] Visit /routes page
- [ ] Verify API routes display with method badges
- [ ] Verify frontend routes display in grid
- [ ] Test search filtering
- [ ] Test method and tag dropdown filters
- [ ] Test route expansion for details

🤖 Generated with [Claude Code](https://claude.com/claude-code)