### PR TITLE
feat(dev-tools): add Metrics Dashboard

### DIFF
--- a/server/app/api/metrics.py
+++ b/server/app/api/metrics.py
@@ -1,0 +1,445 @@
+"""
+Metrics Dashboard API - Application performance metrics.
+
+Features:
+- Request counts and rates
+- Response time statistics (avg, p50, p95, p99)
+- Error tracking
+- Endpoint-level metrics
+- Time-series data for charts
+- System resource usage
+"""
+
+import time
+import statistics
+import psutil
+from collections import deque
+from datetime import datetime, timedelta
+from typing import Optional
+
+from fastapi import APIRouter, Depends, Request, Response
+from pydantic import BaseModel
+from starlette.middleware.base import BaseHTTPMiddleware
+
+from ..api.dbexplorer import require_debug
+
+router = APIRouter(prefix="/api/metrics", tags=["metrics"])
+
+
+class RequestMetric(BaseModel):
+    """Single request metric."""
+    timestamp: float
+    method: str
+    path: str
+    status_code: int
+    response_time_ms: float
+
+
+class EndpointMetrics(BaseModel):
+    """Metrics for a single endpoint."""
+    path: str
+    method: str
+    request_count: int
+    avg_response_time_ms: float
+    min_response_time_ms: float
+    max_response_time_ms: float
+    p50_response_time_ms: float
+    p95_response_time_ms: float
+    p99_response_time_ms: float
+    error_count: int
+    error_rate: float
+
+
+class OverviewMetrics(BaseModel):
+    """Overview metrics."""
+    total_requests: int
+    total_errors: int
+    error_rate: float
+    avg_response_time_ms: float
+    p50_response_time_ms: float
+    p95_response_time_ms: float
+    p99_response_time_ms: float
+    requests_per_minute: float
+    uptime_seconds: float
+
+
+class SystemMetrics(BaseModel):
+    """System resource metrics."""
+    cpu_percent: float
+    memory_percent: float
+    memory_used_mb: float
+    memory_available_mb: float
+    disk_percent: float
+    disk_used_gb: float
+    disk_free_gb: float
+    open_files: int
+    threads: int
+
+
+# In-memory metrics storage
+class MetricsCollector:
+    """Collects and stores application metrics."""
+
+    def __init__(self, max_requests: int = 10000, max_timeseries: int = 1000):
+        self.start_time = time.time()
+        self.requests: deque[RequestMetric] = deque(maxlen=max_requests)
+        self.timeseries: deque[dict] = deque(maxlen=max_timeseries)
+        self.total_requests = 0
+        self.total_errors = 0
+
+        # Per-endpoint metrics
+        self.endpoint_requests: dict[str, list[float]] = {}
+        self.endpoint_errors: dict[str, int] = {}
+
+        # Per-method counts
+        self.method_counts: dict[str, int] = {}
+
+        # Per-status counts
+        self.status_counts: dict[int, int] = {}
+
+        # Last minute tracking
+        self.minute_requests: deque[float] = deque(maxlen=1000)
+
+    def record_request(
+        self,
+        method: str,
+        path: str,
+        status_code: int,
+        response_time_ms: float
+    ):
+        """Record a request metric."""
+        now = time.time()
+
+        metric = RequestMetric(
+            timestamp=now,
+            method=method,
+            path=path,
+            status_code=status_code,
+            response_time_ms=response_time_ms,
+        )
+        self.requests.append(metric)
+
+        # Update totals
+        self.total_requests += 1
+        if status_code >= 400:
+            self.total_errors += 1
+
+        # Update method counts
+        self.method_counts[method] = self.method_counts.get(method, 0) + 1
+
+        # Update status counts
+        self.status_counts[status_code] = self.status_counts.get(status_code, 0) + 1
+
+        # Update endpoint metrics
+        endpoint_key = f"{method}:{path}"
+        if endpoint_key not in self.endpoint_requests:
+            self.endpoint_requests[endpoint_key] = []
+            self.endpoint_errors[endpoint_key] = 0
+        self.endpoint_requests[endpoint_key].append(response_time_ms)
+        if status_code >= 400:
+            self.endpoint_errors[endpoint_key] += 1
+
+        # Track for requests per minute
+        self.minute_requests.append(now)
+
+        # Add to timeseries (aggregated by second)
+        self._add_to_timeseries(now, response_time_ms, status_code >= 400)
+
+    def _add_to_timeseries(self, timestamp: float, response_time: float, is_error: bool):
+        """Add data point to timeseries."""
+        second = int(timestamp)
+
+        # Find or create bucket for this second
+        if self.timeseries and self.timeseries[-1].get("timestamp") == second:
+            bucket = self.timeseries[-1]
+            bucket["count"] += 1
+            bucket["total_time"] += response_time
+            bucket["avg_time"] = bucket["total_time"] / bucket["count"]
+            if is_error:
+                bucket["errors"] += 1
+        else:
+            self.timeseries.append({
+                "timestamp": second,
+                "count": 1,
+                "total_time": response_time,
+                "avg_time": response_time,
+                "errors": 1 if is_error else 0,
+            })
+
+    def get_overview(self) -> OverviewMetrics:
+        """Get overview metrics."""
+        response_times = [r.response_time_ms for r in self.requests]
+
+        # Calculate requests per minute
+        now = time.time()
+        minute_ago = now - 60
+        recent_requests = sum(1 for t in self.minute_requests if t > minute_ago)
+
+        if response_times:
+            sorted_times = sorted(response_times)
+            return OverviewMetrics(
+                total_requests=self.total_requests,
+                total_errors=self.total_errors,
+                error_rate=self.total_errors / self.total_requests if self.total_requests > 0 else 0,
+                avg_response_time_ms=statistics.mean(response_times),
+                p50_response_time_ms=self._percentile(sorted_times, 50),
+                p95_response_time_ms=self._percentile(sorted_times, 95),
+                p99_response_time_ms=self._percentile(sorted_times, 99),
+                requests_per_minute=recent_requests,
+                uptime_seconds=now - self.start_time,
+            )
+        else:
+            return OverviewMetrics(
+                total_requests=0,
+                total_errors=0,
+                error_rate=0,
+                avg_response_time_ms=0,
+                p50_response_time_ms=0,
+                p95_response_time_ms=0,
+                p99_response_time_ms=0,
+                requests_per_minute=0,
+                uptime_seconds=now - self.start_time,
+            )
+
+    def get_endpoint_metrics(self) -> list[EndpointMetrics]:
+        """Get per-endpoint metrics."""
+        metrics = []
+
+        for endpoint_key, times in self.endpoint_requests.items():
+            if not times:
+                continue
+
+            method, path = endpoint_key.split(":", 1)
+            sorted_times = sorted(times)
+            error_count = self.endpoint_errors.get(endpoint_key, 0)
+
+            metrics.append(EndpointMetrics(
+                path=path,
+                method=method,
+                request_count=len(times),
+                avg_response_time_ms=statistics.mean(times),
+                min_response_time_ms=min(times),
+                max_response_time_ms=max(times),
+                p50_response_time_ms=self._percentile(sorted_times, 50),
+                p95_response_time_ms=self._percentile(sorted_times, 95),
+                p99_response_time_ms=self._percentile(sorted_times, 99),
+                error_count=error_count,
+                error_rate=error_count / len(times) if times else 0,
+            ))
+
+        # Sort by request count descending
+        metrics.sort(key=lambda m: m.request_count, reverse=True)
+        return metrics
+
+    def get_timeseries(self, minutes: int = 5) -> list[dict]:
+        """Get timeseries data for the last N minutes."""
+        cutoff = time.time() - (minutes * 60)
+        return [
+            {
+                "timestamp": d["timestamp"],
+                "requests": d["count"],
+                "avg_response_time": round(d["avg_time"], 2),
+                "errors": d["errors"],
+            }
+            for d in self.timeseries
+            if d["timestamp"] > cutoff
+        ]
+
+    def get_recent_requests(self, limit: int = 50) -> list[dict]:
+        """Get recent requests."""
+        requests = list(self.requests)[-limit:]
+        return [
+            {
+                "timestamp": r.timestamp,
+                "method": r.method,
+                "path": r.path,
+                "status_code": r.status_code,
+                "response_time_ms": round(r.response_time_ms, 2),
+            }
+            for r in reversed(requests)
+        ]
+
+    @staticmethod
+    def _percentile(sorted_data: list[float], percentile: int) -> float:
+        """Calculate percentile from sorted data."""
+        if not sorted_data:
+            return 0
+        k = (len(sorted_data) - 1) * percentile / 100
+        f = int(k)
+        c = f + 1 if f + 1 < len(sorted_data) else f
+        return sorted_data[f] + (k - f) * (sorted_data[c] - sorted_data[f])
+
+    def reset(self):
+        """Reset all metrics."""
+        self.requests.clear()
+        self.timeseries.clear()
+        self.total_requests = 0
+        self.total_errors = 0
+        self.endpoint_requests.clear()
+        self.endpoint_errors.clear()
+        self.method_counts.clear()
+        self.status_counts.clear()
+        self.minute_requests.clear()
+        self.start_time = time.time()
+
+
+# Global metrics collector
+metrics_collector = MetricsCollector()
+
+
+class MetricsMiddleware(BaseHTTPMiddleware):
+    """Middleware to collect request metrics."""
+
+    def __init__(self, app, collector: MetricsCollector = None):
+        super().__init__(app)
+        self.collector = collector or metrics_collector
+
+    async def dispatch(self, request: Request, call_next):
+        start_time = time.time()
+
+        response = await call_next(request)
+
+        # Calculate response time
+        response_time_ms = (time.time() - start_time) * 1000
+
+        # Record metric (skip metrics endpoints to avoid recursion)
+        if not request.url.path.startswith("/api/metrics"):
+            self.collector.record_request(
+                method=request.method,
+                path=request.url.path,
+                status_code=response.status_code,
+                response_time_ms=response_time_ms,
+            )
+
+        return response
+
+
+def get_system_metrics() -> SystemMetrics:
+    """Get system resource metrics."""
+    try:
+        cpu_percent = psutil.cpu_percent(interval=0.1)
+        memory = psutil.virtual_memory()
+        disk = psutil.disk_usage("/")
+        process = psutil.Process()
+
+        return SystemMetrics(
+            cpu_percent=cpu_percent,
+            memory_percent=memory.percent,
+            memory_used_mb=memory.used / (1024 * 1024),
+            memory_available_mb=memory.available / (1024 * 1024),
+            disk_percent=disk.percent,
+            disk_used_gb=disk.used / (1024 * 1024 * 1024),
+            disk_free_gb=disk.free / (1024 * 1024 * 1024),
+            open_files=len(process.open_files()),
+            threads=process.num_threads(),
+        )
+    except Exception:
+        return SystemMetrics(
+            cpu_percent=0,
+            memory_percent=0,
+            memory_used_mb=0,
+            memory_available_mb=0,
+            disk_percent=0,
+            disk_used_gb=0,
+            disk_free_gb=0,
+            open_files=0,
+            threads=0,
+        )
+
+
+@router.get("")
+async def get_metrics_overview(
+    _: None = Depends(require_debug),
+):
+    """Get metrics overview."""
+    overview = metrics_collector.get_overview()
+    system = get_system_metrics()
+
+    return {
+        "overview": overview.model_dump(),
+        "system": system.model_dump(),
+        "method_counts": metrics_collector.method_counts,
+        "status_counts": metrics_collector.status_counts,
+    }
+
+
+@router.get("/endpoints")
+async def get_endpoint_metrics(
+    _: None = Depends(require_debug),
+    limit: int = 50,
+):
+    """Get per-endpoint metrics."""
+    metrics = metrics_collector.get_endpoint_metrics()
+    return {
+        "endpoints": [m.model_dump() for m in metrics[:limit]],
+        "total": len(metrics),
+    }
+
+
+@router.get("/timeseries")
+async def get_timeseries_metrics(
+    _: None = Depends(require_debug),
+    minutes: int = 5,
+):
+    """Get timeseries data for charts."""
+    data = metrics_collector.get_timeseries(minutes)
+    return {
+        "timeseries": data,
+        "minutes": minutes,
+        "data_points": len(data),
+    }
+
+
+@router.get("/recent")
+async def get_recent_requests(
+    _: None = Depends(require_debug),
+    limit: int = 50,
+):
+    """Get recent requests."""
+    requests = metrics_collector.get_recent_requests(limit)
+    return {
+        "requests": requests,
+        "total": len(requests),
+    }
+
+
+@router.get("/system")
+async def get_system_metrics_endpoint(
+    _: None = Depends(require_debug),
+):
+    """Get system resource metrics."""
+    return get_system_metrics().model_dump()
+
+
+@router.post("/reset")
+async def reset_metrics(
+    _: None = Depends(require_debug),
+):
+    """Reset all metrics."""
+    metrics_collector.reset()
+    return {"status": "reset", "message": "All metrics have been reset"}
+
+
+@router.get("/summary")
+async def get_metrics_summary(
+    _: None = Depends(require_debug),
+):
+    """Get a compact metrics summary."""
+    overview = metrics_collector.get_overview()
+    top_endpoints = metrics_collector.get_endpoint_metrics()[:5]
+
+    return {
+        "uptime_seconds": overview.uptime_seconds,
+        "total_requests": overview.total_requests,
+        "requests_per_minute": overview.requests_per_minute,
+        "avg_response_time_ms": round(overview.avg_response_time_ms, 2),
+        "error_rate_percent": round(overview.error_rate * 100, 2),
+        "top_endpoints": [
+            {
+                "endpoint": f"{e.method} {e.path}",
+                "requests": e.request_count,
+                "avg_ms": round(e.avg_response_time_ms, 2),
+            }
+            for e in top_endpoints
+        ],
+    }

--- a/server/app/api/routes.py
+++ b/server/app/api/routes.py
@@ -78,6 +78,7 @@ FRONTEND_ROUTES = [
     {"path": "/env-config", "name": "Env Config", "description": "Configuration viewer", "dev_tool": True},
     {"path": "/dependencies", "name": "Dependencies", "description": "Package dependencies", "dev_tool": True},
     {"path": "/routes", "name": "Route Explorer", "description": "API routes viewer", "dev_tool": True},
+    {"path": "/metrics", "name": "Metrics Dashboard", "description": "Performance metrics", "dev_tool": True},
 ]
 
 

--- a/server/app/main.py
+++ b/server/app/main.py
@@ -28,6 +28,7 @@ from .api.flags import router as flags_router
 from .api.config import router as config_router
 from .api.dependencies import router as dependencies_router
 from .api.routes import router as routes_router
+from .api.metrics import router as metrics_router, MetricsMiddleware
 
 
 @asynccontextmanager
@@ -76,6 +77,7 @@ def create_app() -> FastAPI:
     # Performance profiling middleware (debug mode only)
     if settings.debug:
         app.add_middleware(ProfilingMiddleware, enabled=True)
+        app.add_middleware(MetricsMiddleware)
 
     # Include routers
     app.include_router(health_router, prefix="/api", tags=["health"])
@@ -101,6 +103,7 @@ def create_app() -> FastAPI:
     app.include_router(config_router, tags=["dev-tools"])
     app.include_router(dependencies_router, tags=["dev-tools"])
     app.include_router(routes_router, tags=["dev-tools"])
+    app.include_router(metrics_router, tags=["dev-tools"])
 
     # Add exception handler to capture errors (only in debug mode)
     if settings.debug:

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,6 +1,6 @@
 import { Routes, Route } from 'react-router-dom';
 import { Layout } from './components/Layout';
-import { Home, Login, Register, Play, Features, About, PlayScene, SceneDemo, Leaderboard, Ghosts, Profile, Achievements, Spectate, Friends, Presentation, Roadmap, CodebaseHealth, Changelog, DatabaseExplorer, CacheInspector, AudioJukebox, SystemStatus, ApiPlayground, WebSocketMonitor, BuildInfo, LogViewer, ErrorTracker, PerformanceProfiler, SessionInspector, FeatureFlags, EnvConfig, DependencyViewer, RouteExplorer } from './pages';
+import { Home, Login, Register, Play, Features, About, PlayScene, SceneDemo, Leaderboard, Ghosts, Profile, Achievements, Spectate, Friends, Presentation, Roadmap, CodebaseHealth, Changelog, DatabaseExplorer, CacheInspector, AudioJukebox, SystemStatus, ApiPlayground, WebSocketMonitor, BuildInfo, LogViewer, ErrorTracker, PerformanceProfiler, SessionInspector, FeatureFlags, EnvConfig, DependencyViewer, RouteExplorer, MetricsDashboard } from './pages';
 import { FirstPersonDemo } from './pages/FirstPersonDemo';
 import { FirstPersonTestPage } from './pages/FirstPersonTestPage';
 import { Debug3DPage } from './pages/Debug3DPage';
@@ -48,6 +48,7 @@ function App() {
         <Route path="env-config" element={<EnvConfig />} />
         <Route path="dependencies" element={<DependencyViewer />} />
         <Route path="routes" element={<RouteExplorer />} />
+        <Route path="metrics" element={<MetricsDashboard />} />
       </Route>
     </Routes>
   );

--- a/web/src/components/Layout.tsx
+++ b/web/src/components/Layout.tsx
@@ -184,6 +184,10 @@ export function Layout() {
                     <span className="menu-icon">🔀</span>
                     Route Explorer
                   </Link>
+                  <Link to="/metrics" onClick={closeDropdown}>
+                    <span className="menu-icon">📈</span>
+                    Metrics
+                  </Link>
                   <Link to="/codebase-health" onClick={closeDropdown}>
                     <span className="menu-icon">🩺</span>
                     Codebase Health

--- a/web/src/pages/MetricsDashboard.css
+++ b/web/src/pages/MetricsDashboard.css
@@ -1,0 +1,699 @@
+/**
+ * Metrics Dashboard Styles - Green/teal performance theme
+ */
+
+.metrics-dashboard {
+  min-height: 100vh;
+  background: #0d1117;
+  color: #e6edf3;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+}
+
+/* Loading State */
+.metrics-loading {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  min-height: 60vh;
+  gap: 1rem;
+}
+
+.loading-spinner {
+  width: 40px;
+  height: 40px;
+  border: 3px solid #21262d;
+  border-top-color: #22c55e;
+  border-radius: 50%;
+  animation: spin 1s linear infinite;
+}
+
+@keyframes spin {
+  to { transform: rotate(360deg); }
+}
+
+/* Header */
+.metrics-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 1rem 1.5rem;
+  background: #161b22;
+  border-bottom: 1px solid #30363d;
+}
+
+.metrics-header .header-left {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+}
+
+.metrics-header h1 {
+  margin: 0;
+  font-size: 1.25rem;
+  font-weight: 600;
+}
+
+.uptime-badge {
+  font-size: 0.75rem;
+  font-weight: 600;
+  padding: 0.25rem 0.75rem;
+  background: #22c55e22;
+  color: #22c55e;
+  border-radius: 12px;
+}
+
+.header-right {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+}
+
+.auto-refresh-toggle {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.85rem;
+  color: #8b949e;
+  cursor: pointer;
+}
+
+.auto-refresh-toggle input {
+  accent-color: #22c55e;
+}
+
+.reset-btn {
+  padding: 0.4rem 0.75rem;
+  background: #21262d;
+  border: 1px solid #30363d;
+  border-radius: 6px;
+  color: #8b949e;
+  font-size: 0.85rem;
+  cursor: pointer;
+  transition: all 0.15s;
+}
+
+.reset-btn:hover {
+  background: #f8514922;
+  border-color: #f85149;
+  color: #f85149;
+}
+
+/* Stats Grid */
+.stats-grid {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 1rem;
+  padding: 1rem 1.5rem;
+  background: #161b22;
+  border-bottom: 1px solid #21262d;
+}
+
+.stat-card {
+  background: #0d1117;
+  border: 1px solid #30363d;
+  border-radius: 8px;
+  padding: 1rem;
+  text-align: center;
+}
+
+.stat-card.requests {
+  border-color: #22c55e55;
+}
+
+.stat-card.requests .stat-value {
+  color: #22c55e;
+}
+
+.stat-card.errors {
+  border-color: #f8514955;
+}
+
+.stat-card.errors .stat-value {
+  color: #f85149;
+}
+
+.stat-card.response-time {
+  border-color: #3b82f655;
+}
+
+.stat-card.response-time .stat-value {
+  color: #3b82f6;
+}
+
+.stat-card.percentiles {
+  border-color: #a855f755;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  gap: 0.5rem;
+}
+
+.percentile-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.percentile-label {
+  font-size: 0.75rem;
+  color: #8b949e;
+  font-weight: 600;
+}
+
+.percentile-value {
+  font-size: 1rem;
+  font-weight: 700;
+  color: #a855f7;
+}
+
+.stat-value {
+  font-size: 2rem;
+  font-weight: 700;
+  color: #e6edf3;
+}
+
+.stat-label {
+  font-size: 0.75rem;
+  color: #8b949e;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  margin-top: 0.25rem;
+}
+
+.stat-subvalue {
+  font-size: 0.8rem;
+  color: #6b7280;
+  margin-top: 0.5rem;
+}
+
+/* System Stats */
+.system-stats {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 1rem;
+  padding: 1rem 1.5rem;
+  background: #161b22;
+  border-bottom: 1px solid #21262d;
+}
+
+.system-stat {
+  background: #0d1117;
+  border: 1px solid #30363d;
+  border-radius: 8px;
+  padding: 0.75rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.system-stat.mini {
+  flex-direction: row;
+  justify-content: space-around;
+  align-items: center;
+}
+
+.mini-stat {
+  text-align: center;
+}
+
+.mini-value {
+  font-size: 1.25rem;
+  font-weight: 700;
+  color: #e6edf3;
+  display: block;
+}
+
+.mini-label {
+  font-size: 0.65rem;
+  color: #8b949e;
+  text-transform: uppercase;
+}
+
+.system-icon {
+  font-size: 1rem;
+}
+
+.system-info {
+  display: flex;
+  align-items: baseline;
+  gap: 0.5rem;
+}
+
+.system-value {
+  font-size: 1.1rem;
+  font-weight: 700;
+  color: #e6edf3;
+}
+
+.system-label {
+  font-size: 0.7rem;
+  color: #8b949e;
+}
+
+.progress-bar {
+  height: 6px;
+  background: #21262d;
+  border-radius: 3px;
+  overflow: hidden;
+}
+
+.progress-fill {
+  height: 100%;
+  border-radius: 3px;
+  transition: width 0.3s ease;
+}
+
+.progress-fill.cpu {
+  background: linear-gradient(90deg, #22c55e, #d29922);
+}
+
+.progress-fill.memory {
+  background: linear-gradient(90deg, #3b82f6, #a855f7);
+}
+
+.progress-fill.disk {
+  background: linear-gradient(90deg, #06b6d4, #22c55e);
+}
+
+/* Distribution Row */
+.distribution-row {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 1rem;
+  padding: 1rem 1.5rem;
+  background: #161b22;
+  border-bottom: 1px solid #21262d;
+}
+
+.distribution-card {
+  background: #0d1117;
+  border: 1px solid #30363d;
+  border-radius: 8px;
+  padding: 1rem;
+}
+
+.distribution-card h3 {
+  margin: 0 0 0.75rem 0;
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: #8b949e;
+}
+
+.method-bars,
+.status-bars {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.method-bar-row,
+.status-bar-row {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.method-badge,
+.status-badge {
+  font-size: 0.65rem;
+  font-weight: 700;
+  padding: 0.15rem 0.4rem;
+  border-radius: 4px;
+  min-width: 45px;
+  text-align: center;
+}
+
+.bar-container {
+  flex: 1;
+  height: 8px;
+  background: #21262d;
+  border-radius: 4px;
+  overflow: hidden;
+}
+
+.bar-fill {
+  height: 100%;
+  border-radius: 4px;
+  transition: width 0.3s ease;
+}
+
+.bar-count {
+  font-size: 0.75rem;
+  color: #8b949e;
+  min-width: 40px;
+  text-align: right;
+}
+
+/* View Controls */
+.view-controls {
+  padding: 0.75rem 1.5rem;
+  background: #161b22;
+  border-bottom: 1px solid #21262d;
+}
+
+.view-toggle {
+  display: flex;
+  gap: 0;
+}
+
+.view-toggle button {
+  padding: 0.5rem 1rem;
+  background: transparent;
+  border: 1px solid #30363d;
+  color: #8b949e;
+  font-size: 0.85rem;
+  cursor: pointer;
+  transition: all 0.15s;
+}
+
+.view-toggle button:first-child {
+  border-radius: 6px 0 0 6px;
+}
+
+.view-toggle button:last-child {
+  border-radius: 0 6px 6px 0;
+}
+
+.view-toggle button:not(:first-child) {
+  border-left: none;
+}
+
+.view-toggle button:hover {
+  color: #e6edf3;
+  background: #21262d;
+}
+
+.view-toggle button.active {
+  color: #22c55e;
+  background: #22c55e22;
+  border-color: #22c55e55;
+}
+
+/* Content */
+.metrics-content {
+  padding: 1.5rem;
+}
+
+.no-data {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 3rem;
+  color: #6b7280;
+  background: #0d1117;
+  border: 1px solid #30363d;
+  border-radius: 8px;
+}
+
+/* Timeseries Section */
+.timeseries-section {
+  background: #161b22;
+  border: 1px solid #30363d;
+  border-radius: 8px;
+  padding: 1rem;
+}
+
+.timeseries-section h3 {
+  margin: 0 0 1rem 0;
+  font-size: 0.9rem;
+  font-weight: 600;
+  color: #e6edf3;
+}
+
+.timeseries-chart {
+  display: flex;
+  align-items: flex-end;
+  gap: 2px;
+  height: 150px;
+  padding: 1rem 0;
+  background: #0d1117;
+  border-radius: 6px;
+}
+
+.chart-bar-container {
+  flex: 1;
+  height: 100%;
+  display: flex;
+  align-items: flex-end;
+}
+
+.chart-bar {
+  width: 100%;
+  min-height: 2px;
+  border-radius: 2px 2px 0 0;
+  transition: height 0.3s ease;
+}
+
+.chart-legend {
+  display: flex;
+  gap: 1.5rem;
+  justify-content: center;
+  padding-top: 0.75rem;
+}
+
+.legend-item {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.75rem;
+  color: #8b949e;
+}
+
+.legend-color {
+  width: 12px;
+  height: 12px;
+  border-radius: 2px;
+}
+
+.legend-color.success {
+  background: #22c55e;
+}
+
+.legend-color.error {
+  background: #f85149;
+}
+
+/* Endpoints Section */
+.endpoints-section {
+  background: #161b22;
+  border: 1px solid #30363d;
+  border-radius: 8px;
+  overflow: hidden;
+}
+
+.endpoints-section h3 {
+  margin: 0;
+  padding: 1rem;
+  font-size: 0.9rem;
+  font-weight: 600;
+  color: #e6edf3;
+  background: #21262d;
+  border-bottom: 1px solid #30363d;
+}
+
+.endpoints-table {
+  background: #0d1117;
+}
+
+.table-header {
+  display: grid;
+  grid-template-columns: 2fr 100px 100px 100px 80px;
+  gap: 1rem;
+  padding: 0.75rem 1rem;
+  background: #161b22;
+  border-bottom: 1px solid #30363d;
+  font-size: 0.7rem;
+  font-weight: 600;
+  color: #8b949e;
+  text-transform: uppercase;
+}
+
+.table-row {
+  display: grid;
+  grid-template-columns: 2fr 100px 100px 100px 80px;
+  gap: 1rem;
+  padding: 0.6rem 1rem;
+  border-bottom: 1px solid #21262d;
+  align-items: center;
+}
+
+.table-row:last-child {
+  border-bottom: none;
+}
+
+.table-row:hover {
+  background: #161b22;
+}
+
+.col-endpoint {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  overflow: hidden;
+}
+
+.col-endpoint code {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.8rem;
+  color: #e6edf3;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.col-count,
+.col-avg,
+.col-p95 {
+  font-size: 0.85rem;
+  font-weight: 500;
+}
+
+.col-errors {
+  text-align: center;
+}
+
+.error-count {
+  font-size: 0.75rem;
+  font-weight: 600;
+  padding: 0.15rem 0.4rem;
+  background: #f8514922;
+  color: #f85149;
+  border-radius: 4px;
+}
+
+.no-errors {
+  color: #6b7280;
+}
+
+.method-badge.small {
+  font-size: 0.6rem;
+  padding: 0.1rem 0.3rem;
+  min-width: 35px;
+}
+
+/* Requests Section */
+.requests-section {
+  background: #161b22;
+  border: 1px solid #30363d;
+  border-radius: 8px;
+  overflow: hidden;
+}
+
+.requests-section h3 {
+  margin: 0;
+  padding: 1rem;
+  font-size: 0.9rem;
+  font-weight: 600;
+  color: #e6edf3;
+  background: #21262d;
+  border-bottom: 1px solid #30363d;
+}
+
+.requests-list {
+  background: #0d1117;
+  max-height: 400px;
+  overflow-y: auto;
+}
+
+.request-row {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.5rem 1rem;
+  border-bottom: 1px solid #21262d;
+  font-size: 0.85rem;
+}
+
+.request-row:last-child {
+  border-bottom: none;
+}
+
+.request-row:hover {
+  background: #161b22;
+}
+
+.request-path {
+  flex: 1;
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.8rem;
+  color: #e6edf3;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.status-code {
+  font-size: 0.7rem;
+  font-weight: 600;
+  padding: 0.15rem 0.4rem;
+  border-radius: 4px;
+  min-width: 35px;
+  text-align: center;
+}
+
+.response-time {
+  font-size: 0.8rem;
+  font-weight: 500;
+  min-width: 60px;
+  text-align: right;
+}
+
+.timestamp {
+  font-size: 0.75rem;
+  color: #6b7280;
+  min-width: 75px;
+}
+
+/* Responsive */
+@media (max-width: 1024px) {
+  .stats-grid {
+    grid-template-columns: repeat(2, 1fr);
+  }
+
+  .system-stats {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}
+
+@media (max-width: 768px) {
+  .stats-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .system-stats {
+    grid-template-columns: 1fr;
+  }
+
+  .distribution-row {
+    grid-template-columns: 1fr;
+  }
+
+  .table-header,
+  .table-row {
+    grid-template-columns: 1fr;
+    gap: 0.5rem;
+  }
+
+  .table-header {
+    display: none;
+  }
+
+  .table-row {
+    display: flex;
+    flex-wrap: wrap;
+  }
+
+  .col-endpoint {
+    width: 100%;
+  }
+
+  .request-row {
+    flex-wrap: wrap;
+  }
+
+  .request-path {
+    width: 100%;
+    margin-top: 0.25rem;
+  }
+}

--- a/web/src/pages/MetricsDashboard.tsx
+++ b/web/src/pages/MetricsDashboard.tsx
@@ -1,0 +1,601 @@
+/**
+ * Metrics Dashboard - Application performance metrics
+ *
+ * Features:
+ * - Overview stats (requests, errors, response times)
+ * - System metrics (CPU, memory, disk)
+ * - Per-endpoint metrics
+ * - Recent requests log
+ * - Timeseries visualization
+ * - Auto-refresh
+ */
+
+import { useState, useEffect, useCallback } from 'react';
+import './MetricsDashboard.css';
+
+const API_BASE = 'http://localhost:8000/api/metrics';
+
+interface OverviewMetrics {
+  total_requests: number;
+  total_errors: number;
+  error_rate: number;
+  avg_response_time_ms: number;
+  p50_response_time_ms: number;
+  p95_response_time_ms: number;
+  p99_response_time_ms: number;
+  requests_per_minute: number;
+  uptime_seconds: number;
+}
+
+interface SystemMetrics {
+  cpu_percent: number;
+  memory_percent: number;
+  memory_used_mb: number;
+  memory_available_mb: number;
+  disk_percent: number;
+  disk_used_gb: number;
+  disk_free_gb: number;
+  open_files: number;
+  threads: number;
+}
+
+interface EndpointMetric {
+  path: string;
+  method: string;
+  request_count: number;
+  avg_response_time_ms: number;
+  min_response_time_ms: number;
+  max_response_time_ms: number;
+  p50_response_time_ms: number;
+  p95_response_time_ms: number;
+  p99_response_time_ms: number;
+  error_count: number;
+  error_rate: number;
+}
+
+interface RecentRequest {
+  timestamp: number;
+  method: string;
+  path: string;
+  status_code: number;
+  response_time_ms: number;
+}
+
+interface TimeseriesPoint {
+  timestamp: number;
+  requests: number;
+  avg_response_time: number;
+  errors: number;
+}
+
+const METHOD_COLORS: Record<string, string> = {
+  GET: '#22c55e',
+  POST: '#3b82f6',
+  PUT: '#d29922',
+  PATCH: '#a855f7',
+  DELETE: '#f85149',
+};
+
+function formatUptime(seconds: number): string {
+  const hours = Math.floor(seconds / 3600);
+  const mins = Math.floor((seconds % 3600) / 60);
+  const secs = Math.floor(seconds % 60);
+  if (hours > 0) return `${hours}h ${mins}m`;
+  if (mins > 0) return `${mins}m ${secs}s`;
+  return `${secs}s`;
+}
+
+function formatBytes(mb: number): string {
+  if (mb >= 1024) return `${(mb / 1024).toFixed(1)} GB`;
+  return `${mb.toFixed(0)} MB`;
+}
+
+export function MetricsDashboard() {
+  const [overview, setOverview] = useState<OverviewMetrics | null>(null);
+  const [system, setSystem] = useState<SystemMetrics | null>(null);
+  const [methodCounts, setMethodCounts] = useState<Record<string, number>>({});
+  const [statusCounts, setStatusCounts] = useState<Record<string, number>>({});
+  const [endpoints, setEndpoints] = useState<EndpointMetric[]>([]);
+  const [recentRequests, setRecentRequests] = useState<RecentRequest[]>([]);
+  const [timeseries, setTimeseries] = useState<TimeseriesPoint[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [autoRefresh, setAutoRefresh] = useState(true);
+  const [view, setView] = useState<'overview' | 'endpoints' | 'requests'>('overview');
+
+  // Fetch overview metrics
+  const fetchOverview = useCallback(async () => {
+    try {
+      const res = await fetch(API_BASE);
+      if (res.ok) {
+        const data = await res.json();
+        setOverview(data.overview);
+        setSystem(data.system);
+        setMethodCounts(data.method_counts || {});
+        setStatusCounts(data.status_counts || {});
+      }
+    } catch {
+      // Silently fail
+    }
+  }, []);
+
+  // Fetch endpoint metrics
+  const fetchEndpoints = useCallback(async () => {
+    try {
+      const res = await fetch(`${API_BASE}/endpoints`);
+      if (res.ok) {
+        const data = await res.json();
+        setEndpoints(data.endpoints);
+      }
+    } catch {
+      // Silently fail
+    }
+  }, []);
+
+  // Fetch recent requests
+  const fetchRecent = useCallback(async () => {
+    try {
+      const res = await fetch(`${API_BASE}/recent?limit=50`);
+      if (res.ok) {
+        const data = await res.json();
+        setRecentRequests(data.requests);
+      }
+    } catch {
+      // Silently fail
+    }
+  }, []);
+
+  // Fetch timeseries
+  const fetchTimeseries = useCallback(async () => {
+    try {
+      const res = await fetch(`${API_BASE}/timeseries?minutes=5`);
+      if (res.ok) {
+        const data = await res.json();
+        setTimeseries(data.timeseries);
+      }
+    } catch {
+      // Silently fail
+    }
+  }, []);
+
+  // Initial fetch
+  useEffect(() => {
+    const loadData = async () => {
+      setLoading(true);
+      await Promise.all([
+        fetchOverview(),
+        fetchEndpoints(),
+        fetchRecent(),
+        fetchTimeseries(),
+      ]);
+      setLoading(false);
+    };
+    loadData();
+  }, [fetchOverview, fetchEndpoints, fetchRecent, fetchTimeseries]);
+
+  // Auto-refresh
+  useEffect(() => {
+    if (!autoRefresh) return;
+
+    const interval = setInterval(() => {
+      fetchOverview();
+      fetchEndpoints();
+      fetchRecent();
+      fetchTimeseries();
+    }, 5000);
+
+    return () => clearInterval(interval);
+  }, [autoRefresh, fetchOverview, fetchEndpoints, fetchRecent, fetchTimeseries]);
+
+  // Reset metrics
+  const handleReset = async () => {
+    if (!confirm('Reset all metrics? This cannot be undone.')) return;
+    try {
+      const res = await fetch(`${API_BASE}/reset`, { method: 'POST' });
+      if (res.ok) {
+        await Promise.all([
+          fetchOverview(),
+          fetchEndpoints(),
+          fetchRecent(),
+          fetchTimeseries(),
+        ]);
+      }
+    } catch {
+      // Silently fail
+    }
+  };
+
+  // Get status color
+  const getStatusColor = (status: number): string => {
+    if (status >= 500) return '#f85149';
+    if (status >= 400) return '#d29922';
+    if (status >= 300) return '#3b82f6';
+    return '#22c55e';
+  };
+
+  // Get response time color
+  const getResponseTimeColor = (ms: number): string => {
+    if (ms > 1000) return '#f85149';
+    if (ms > 500) return '#d29922';
+    if (ms > 200) return '#3b82f6';
+    return '#22c55e';
+  };
+
+  if (loading) {
+    return (
+      <div className="metrics-dashboard">
+        <div className="metrics-loading">
+          <div className="loading-spinner" />
+          <p>Loading metrics...</p>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="metrics-dashboard">
+      {/* Header */}
+      <header className="metrics-header">
+        <div className="header-left">
+          <h1>Metrics Dashboard</h1>
+          {overview && (
+            <span className="uptime-badge">
+              Uptime: {formatUptime(overview.uptime_seconds)}
+            </span>
+          )}
+        </div>
+        <div className="header-right">
+          <label className="auto-refresh-toggle">
+            <input
+              type="checkbox"
+              checked={autoRefresh}
+              onChange={(e) => setAutoRefresh(e.target.checked)}
+            />
+            Auto-refresh
+          </label>
+          <button onClick={handleReset} className="reset-btn">
+            Reset
+          </button>
+        </div>
+      </header>
+
+      {/* Overview Stats */}
+      {overview && (
+        <div className="stats-grid">
+          <div className="stat-card requests">
+            <div className="stat-value">{overview.total_requests.toLocaleString()}</div>
+            <div className="stat-label">Total Requests</div>
+            <div className="stat-subvalue">
+              {overview.requests_per_minute.toFixed(1)}/min
+            </div>
+          </div>
+          <div className="stat-card errors">
+            <div className="stat-value">{overview.total_errors.toLocaleString()}</div>
+            <div className="stat-label">Total Errors</div>
+            <div className="stat-subvalue">
+              {(overview.error_rate * 100).toFixed(2)}% rate
+            </div>
+          </div>
+          <div className="stat-card response-time">
+            <div className="stat-value">{overview.avg_response_time_ms.toFixed(1)}</div>
+            <div className="stat-label">Avg Response (ms)</div>
+            <div className="stat-subvalue">
+              p50: {overview.p50_response_time_ms.toFixed(1)}ms
+            </div>
+          </div>
+          <div className="stat-card percentiles">
+            <div className="percentile-row">
+              <span className="percentile-label">p95</span>
+              <span className="percentile-value">
+                {overview.p95_response_time_ms.toFixed(1)}ms
+              </span>
+            </div>
+            <div className="percentile-row">
+              <span className="percentile-label">p99</span>
+              <span className="percentile-value">
+                {overview.p99_response_time_ms.toFixed(1)}ms
+              </span>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* System Stats */}
+      {system && (
+        <div className="system-stats">
+          <div className="system-stat">
+            <div className="system-icon">💻</div>
+            <div className="system-info">
+              <div className="system-value">{system.cpu_percent.toFixed(1)}%</div>
+              <div className="system-label">CPU</div>
+            </div>
+            <div className="progress-bar">
+              <div
+                className="progress-fill cpu"
+                style={{ width: `${Math.min(system.cpu_percent, 100)}%` }}
+              />
+            </div>
+          </div>
+          <div className="system-stat">
+            <div className="system-icon">🧠</div>
+            <div className="system-info">
+              <div className="system-value">{system.memory_percent.toFixed(1)}%</div>
+              <div className="system-label">
+                Memory ({formatBytes(system.memory_used_mb)})
+              </div>
+            </div>
+            <div className="progress-bar">
+              <div
+                className="progress-fill memory"
+                style={{ width: `${Math.min(system.memory_percent, 100)}%` }}
+              />
+            </div>
+          </div>
+          <div className="system-stat">
+            <div className="system-icon">💾</div>
+            <div className="system-info">
+              <div className="system-value">{system.disk_percent.toFixed(1)}%</div>
+              <div className="system-label">
+                Disk ({system.disk_free_gb.toFixed(1)} GB free)
+              </div>
+            </div>
+            <div className="progress-bar">
+              <div
+                className="progress-fill disk"
+                style={{ width: `${Math.min(system.disk_percent, 100)}%` }}
+              />
+            </div>
+          </div>
+          <div className="system-stat mini">
+            <div className="mini-stat">
+              <span className="mini-value">{system.threads}</span>
+              <span className="mini-label">Threads</span>
+            </div>
+            <div className="mini-stat">
+              <span className="mini-value">{system.open_files}</span>
+              <span className="mini-label">Open Files</span>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* Method and Status Distribution */}
+      <div className="distribution-row">
+        <div className="distribution-card">
+          <h3>By Method</h3>
+          <div className="method-bars">
+            {Object.entries(methodCounts).map(([method, count]) => {
+              const total = Object.values(methodCounts).reduce((a, b) => a + b, 0);
+              const percent = total > 0 ? (count / total) * 100 : 0;
+              return (
+                <div key={method} className="method-bar-row">
+                  <span
+                    className="method-badge"
+                    style={{
+                      background: METHOD_COLORS[method] + '22',
+                      color: METHOD_COLORS[method],
+                    }}
+                  >
+                    {method}
+                  </span>
+                  <div className="bar-container">
+                    <div
+                      className="bar-fill"
+                      style={{
+                        width: `${percent}%`,
+                        background: METHOD_COLORS[method],
+                      }}
+                    />
+                  </div>
+                  <span className="bar-count">{count}</span>
+                </div>
+              );
+            })}
+          </div>
+        </div>
+        <div className="distribution-card">
+          <h3>By Status</h3>
+          <div className="status-bars">
+            {Object.entries(statusCounts)
+              .sort(([a], [b]) => Number(a) - Number(b))
+              .map(([status, count]) => {
+                const total = Object.values(statusCounts).reduce((a, b) => a + b, 0);
+                const percent = total > 0 ? (count / total) * 100 : 0;
+                return (
+                  <div key={status} className="status-bar-row">
+                    <span
+                      className="status-badge"
+                      style={{
+                        background: getStatusColor(Number(status)) + '22',
+                        color: getStatusColor(Number(status)),
+                      }}
+                    >
+                      {status}
+                    </span>
+                    <div className="bar-container">
+                      <div
+                        className="bar-fill"
+                        style={{
+                          width: `${percent}%`,
+                          background: getStatusColor(Number(status)),
+                        }}
+                      />
+                    </div>
+                    <span className="bar-count">{count}</span>
+                  </div>
+                );
+              })}
+          </div>
+        </div>
+      </div>
+
+      {/* View Toggle */}
+      <div className="view-controls">
+        <div className="view-toggle">
+          <button
+            className={view === 'overview' ? 'active' : ''}
+            onClick={() => setView('overview')}
+          >
+            Timeseries
+          </button>
+          <button
+            className={view === 'endpoints' ? 'active' : ''}
+            onClick={() => setView('endpoints')}
+          >
+            Endpoints
+          </button>
+          <button
+            className={view === 'requests' ? 'active' : ''}
+            onClick={() => setView('requests')}
+          >
+            Recent Requests
+          </button>
+        </div>
+      </div>
+
+      {/* Content */}
+      <div className="metrics-content">
+        {/* Timeseries View */}
+        {view === 'overview' && (
+          <div className="timeseries-section">
+            <h3>Request Rate (Last 5 minutes)</h3>
+            {timeseries.length === 0 ? (
+              <div className="no-data">No timeseries data yet</div>
+            ) : (
+              <div className="timeseries-chart">
+                {timeseries.slice(-60).map((point, idx) => {
+                  const maxReqs = Math.max(...timeseries.map((p) => p.requests), 1);
+                  const height = (point.requests / maxReqs) * 100;
+                  return (
+                    <div key={idx} className="chart-bar-container">
+                      <div
+                        className="chart-bar"
+                        style={{
+                          height: `${height}%`,
+                          background: point.errors > 0 ? '#f85149' : '#22c55e',
+                        }}
+                        title={`${point.requests} requests, ${point.errors} errors, ${point.avg_response_time}ms avg`}
+                      />
+                    </div>
+                  );
+                })}
+              </div>
+            )}
+            <div className="chart-legend">
+              <span className="legend-item">
+                <span className="legend-color success" />
+                Success
+              </span>
+              <span className="legend-item">
+                <span className="legend-color error" />
+                With Errors
+              </span>
+            </div>
+          </div>
+        )}
+
+        {/* Endpoints View */}
+        {view === 'endpoints' && (
+          <div className="endpoints-section">
+            <h3>Endpoint Metrics</h3>
+            {endpoints.length === 0 ? (
+              <div className="no-data">No endpoint data yet</div>
+            ) : (
+              <div className="endpoints-table">
+                <div className="table-header">
+                  <span className="col-endpoint">Endpoint</span>
+                  <span className="col-count">Requests</span>
+                  <span className="col-avg">Avg</span>
+                  <span className="col-p95">p95</span>
+                  <span className="col-errors">Errors</span>
+                </div>
+                {endpoints.map((ep, idx) => (
+                  <div key={idx} className="table-row">
+                    <span className="col-endpoint">
+                      <span
+                        className="method-badge small"
+                        style={{
+                          background: METHOD_COLORS[ep.method] + '22',
+                          color: METHOD_COLORS[ep.method],
+                        }}
+                      >
+                        {ep.method}
+                      </span>
+                      <code>{ep.path}</code>
+                    </span>
+                    <span className="col-count">{ep.request_count}</span>
+                    <span
+                      className="col-avg"
+                      style={{ color: getResponseTimeColor(ep.avg_response_time_ms) }}
+                    >
+                      {ep.avg_response_time_ms.toFixed(1)}ms
+                    </span>
+                    <span
+                      className="col-p95"
+                      style={{ color: getResponseTimeColor(ep.p95_response_time_ms) }}
+                    >
+                      {ep.p95_response_time_ms.toFixed(1)}ms
+                    </span>
+                    <span className="col-errors">
+                      {ep.error_count > 0 ? (
+                        <span className="error-count">{ep.error_count}</span>
+                      ) : (
+                        <span className="no-errors">0</span>
+                      )}
+                    </span>
+                  </div>
+                ))}
+              </div>
+            )}
+          </div>
+        )}
+
+        {/* Recent Requests View */}
+        {view === 'requests' && (
+          <div className="requests-section">
+            <h3>Recent Requests</h3>
+            {recentRequests.length === 0 ? (
+              <div className="no-data">No recent requests</div>
+            ) : (
+              <div className="requests-list">
+                {recentRequests.map((req, idx) => (
+                  <div key={idx} className="request-row">
+                    <span
+                      className="method-badge small"
+                      style={{
+                        background: METHOD_COLORS[req.method] + '22',
+                        color: METHOD_COLORS[req.method],
+                      }}
+                    >
+                      {req.method}
+                    </span>
+                    <code className="request-path">{req.path}</code>
+                    <span
+                      className="status-code"
+                      style={{
+                        background: getStatusColor(req.status_code) + '22',
+                        color: getStatusColor(req.status_code),
+                      }}
+                    >
+                      {req.status_code}
+                    </span>
+                    <span
+                      className="response-time"
+                      style={{ color: getResponseTimeColor(req.response_time_ms) }}
+                    >
+                      {req.response_time_ms.toFixed(1)}ms
+                    </span>
+                    <span className="timestamp">
+                      {new Date(req.timestamp * 1000).toLocaleTimeString()}
+                    </span>
+                  </div>
+                ))}
+              </div>
+            )}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export default MetricsDashboard;

--- a/web/src/pages/index.ts
+++ b/web/src/pages/index.ts
@@ -31,3 +31,4 @@ export { FeatureFlags } from './FeatureFlags';
 export { EnvConfig } from './EnvConfig';
 export { DependencyViewer } from './DependencyViewer';
 export { RouteExplorer } from './RouteExplorer';
+export { MetricsDashboard } from './MetricsDashboard';


### PR DESCRIPTION
## Summary
- Add Metrics Dashboard for real-time application performance monitoring
- Backend API with middleware that tracks all requests automatically
- Overview stats: request counts, error rates, response time percentiles
- System metrics: CPU, memory, disk usage monitoring
- Per-endpoint breakdown with detailed timing statistics
- Timeseries chart showing request rate over time
- Auto-refresh and manual reset capabilities

## Test plan
- [ ] Visit /metrics page
- [ ] Verify overview stats display (requests, errors, response times)
- [ ] Verify system metrics show CPU/memory/disk
- [ ] Make API requests and verify metrics update
- [ ] Test auto-refresh toggle
- [ ] Test endpoint metrics view
- [ ] Test recent requests view
- [ ] Test reset button

🤖 Generated with [Claude Code](https://claude.com/claude-code)