### PR TITLE
feat(content): add Bestiary page

### DIFF
--- a/server/app/api/bestiary.py
+++ b/server/app/api/bestiary.py
@@ -1,0 +1,544 @@
+"""
+Bestiary API - Creature and enemy database.
+
+Features:
+- Creature categories (Common, Elite, Boss, etc.)
+- Stats (health, damage, speed)
+- Floor ranges and spawn locations
+- Abilities and attack patterns
+- Loot drops and weaknesses
+"""
+
+from typing import Optional
+from fastapi import APIRouter
+from pydantic import BaseModel
+
+router = APIRouter(prefix="/api/bestiary", tags=["bestiary"])
+
+
+class Ability(BaseModel):
+    """A creature ability or attack."""
+    name: str
+    description: str
+    damage: Optional[int] = None
+    effect: Optional[str] = None
+
+
+class LootDrop(BaseModel):
+    """A potential loot drop."""
+    item: str
+    chance: str  # "Common", "Rare", "Very Rare"
+
+
+class Creature(BaseModel):
+    """A bestiary creature entry."""
+    id: str
+    name: str
+    title: Optional[str] = None
+    category: str  # "common", "elite", "miniboss", "boss", "unique"
+    description: str
+    appearance: str
+    behavior: str
+    floors: str  # e.g., "1-5", "6-10", "All"
+
+    # Stats
+    health: int
+    damage: int
+    speed: str  # "Slow", "Normal", "Fast", "Very Fast"
+
+    # Combat
+    abilities: list[Ability]
+    weaknesses: list[str]
+    resistances: list[str]
+
+    # Rewards
+    experience: int
+    loot: list[LootDrop]
+
+    # Visual
+    icon: str
+    threat_level: int  # 1-5 skulls
+
+
+# ============================================================================
+# BESTIARY DATA
+# ============================================================================
+
+CREATURES: list[Creature] = [
+    # === COMMON ENEMIES (Floors 1-5) ===
+    Creature(
+        id="hollow_walker",
+        name="Hollow Walker",
+        category="common",
+        description="The animated remains of fallen adventurers, still wearing their rusted armor and clutching broken weapons. Their empty eyes glow with a faint, hungry light.",
+        appearance="Shambling humanoid corpse in tattered armor. Pale, desiccated skin stretched over bones. Glowing pinpoints where eyes should be.",
+        behavior="Patrols set paths mindlessly. Attacks any living creature on sight. Will pursue until target is lost or destroyed.",
+        floors="1-5",
+        health=30,
+        damage=8,
+        speed="Slow",
+        abilities=[
+            Ability(name="Rusted Strike", description="A clumsy swing with a corroded weapon", damage=8),
+            Ability(name="Hollow Grasp", description="Grabs and holds the target briefly", effect="Immobilize 1s"),
+        ],
+        weaknesses=["Fire", "Holy"],
+        resistances=["Poison", "Cold"],
+        experience=15,
+        loot=[
+            LootDrop(item="Rusted Coin", chance="Common"),
+            LootDrop(item="Tattered Cloth", chance="Common"),
+            LootDrop(item="Hollow Essence", chance="Rare"),
+        ],
+        icon="💀",
+        threat_level=1,
+    ),
+    Creature(
+        id="dungeon_rat",
+        name="Dungeon Rat",
+        category="common",
+        description="Rats grown large and aggressive from feeding on magical residue. They hunt in packs and show disturbing cunning.",
+        appearance="Dog-sized rat with matted fur and glowing eyes. Elongated teeth drip with infectious saliva.",
+        behavior="Swarms in groups of 3-5. Flanks prey and attacks from multiple angles. Retreats when pack is reduced below 2.",
+        floors="1-3",
+        health=15,
+        damage=5,
+        speed="Fast",
+        abilities=[
+            Ability(name="Gnaw", description="Rapid biting attack", damage=5),
+            Ability(name="Pack Tactics", description="Gains bonus damage when allies are nearby", effect="+2 damage per nearby rat"),
+            Ability(name="Disease Bite", description="Chance to inflict infection", effect="Poison 3s"),
+        ],
+        weaknesses=["Fire", "Area attacks"],
+        resistances=["Poison"],
+        experience=8,
+        loot=[
+            LootDrop(item="Rat Tail", chance="Common"),
+            LootDrop(item="Diseased Fang", chance="Rare"),
+        ],
+        icon="🐀",
+        threat_level=1,
+    ),
+    Creature(
+        id="animated_armor",
+        name="Animated Armor",
+        category="common",
+        description="Empty suits of Valdrian armor, still following patrol routes programmed centuries ago. They attack with mechanical precision.",
+        appearance="Complete set of ornate plate armor floating without a wearer. Joints creak and grind. Visor reveals only darkness within.",
+        behavior="Follows predetermined patrol routes. Challenges intruders with archaic phrases before attacking. Returns to patrol if target flees zone.",
+        floors="2-5",
+        health=50,
+        damage=12,
+        speed="Slow",
+        abilities=[
+            Ability(name="Heavy Swing", description="Powerful overhead attack", damage=15),
+            Ability(name="Shield Bash", description="Knocks target back", damage=8, effect="Knockback"),
+            Ability(name="Defensive Stance", description="Reduces incoming damage temporarily", effect="50% damage reduction 3s"),
+        ],
+        weaknesses=["Lightning", "Rust attacks"],
+        resistances=["Poison", "Psychic", "Piercing"],
+        experience=25,
+        loot=[
+            LootDrop(item="Armor Scraps", chance="Common"),
+            LootDrop(item="Valdrian Steel Shard", chance="Rare"),
+            LootDrop(item="Animation Core", chance="Very Rare"),
+        ],
+        icon="🛡️",
+        threat_level=2,
+    ),
+    Creature(
+        id="tomb_spider",
+        name="Tomb Spider",
+        category="common",
+        description="Pale spiders that weave webs of crystallized magic. Their bite drains more than blood.",
+        appearance="Cat-sized spider with translucent carapace. Internal organs glow faintly. Webs shimmer with captured magical energy.",
+        behavior="Creates web traps in chokepoints. Waits in ceiling corners. Drops on unsuspecting prey.",
+        floors="1-5",
+        health=20,
+        damage=6,
+        speed="Fast",
+        abilities=[
+            Ability(name="Venomous Bite", description="Injects paralyzing venom", damage=6, effect="Slow 2s"),
+            Ability(name="Web Shot", description="Fires sticky web at range", effect="Root 2s"),
+            Ability(name="Mana Drain", description="Drains magical energy on hit", effect="-10 Mana"),
+        ],
+        weaknesses=["Fire", "Crushing"],
+        resistances=["Poison"],
+        experience=12,
+        loot=[
+            LootDrop(item="Spider Silk", chance="Common"),
+            LootDrop(item="Venom Gland", chance="Rare"),
+            LootDrop(item="Crystallized Web", chance="Very Rare"),
+        ],
+        icon="🕷️",
+        threat_level=1,
+    ),
+
+    # === ELITE ENEMIES ===
+    Creature(
+        id="bone_knight",
+        name="Bone Knight",
+        category="elite",
+        description="The elite warriors of ancient Valdris, their loyalty outlasting their flesh. They retain their combat training and tactical awareness.",
+        appearance="Skeleton in blackened plate armor. Blue flames burn in eye sockets. Wields ancient weapons with obvious skill.",
+        behavior="Commands nearby undead. Uses tactical formations. Retreats to regroup if overwhelmed.",
+        floors="3-7",
+        health=120,
+        damage=20,
+        speed="Normal",
+        abilities=[
+            Ability(name="Cleaving Strike", description="Wide arc attack hitting multiple targets", damage=18),
+            Ability(name="Rally Undead", description="Empowers nearby undead allies", effect="Nearby undead +25% damage"),
+            Ability(name="Death's Challenge", description="Forces target to engage", effect="Taunt 3s"),
+            Ability(name="Bone Shield", description="Creates shield from nearby bones", effect="Block next attack"),
+        ],
+        weaknesses=["Holy", "Blunt weapons"],
+        resistances=["Cold", "Piercing", "Poison"],
+        experience=75,
+        loot=[
+            LootDrop(item="Knight's Sigil", chance="Common"),
+            LootDrop(item="Blackened Steel", chance="Rare"),
+            LootDrop(item="Soul Fragment", chance="Rare"),
+            LootDrop(item="Knight's Oath Ring", chance="Very Rare"),
+        ],
+        icon="⚔️",
+        threat_level=3,
+    ),
+    Creature(
+        id="mimic",
+        name="Mimic",
+        category="elite",
+        description="Shapeshifting predators that take the form of treasure chests and other objects. By the time victims realize their mistake, it's usually too late.",
+        appearance="In true form: amorphous mass of teeth and tentacles. Disguised: perfect imitation of a treasure chest, door, or valuable item.",
+        behavior="Waits motionlessly for prey to approach. Reveals true form when touched or attacked. Extremely aggressive once revealed.",
+        floors="2-10",
+        health=100,
+        damage=25,
+        speed="Normal",
+        abilities=[
+            Ability(name="Crushing Maw", description="Massive bite attack", damage=25),
+            Ability(name="Sticky Tongue", description="Pulls target into melee range", effect="Pull + Root 1s"),
+            Ability(name="Digest", description="Ongoing damage while grappled", damage=10, effect="Per second while grabbed"),
+            Ability(name="Perfect Disguise", description="Undetectable until interaction", effect="Stealth"),
+        ],
+        weaknesses=["Fire", "Acid"],
+        resistances=["Physical"],
+        experience=80,
+        loot=[
+            LootDrop(item="Mimic Tooth", chance="Common"),
+            LootDrop(item="False Gold", chance="Common"),
+            LootDrop(item="Shapeshifter Essence", chance="Rare"),
+            LootDrop(item="Mimic's Tongue", chance="Very Rare"),
+        ],
+        icon="📦",
+        threat_level=3,
+    ),
+    Creature(
+        id="shadow_stalker",
+        name="Shadow Stalker",
+        category="elite",
+        description="Creatures of pure darkness that exist in the spaces between light. They feed on fear and consume the minds of their victims.",
+        appearance="Vaguely humanoid shape of absolute darkness. No features except hollow white eyes. Edges blur and shift constantly.",
+        behavior="Hunts those experiencing fear. Can only be seen in peripheral vision. Retreats from strong light sources.",
+        floors="6-10",
+        health=80,
+        damage=15,
+        speed="Very Fast",
+        abilities=[
+            Ability(name="Shadow Touch", description="Phasing attack that ignores armor", damage=15),
+            Ability(name="Terrorize", description="Inflicts supernatural fear", effect="Fear 3s"),
+            Ability(name="Shadow Step", description="Teleports between shadows", effect="Teleport"),
+            Ability(name="Mind Feed", description="Drains sanity on successful fear", effect="-10 Sanity"),
+        ],
+        weaknesses=["Light", "Holy", "Fire"],
+        resistances=["Physical", "Cold", "Poison"],
+        experience=90,
+        loot=[
+            LootDrop(item="Shadow Essence", chance="Rare"),
+            LootDrop(item="Void Crystal", chance="Rare"),
+            LootDrop(item="Cloak of Shadows", chance="Very Rare"),
+        ],
+        icon="👁️",
+        threat_level=4,
+    ),
+
+    # === MINIBOSSES ===
+    Creature(
+        id="the_warden",
+        name="The Warden",
+        title="Guardian of the Third Lock",
+        category="miniboss",
+        description="An Eternal Guardian who has stood watch over the entrance to the lower floors for three centuries. Unlike others, it remembers everything—and everyone.",
+        appearance="Massive suit of golden armor, twice human height. Wielding a greatsword longer than a man. Eyes burn with blue-white flame.",
+        behavior="Challenges all who approach the stairway. Can be reasoned with briefly. Once combat begins, fights without mercy.",
+        floors="5",
+        health=500,
+        damage=40,
+        speed="Normal",
+        abilities=[
+            Ability(name="Judgment Strike", description="Devastating overhead blow", damage=50),
+            Ability(name="Guardian's Oath", description="Cannot be moved or knocked back", effect="Immunity to displacement"),
+            Ability(name="Seal the Path", description="Creates barrier preventing retreat", effect="Arena sealed 30s"),
+            Ability(name="Remember the Fallen", description="Gains power from deaths on this floor", effect="+5% damage per adventurer death this session"),
+        ],
+        weaknesses=["Lightning", "Exploiting oath loopholes"],
+        resistances=["Physical", "Magic"],
+        experience=300,
+        loot=[
+            LootDrop(item="Warden's Key Fragment", chance="Common"),
+            LootDrop(item="Golden Armor Plate", chance="Rare"),
+            LootDrop(item="Oath-Bound Blade", chance="Very Rare"),
+        ],
+        icon="⚜️",
+        threat_level=4,
+    ),
+    Creature(
+        id="brood_mother",
+        name="The Brood Mother",
+        title="Queen of the Web",
+        category="miniboss",
+        description="A Tomb Spider grown to monstrous proportions, mother to all the spiders infesting the upper halls. Her web spans entire chambers.",
+        appearance="Elephant-sized spider with a bulbous abdomen pulsing with eggs. Crown of eyes covers her head. Legs end in blade-like points.",
+        behavior="Rarely moves from central web. Summons offspring constantly. Protects egg sacs aggressively.",
+        floors="4",
+        health=400,
+        damage=30,
+        speed="Slow",
+        abilities=[
+            Ability(name="Impaling Leg", description="Strikes with sharpened limb", damage=35),
+            Ability(name="Summon Brood", description="Spawns 3-5 Tomb Spiders", effect="Every 20s"),
+            Ability(name="Web Tomb", description="Encases target in web cocoon", effect="Stun 5s, damage over time"),
+            Ability(name="Mana Feast", description="Drains magic from all nearby targets", effect="AoE mana drain"),
+        ],
+        weaknesses=["Fire", "Destroying egg sacs"],
+        resistances=["Poison", "Web immunity"],
+        experience=250,
+        loot=[
+            LootDrop(item="Brood Silk", chance="Common"),
+            LootDrop(item="Spider Queen Fang", chance="Rare"),
+            LootDrop(item="Egg of the Brood", chance="Very Rare"),
+        ],
+        icon="🕸️",
+        threat_level=4,
+    ),
+
+    # === BOSSES ===
+    Creature(
+        id="the_hollow_king",
+        name="The Hollow King",
+        title="First of the Fallen",
+        category="boss",
+        description="The first adventurer to die in the Citadel, transformed into something far worse than a simple Hollow. He rules the undead of the upper floors from his throne of bones.",
+        appearance="Regal skeleton in crown of corroded gold. Royal robes hang in tatters. Sits on throne made of adventurer bones. Carries scepter that pulses with necromantic energy.",
+        behavior="Summons minions before engaging. Commands undead tactically. Becomes more aggressive as health drops.",
+        floors="5 (Boss Arena)",
+        health=800,
+        damage=35,
+        speed="Normal",
+        abilities=[
+            Ability(name="Royal Decree", description="Commands all undead to attack target", effect="Focus fire"),
+            Ability(name="Crown of Command", description="Raises fallen enemies as Hollows", effect="Resurrect slain enemies"),
+            Ability(name="Death's Embrace", description="Life-draining beam attack", damage=25, effect="Heals for damage dealt"),
+            Ability(name="Bone Throne", description="Summons bone spikes from floor", damage=40, effect="AoE"),
+            Ability(name="Undying Majesty", description="Resurrects once at 30% health", effect="One-time revival"),
+        ],
+        weaknesses=["Holy", "Destroying the crown"],
+        resistances=["Cold", "Poison", "Necrotic"],
+        experience=500,
+        loot=[
+            LootDrop(item="Crown of the Hollow King", chance="Common"),
+            LootDrop(item="Royal Bone", chance="Rare"),
+            LootDrop(item="Scepter of Dominion", chance="Very Rare"),
+            LootDrop(item="Key to the Depths", chance="Common"),
+        ],
+        icon="👑",
+        threat_level=5,
+    ),
+    Creature(
+        id="the_amalgam",
+        name="The Amalgam",
+        title="A Thousand Screaming Voices",
+        category="boss",
+        description="When too many die in one place, their essence can merge into something new. The Amalgam is made of hundreds of failed adventurers, fused into one nightmare.",
+        appearance="Writhing mass of body parts. Faces emerge and sink back into the flesh. Dozens of arms reach in all directions. Constant wet, grinding sounds.",
+        behavior="Moves erratically. Attacks with random limbs. Absorbs corpses to heal. Each face speaks different warnings.",
+        floors="8 (Boss Arena)",
+        health=1200,
+        damage=30,
+        speed="Slow",
+        abilities=[
+            Ability(name="Flailing Assault", description="Attacks multiple times randomly", damage=20, effect="3-6 hits"),
+            Ability(name="Absorb", description="Consumes corpses to restore health", effect="Heal 100 per corpse"),
+            Ability(name="Voices of the Lost", description="Psychic scream from all faces", damage=15, effect="AoE Fear"),
+            Ability(name="Split Form", description="Separates into smaller amalgams at 50% HP", effect="Splits into 3 mini-bosses"),
+            Ability(name="Reform", description="Mini-bosses recombine if not killed quickly", effect="Full heal if all 3 reunite"),
+        ],
+        weaknesses=["Fire", "Holy", "Killing splits quickly"],
+        resistances=["Physical", "Psychic"],
+        experience=800,
+        loot=[
+            LootDrop(item="Amalgam Flesh", chance="Common"),
+            LootDrop(item="Fused Soul Crystal", chance="Rare"),
+            LootDrop(item="Ring of the Lost", chance="Very Rare"),
+            LootDrop(item="Fragment of Identity", chance="Very Rare"),
+        ],
+        icon="🫀",
+        threat_level=5,
+    ),
+
+    # === UNIQUE CREATURES ===
+    Creature(
+        id="the_merchant",
+        name="???",
+        title="The Helpful Stranger",
+        category="unique",
+        description="A figure that appears in the strangest places, offering valuable items for... unusual prices. Some say it's a demon, others a god. No one knows for certain.",
+        appearance="Shifts constantly. Sometimes a cloaked figure, sometimes a child, sometimes a beast. The only constant is the knowing smile.",
+        behavior="Never hostile. Offers trades. Prices are always personal. Disappears if attacked, but remembers.",
+        floors="Any",
+        health=999,
+        damage=0,
+        speed="Normal",
+        abilities=[
+            Ability(name="Inventory of Wonders", description="Sells unique items", effect="Shop"),
+            Ability(name="Fair Trade", description="Trades items, memories, or services", effect="Barter"),
+            Ability(name="Vanish", description="Disappears if threatened", effect="Immune to damage"),
+            Ability(name="Remember", description="Remembers how you treat it across runs", effect="Persistent reputation"),
+        ],
+        weaknesses=["None known"],
+        resistances=["All"],
+        experience=0,
+        loot=[],
+        icon="❓",
+        threat_level=0,
+    ),
+]
+
+# Category info
+CATEGORIES = {
+    "common": {"name": "Common", "description": "Frequently encountered enemies", "color": "#6b7280"},
+    "elite": {"name": "Elite", "description": "Dangerous foes requiring caution", "color": "#3b82f6"},
+    "miniboss": {"name": "Mini-Boss", "description": "Powerful guardians of key locations", "color": "#a855f7"},
+    "boss": {"name": "Boss", "description": "The rulers of each domain", "color": "#f59e0b"},
+    "unique": {"name": "Unique", "description": "One-of-a-kind encounters", "color": "#22c55e"},
+}
+
+
+@router.get("")
+async def get_all_creatures():
+    """Get all bestiary entries."""
+    return {
+        "creatures": [c.model_dump() for c in CREATURES],
+        "total": len(CREATURES),
+        "categories": CATEGORIES,
+    }
+
+
+@router.get("/categories")
+async def get_categories():
+    """Get creature categories."""
+    category_counts = {}
+    for creature in CREATURES:
+        cat = creature.category
+        category_counts[cat] = category_counts.get(cat, 0) + 1
+
+    return {
+        "categories": [
+            {
+                "id": cat_id,
+                **cat_info,
+                "count": category_counts.get(cat_id, 0),
+            }
+            for cat_id, cat_info in CATEGORIES.items()
+        ]
+    }
+
+
+@router.get("/category/{category_id}")
+async def get_creatures_by_category(category_id: str):
+    """Get creatures in a specific category."""
+    creatures = [c for c in CREATURES if c.category == category_id]
+    return {
+        "category": CATEGORIES.get(category_id),
+        "creatures": [c.model_dump() for c in creatures],
+        "count": len(creatures),
+    }
+
+
+@router.get("/creature/{creature_id}")
+async def get_creature(creature_id: str):
+    """Get a specific creature."""
+    for creature in CREATURES:
+        if creature.id == creature_id:
+            return creature.model_dump()
+    return {"error": "Creature not found"}
+
+
+@router.get("/search")
+async def search_creatures(q: str):
+    """Search creatures by name or description."""
+    query = q.lower()
+    results = [
+        c for c in CREATURES
+        if query in c.name.lower()
+        or query in c.description.lower()
+        or (c.title and query in c.title.lower())
+    ]
+    return {
+        "query": q,
+        "results": [c.model_dump() for c in results],
+        "count": len(results),
+    }
+
+
+@router.get("/floors/{floor}")
+async def get_creatures_by_floor(floor: int):
+    """Get creatures that appear on a specific floor."""
+    results = []
+    for creature in CREATURES:
+        floor_range = creature.floors
+        if floor_range == "Any" or floor_range == "All":
+            results.append(creature)
+        elif "-" in floor_range:
+            # Handle ranges like "1-5"
+            parts = floor_range.replace(" (Boss Arena)", "").split("-")
+            try:
+                min_floor, max_floor = int(parts[0]), int(parts[1])
+                if min_floor <= floor <= max_floor:
+                    results.append(creature)
+            except ValueError:
+                pass
+        else:
+            # Single floor
+            try:
+                if int(floor_range.replace(" (Boss Arena)", "")) == floor:
+                    results.append(creature)
+            except ValueError:
+                pass
+
+    return {
+        "floor": floor,
+        "creatures": [c.model_dump() for c in results],
+        "count": len(results),
+    }
+
+
+@router.get("/stats")
+async def get_bestiary_stats():
+    """Get bestiary statistics."""
+    category_counts = {}
+    total_health = 0
+    max_damage = 0
+
+    for creature in CREATURES:
+        cat = creature.category
+        category_counts[cat] = category_counts.get(cat, 0) + 1
+        total_health += creature.health
+        if creature.damage > max_damage:
+            max_damage = creature.damage
+
+    return {
+        "total_creatures": len(CREATURES),
+        "by_category": category_counts,
+        "average_health": total_health // len(CREATURES) if CREATURES else 0,
+        "max_damage": max_damage,
+    }

--- a/server/app/api/routes.py
+++ b/server/app/api/routes.py
@@ -64,6 +64,7 @@ FRONTEND_ROUTES = [
     {"path": "/codebase-health", "name": "Codebase Health", "description": "Code statistics"},
     {"path": "/changelog", "name": "Changelog", "description": "Patch notes"},
     {"path": "/lore", "name": "Lore & Story", "description": "World-building and backstory"},
+    {"path": "/bestiary", "name": "Bestiary", "description": "Creature encyclopedia"},
     {"path": "/db-explorer", "name": "DB Explorer", "description": "Database browser", "dev_tool": True},
     {"path": "/cache-inspector", "name": "Cache Inspector", "description": "Cache viewer", "dev_tool": True},
     {"path": "/audio-jukebox", "name": "Audio Jukebox", "description": "Sound testing", "dev_tool": True},

--- a/server/app/main.py
+++ b/server/app/main.py
@@ -30,6 +30,7 @@ from .api.dependencies import router as dependencies_router
 from .api.routes import router as routes_router
 from .api.metrics import router as metrics_router, MetricsMiddleware
 from .api.lore import router as lore_router
+from .api.bestiary import router as bestiary_router
 
 
 @asynccontextmanager
@@ -106,6 +107,7 @@ def create_app() -> FastAPI:
     app.include_router(routes_router, tags=["dev-tools"])
     app.include_router(metrics_router, tags=["dev-tools"])
     app.include_router(lore_router, tags=["content"])
+    app.include_router(bestiary_router, tags=["content"])
 
     # Add exception handler to capture errors (only in debug mode)
     if settings.debug:

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,6 +1,6 @@
 import { Routes, Route } from 'react-router-dom';
 import { Layout } from './components/Layout';
-import { Home, Login, Register, Play, Features, About, PlayScene, SceneDemo, Leaderboard, Ghosts, Profile, Achievements, Spectate, Friends, Presentation, Roadmap, CodebaseHealth, Changelog, DatabaseExplorer, CacheInspector, AudioJukebox, SystemStatus, ApiPlayground, WebSocketMonitor, BuildInfo, LogViewer, ErrorTracker, PerformanceProfiler, SessionInspector, FeatureFlags, EnvConfig, DependencyViewer, RouteExplorer, MetricsDashboard, LorePage } from './pages';
+import { Home, Login, Register, Play, Features, About, PlayScene, SceneDemo, Leaderboard, Ghosts, Profile, Achievements, Spectate, Friends, Presentation, Roadmap, CodebaseHealth, Changelog, DatabaseExplorer, CacheInspector, AudioJukebox, SystemStatus, ApiPlayground, WebSocketMonitor, BuildInfo, LogViewer, ErrorTracker, PerformanceProfiler, SessionInspector, FeatureFlags, EnvConfig, DependencyViewer, RouteExplorer, MetricsDashboard, LorePage, Bestiary } from './pages';
 import { FirstPersonDemo } from './pages/FirstPersonDemo';
 import { FirstPersonTestPage } from './pages/FirstPersonTestPage';
 import { Debug3DPage } from './pages/Debug3DPage';
@@ -50,6 +50,7 @@ function App() {
         <Route path="routes" element={<RouteExplorer />} />
         <Route path="metrics" element={<MetricsDashboard />} />
         <Route path="lore" element={<LorePage />} />
+        <Route path="bestiary" element={<Bestiary />} />
       </Route>
     </Routes>
   );

--- a/web/src/components/Layout.tsx
+++ b/web/src/components/Layout.tsx
@@ -77,6 +77,10 @@ export function Layout() {
                     <span className="menu-icon">📜</span>
                     Lore & Story
                   </Link>
+                  <Link to="/bestiary" onClick={closeDropdown}>
+                    <span className="menu-icon">👹</span>
+                    Bestiary
+                  </Link>
                 </div>
               )}
             </div>

--- a/web/src/pages/Bestiary.css
+++ b/web/src/pages/Bestiary.css
@@ -1,0 +1,709 @@
+/**
+ * Bestiary Page Styles - Dark crimson monster theme
+ */
+
+.bestiary-page {
+  min-height: 100vh;
+  background: linear-gradient(180deg, #0f0a0a 0%, #1a1010 50%, #0f0a0a 100%);
+  color: #e8d8d8;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+}
+
+/* Loading State */
+.bestiary-loading {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  min-height: 60vh;
+  gap: 1rem;
+}
+
+.loading-spinner {
+  width: 40px;
+  height: 40px;
+  border: 3px solid #2a1a1a;
+  border-top-color: #8b3a3a;
+  border-radius: 50%;
+  animation: spin 1s linear infinite;
+}
+
+@keyframes spin {
+  to { transform: rotate(360deg); }
+}
+
+/* Header */
+.bestiary-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 2rem 2.5rem;
+  background: linear-gradient(180deg, rgba(30, 15, 15, 0.95) 0%, rgba(20, 10, 10, 0.9) 100%);
+  border-bottom: 1px solid #3d2020;
+}
+
+.header-content h1 {
+  margin: 0;
+  font-size: 2rem;
+  font-weight: 600;
+  color: #e8d8d8;
+  letter-spacing: 1px;
+}
+
+.header-subtitle {
+  margin: 0.25rem 0 0 0;
+  font-size: 0.9rem;
+  color: #8b5a5a;
+}
+
+.header-search {
+  display: flex;
+  align-items: center;
+}
+
+.search-input {
+  padding: 0.6rem 1rem;
+  background: rgba(20, 10, 10, 0.8);
+  border: 1px solid #3d2020;
+  border-radius: 6px;
+  color: #e8d8d8;
+  font-size: 0.9rem;
+  width: 250px;
+  transition: all 0.2s;
+}
+
+.search-input::placeholder {
+  color: #6b4a4a;
+}
+
+.search-input:focus {
+  outline: none;
+  border-color: #8b3a3a;
+  background: rgba(25, 12, 12, 0.9);
+}
+
+/* Category Filter */
+.category-filter {
+  display: flex;
+  gap: 0.5rem;
+  padding: 1rem 2.5rem;
+  background: rgba(20, 10, 10, 0.95);
+  border-bottom: 1px solid #3d2020;
+  overflow-x: auto;
+}
+
+.category-btn {
+  padding: 0.5rem 1rem;
+  background: rgba(30, 15, 15, 0.8);
+  border: 1px solid #3d2020;
+  border-radius: 6px;
+  color: #8b7a7a;
+  font-size: 0.85rem;
+  cursor: pointer;
+  transition: all 0.2s;
+  white-space: nowrap;
+}
+
+.category-btn:hover {
+  background: rgba(139, 58, 58, 0.2);
+  border-color: #5a3030;
+  color: #e8d8d8;
+}
+
+.category-btn.active {
+  background: rgba(139, 58, 58, 0.3);
+  border-color: var(--cat-color, #8b3a3a);
+  color: #e8d8d8;
+  box-shadow: 0 0 10px rgba(139, 58, 58, 0.2);
+}
+
+/* Main Content */
+.bestiary-content {
+  display: grid;
+  grid-template-columns: 400px 1fr;
+  min-height: calc(100vh - 180px);
+}
+
+/* Creature List */
+.creature-list {
+  background: rgba(15, 10, 10, 0.95);
+  border-right: 1px solid #3d2020;
+  padding: 1rem;
+  overflow-y: auto;
+  max-height: calc(100vh - 180px);
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.no-creatures {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 3rem;
+  color: #5a4a4a;
+}
+
+.creature-card {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  padding: 1rem;
+  background: rgba(25, 15, 15, 0.8);
+  border: 1px solid #3d2020;
+  border-left: 3px solid var(--card-color, #6b7280);
+  border-radius: 6px;
+  cursor: pointer;
+  transition: all 0.2s;
+  text-align: left;
+  width: 100%;
+}
+
+.creature-card:hover {
+  background: rgba(139, 58, 58, 0.15);
+  border-color: #5a3030;
+  transform: translateX(4px);
+}
+
+.creature-card.selected {
+  background: rgba(139, 58, 58, 0.25);
+  border-color: var(--card-color, #8b3a3a);
+  box-shadow: 0 0 15px rgba(139, 58, 58, 0.2);
+}
+
+.creature-card-header {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.75rem;
+}
+
+.creature-icon {
+  font-size: 2rem;
+  line-height: 1;
+}
+
+.creature-info {
+  flex: 1;
+}
+
+.creature-info h3 {
+  margin: 0;
+  font-size: 1rem;
+  font-weight: 600;
+  color: #e8d8d8;
+}
+
+.creature-title {
+  margin: 0.15rem 0 0 0;
+  font-size: 0.8rem;
+  color: #8b5a5a;
+  font-style: italic;
+}
+
+.creature-threat {
+  display: flex;
+  gap: 2px;
+  font-size: 0.7rem;
+}
+
+.skull {
+  opacity: 0.2;
+}
+
+.skull.active {
+  opacity: 1;
+}
+
+.creature-card-stats {
+  display: flex;
+  gap: 1rem;
+  font-size: 0.8rem;
+  color: #8b7a7a;
+}
+
+.stat {
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
+}
+
+.stat-icon {
+  font-size: 0.85rem;
+}
+
+.stat.floors {
+  margin-left: auto;
+}
+
+/* Creature Detail */
+.creature-detail {
+  padding: 2rem;
+  overflow-y: auto;
+  max-height: calc(100vh - 180px);
+  background: rgba(10, 5, 5, 0.5);
+}
+
+.no-creature-selected {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  height: 100%;
+  min-height: 400px;
+  text-align: center;
+  color: #5a4a4a;
+}
+
+.placeholder-icon {
+  font-size: 4rem;
+  margin-bottom: 1rem;
+  opacity: 0.5;
+}
+
+.no-creature-selected p {
+  margin: 0;
+  font-size: 1.1rem;
+}
+
+.placeholder-hint {
+  margin-top: 0.5rem !important;
+  font-size: 0.9rem !important;
+  max-width: 300px;
+  color: #4a3a3a !important;
+}
+
+/* Creature Article */
+.creature-article {
+  max-width: 800px;
+  margin: 0 auto;
+}
+
+.article-header {
+  margin-bottom: 2rem;
+  padding-bottom: 1.5rem;
+  border-bottom: 1px solid #3d2020;
+}
+
+.header-top {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 1rem;
+}
+
+.category-badge {
+  font-size: 0.75rem;
+  font-weight: 600;
+  padding: 0.25rem 0.75rem;
+  border-radius: 4px;
+  color: #fff;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+
+.threat-display {
+  display: flex;
+  gap: 4px;
+  font-size: 1rem;
+}
+
+.header-main {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+}
+
+.creature-icon-large {
+  font-size: 3.5rem;
+  line-height: 1;
+}
+
+.header-main h1 {
+  margin: 0;
+  font-size: 2rem;
+  font-weight: 600;
+  color: #e8d8d8;
+}
+
+.creature-title-large {
+  margin: 0.25rem 0 0 0;
+  font-size: 1.1rem;
+  color: #8b5a5a;
+  font-style: italic;
+}
+
+/* Stats Section */
+.stats-section {
+  background: rgba(25, 15, 15, 0.6);
+  border: 1px solid #3d2020;
+  border-radius: 8px;
+  padding: 1.25rem;
+  margin-bottom: 1.5rem;
+}
+
+.stats-section h2,
+.description-section h2,
+.abilities-section h2,
+.loot-section h2 {
+  margin: 0 0 1rem 0;
+  font-size: 1rem;
+  font-weight: 600;
+  color: #8b5a5a;
+  text-transform: uppercase;
+  letter-spacing: 1px;
+}
+
+.stats-grid {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.stat-row {
+  display: grid;
+  grid-template-columns: 100px 80px 1fr;
+  align-items: center;
+  gap: 1rem;
+}
+
+.stat-label {
+  font-size: 0.85rem;
+  color: #8b7a7a;
+}
+
+.stat-value {
+  font-size: 1rem;
+  font-weight: 600;
+  color: #e8d8d8;
+}
+
+.stat-value.speed {
+  font-weight: 600;
+}
+
+.stat-value.xp {
+  color: #22c55e;
+}
+
+.stat-bar {
+  height: 8px;
+  background: #2a1a1a;
+  border-radius: 4px;
+  overflow: hidden;
+}
+
+.stat-bar-fill {
+  height: 100%;
+  border-radius: 4px;
+  transition: width 0.3s ease;
+}
+
+/* Description Section */
+.description-section {
+  margin-bottom: 1.5rem;
+}
+
+.description-section p {
+  margin: 0;
+  line-height: 1.7;
+  color: #c8b8b8;
+}
+
+/* Info Section */
+.info-section {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 1rem;
+  margin-bottom: 1.5rem;
+}
+
+.info-block {
+  background: rgba(25, 15, 15, 0.4);
+  border: 1px solid #3d2020;
+  border-radius: 6px;
+  padding: 1rem;
+}
+
+.info-block h3 {
+  margin: 0 0 0.5rem 0;
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: #8b5a5a;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+
+.info-block p {
+  margin: 0;
+  font-size: 0.9rem;
+  line-height: 1.6;
+  color: #a89898;
+}
+
+/* Abilities Section */
+.abilities-section {
+  margin-bottom: 1.5rem;
+}
+
+.abilities-list {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.ability-card {
+  background: rgba(25, 15, 15, 0.5);
+  border: 1px solid #3d2020;
+  border-radius: 6px;
+  padding: 1rem;
+}
+
+.ability-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 0.5rem;
+}
+
+.ability-header h4 {
+  margin: 0;
+  font-size: 0.95rem;
+  font-weight: 600;
+  color: #e8d8d8;
+}
+
+.ability-damage {
+  font-size: 0.8rem;
+  font-weight: 600;
+  padding: 0.15rem 0.5rem;
+  background: rgba(239, 68, 68, 0.2);
+  color: #ef4444;
+  border-radius: 4px;
+}
+
+.ability-description {
+  margin: 0;
+  font-size: 0.9rem;
+  color: #a89898;
+}
+
+.ability-effect {
+  margin: 0.5rem 0 0 0;
+  font-size: 0.85rem;
+  color: #a855f7;
+  font-style: italic;
+}
+
+/* Combat Section */
+.combat-section {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 1rem;
+  margin-bottom: 1.5rem;
+}
+
+.combat-block {
+  background: rgba(25, 15, 15, 0.4);
+  border: 1px solid #3d2020;
+  border-radius: 6px;
+  padding: 1rem;
+}
+
+.combat-block h3 {
+  margin: 0 0 0.75rem 0;
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: #8b5a5a;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+
+.tag-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.tag {
+  font-size: 0.8rem;
+  padding: 0.25rem 0.6rem;
+  border-radius: 4px;
+}
+
+.tag.weakness {
+  background: rgba(34, 197, 94, 0.2);
+  color: #22c55e;
+}
+
+.tag.resistance {
+  background: rgba(239, 68, 68, 0.2);
+  color: #ef4444;
+}
+
+.no-data {
+  font-size: 0.85rem;
+  color: #5a4a4a;
+  font-style: italic;
+}
+
+/* Loot Section */
+.loot-section {
+  background: rgba(25, 15, 15, 0.4);
+  border: 1px solid #3d2020;
+  border-radius: 8px;
+  padding: 1.25rem;
+}
+
+.loot-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.loot-item {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 0.5rem 0.75rem;
+  background: rgba(20, 10, 10, 0.5);
+  border-radius: 4px;
+  border-left: 3px solid #6b7280;
+}
+
+.loot-item.common {
+  border-left-color: #6b7280;
+}
+
+.loot-item.rare {
+  border-left-color: #3b82f6;
+}
+
+.loot-item.very-rare {
+  border-left-color: #a855f7;
+}
+
+.loot-name {
+  font-size: 0.9rem;
+  color: #e8d8d8;
+}
+
+.loot-chance {
+  font-size: 0.75rem;
+  font-weight: 600;
+  padding: 0.15rem 0.5rem;
+  background: rgba(60, 60, 75, 0.3);
+  border-radius: 4px;
+  color: #8b7a7a;
+}
+
+.loot-item.rare .loot-chance {
+  background: rgba(59, 130, 246, 0.2);
+  color: #3b82f6;
+}
+
+.loot-item.very-rare .loot-chance {
+  background: rgba(168, 85, 247, 0.2);
+  color: #a855f7;
+}
+
+/* Scrollbar styling */
+.creature-list::-webkit-scrollbar,
+.creature-detail::-webkit-scrollbar {
+  width: 8px;
+}
+
+.creature-list::-webkit-scrollbar-track,
+.creature-detail::-webkit-scrollbar-track {
+  background: rgba(20, 10, 10, 0.5);
+}
+
+.creature-list::-webkit-scrollbar-thumb,
+.creature-detail::-webkit-scrollbar-thumb {
+  background: #3d2020;
+  border-radius: 4px;
+}
+
+.creature-list::-webkit-scrollbar-thumb:hover,
+.creature-detail::-webkit-scrollbar-thumb:hover {
+  background: #5a3030;
+}
+
+/* Responsive */
+@media (max-width: 1024px) {
+  .bestiary-content {
+    grid-template-columns: 320px 1fr;
+  }
+}
+
+@media (max-width: 768px) {
+  .bestiary-header {
+    flex-direction: column;
+    gap: 1rem;
+    padding: 1.5rem;
+  }
+
+  .header-content {
+    text-align: center;
+  }
+
+  .header-content h1 {
+    font-size: 1.5rem;
+  }
+
+  .search-input {
+    width: 100%;
+  }
+
+  .category-filter {
+    padding: 1rem;
+  }
+
+  .bestiary-content {
+    grid-template-columns: 1fr;
+  }
+
+  .creature-list {
+    border-right: none;
+    border-bottom: 1px solid #3d2020;
+    max-height: 300px;
+    flex-direction: row;
+    flex-wrap: wrap;
+  }
+
+  .creature-card {
+    flex: 1 1 calc(50% - 0.5rem);
+    min-width: 200px;
+  }
+
+  .creature-detail {
+    max-height: none;
+    padding: 1.5rem;
+  }
+
+  .info-section,
+  .combat-section {
+    grid-template-columns: 1fr;
+  }
+
+  .stat-row {
+    grid-template-columns: 80px 60px 1fr;
+    gap: 0.5rem;
+  }
+}
+
+@media (max-width: 480px) {
+  .creature-card {
+    flex: 1 1 100%;
+  }
+
+  .header-main {
+    flex-direction: column;
+    text-align: center;
+  }
+
+  .stat-row {
+    grid-template-columns: 1fr 1fr;
+  }
+
+  .stat-bar {
+    grid-column: span 2;
+  }
+}

--- a/web/src/pages/Bestiary.tsx
+++ b/web/src/pages/Bestiary.tsx
@@ -1,0 +1,413 @@
+/**
+ * Bestiary Page - Creature and enemy database
+ *
+ * Features:
+ * - Creature categories (Common, Elite, Mini-Boss, Boss, Unique)
+ * - Detailed stat displays
+ * - Abilities and loot information
+ * - Search and filter functionality
+ * - Threat level indicators
+ */
+
+import { useState, useEffect, useCallback } from 'react';
+import './Bestiary.css';
+
+const API_BASE = 'http://localhost:8000/api/bestiary';
+
+interface Ability {
+  name: string;
+  description: string;
+  damage?: number;
+  effect?: string;
+}
+
+interface LootDrop {
+  item: string;
+  chance: string;
+}
+
+interface Creature {
+  id: string;
+  name: string;
+  title?: string;
+  category: string;
+  description: string;
+  appearance: string;
+  behavior: string;
+  floors: string;
+  health: number;
+  damage: number;
+  speed: string;
+  abilities: Ability[];
+  weaknesses: string[];
+  resistances: string[];
+  experience: number;
+  loot: LootDrop[];
+  icon: string;
+  threat_level: number;
+}
+
+interface Category {
+  id: string;
+  name: string;
+  description: string;
+  color: string;
+  count: number;
+}
+
+const SPEED_COLORS: Record<string, string> = {
+  'Slow': '#6b7280',
+  'Normal': '#22c55e',
+  'Fast': '#f59e0b',
+  'Very Fast': '#ef4444',
+};
+
+const CATEGORY_COLORS: Record<string, string> = {
+  common: '#6b7280',
+  elite: '#3b82f6',
+  miniboss: '#a855f7',
+  boss: '#f59e0b',
+  unique: '#22c55e',
+};
+
+export function Bestiary() {
+  const [creatures, setCreatures] = useState<Creature[]>([]);
+  const [categories, setCategories] = useState<Category[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [selectedCategory, setSelectedCategory] = useState<string | null>(null);
+  const [selectedCreature, setSelectedCreature] = useState<Creature | null>(null);
+  const [searchQuery, setSearchQuery] = useState('');
+
+  // Fetch all creatures
+  const fetchCreatures = useCallback(async () => {
+    try {
+      const res = await fetch(API_BASE);
+      if (res.ok) {
+        const data = await res.json();
+        setCreatures(data.creatures);
+      }
+    } catch {
+      // Silently fail
+    }
+  }, []);
+
+  // Fetch categories
+  const fetchCategories = useCallback(async () => {
+    try {
+      const res = await fetch(`${API_BASE}/categories`);
+      if (res.ok) {
+        const data = await res.json();
+        setCategories(data.categories);
+      }
+    } catch {
+      // Silently fail
+    }
+  }, []);
+
+  // Initial fetch
+  useEffect(() => {
+    const loadData = async () => {
+      setLoading(true);
+      await Promise.all([fetchCreatures(), fetchCategories()]);
+      setLoading(false);
+    };
+    loadData();
+  }, [fetchCreatures, fetchCategories]);
+
+  // Filter creatures
+  const filteredCreatures = creatures.filter((creature) => {
+    if (selectedCategory && creature.category !== selectedCategory) return false;
+    if (searchQuery) {
+      const query = searchQuery.toLowerCase();
+      if (
+        !creature.name.toLowerCase().includes(query) &&
+        !creature.description.toLowerCase().includes(query) &&
+        !(creature.title && creature.title.toLowerCase().includes(query))
+      ) {
+        return false;
+      }
+    }
+    return true;
+  });
+
+  // Render threat skulls
+  const renderThreat = (level: number) => {
+    return Array.from({ length: 5 }, (_, i) => (
+      <span key={i} className={`skull ${i < level ? 'active' : ''}`}>
+        💀
+      </span>
+    ));
+  };
+
+  // Render stat bar
+  const renderStatBar = (value: number, max: number, color: string) => {
+    const percent = Math.min((value / max) * 100, 100);
+    return (
+      <div className="stat-bar">
+        <div
+          className="stat-bar-fill"
+          style={{ width: `${percent}%`, background: color }}
+        />
+      </div>
+    );
+  };
+
+  if (loading) {
+    return (
+      <div className="bestiary-page">
+        <div className="bestiary-loading">
+          <div className="loading-spinner" />
+          <p>Consulting the archives...</p>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="bestiary-page">
+      {/* Header */}
+      <header className="bestiary-header">
+        <div className="header-content">
+          <h1>Bestiary</h1>
+          <p className="header-subtitle">Creatures of the Sunken Citadel</p>
+        </div>
+        <div className="header-search">
+          <input
+            type="text"
+            placeholder="Search creatures..."
+            value={searchQuery}
+            onChange={(e) => setSearchQuery(e.target.value)}
+            className="search-input"
+          />
+        </div>
+      </header>
+
+      {/* Category Filter */}
+      <div className="category-filter">
+        <button
+          className={`category-btn ${selectedCategory === null ? 'active' : ''}`}
+          onClick={() => setSelectedCategory(null)}
+        >
+          All ({creatures.length})
+        </button>
+        {categories.map((cat) => (
+          <button
+            key={cat.id}
+            className={`category-btn ${selectedCategory === cat.id ? 'active' : ''}`}
+            style={{
+              '--cat-color': cat.color,
+            } as React.CSSProperties}
+            onClick={() => setSelectedCategory(cat.id)}
+          >
+            {cat.name} ({cat.count})
+          </button>
+        ))}
+      </div>
+
+      {/* Main Content */}
+      <div className="bestiary-content">
+        {/* Creature List */}
+        <div className="creature-list">
+          {filteredCreatures.length === 0 ? (
+            <div className="no-creatures">
+              <p>No creatures found</p>
+            </div>
+          ) : (
+            filteredCreatures.map((creature) => (
+              <button
+                key={creature.id}
+                className={`creature-card ${selectedCreature?.id === creature.id ? 'selected' : ''}`}
+                onClick={() => setSelectedCreature(creature)}
+                style={{
+                  '--card-color': CATEGORY_COLORS[creature.category],
+                } as React.CSSProperties}
+              >
+                <div className="creature-card-header">
+                  <span className="creature-icon">{creature.icon}</span>
+                  <div className="creature-info">
+                    <h3>{creature.name}</h3>
+                    {creature.title && <p className="creature-title">{creature.title}</p>}
+                  </div>
+                  <div className="creature-threat">
+                    {renderThreat(creature.threat_level)}
+                  </div>
+                </div>
+                <div className="creature-card-stats">
+                  <span className="stat">
+                    <span className="stat-icon">❤️</span>
+                    {creature.health}
+                  </span>
+                  <span className="stat">
+                    <span className="stat-icon">⚔️</span>
+                    {creature.damage}
+                  </span>
+                  <span className="stat floors">
+                    <span className="stat-icon">🏛️</span>
+                    {creature.floors}
+                  </span>
+                </div>
+              </button>
+            ))
+          )}
+        </div>
+
+        {/* Creature Detail */}
+        <div className="creature-detail">
+          {selectedCreature ? (
+            <article className="creature-article">
+              {/* Header */}
+              <header className="article-header">
+                <div className="header-top">
+                  <span
+                    className="category-badge"
+                    style={{ background: CATEGORY_COLORS[selectedCreature.category] }}
+                  >
+                    {categories.find((c) => c.id === selectedCreature.category)?.name}
+                  </span>
+                  <div className="threat-display">
+                    {renderThreat(selectedCreature.threat_level)}
+                  </div>
+                </div>
+                <div className="header-main">
+                  <span className="creature-icon-large">{selectedCreature.icon}</span>
+                  <div>
+                    <h1>{selectedCreature.name}</h1>
+                    {selectedCreature.title && (
+                      <p className="creature-title-large">{selectedCreature.title}</p>
+                    )}
+                  </div>
+                </div>
+              </header>
+
+              {/* Stats */}
+              <section className="stats-section">
+                <h2>Statistics</h2>
+                <div className="stats-grid">
+                  <div className="stat-row">
+                    <span className="stat-label">Health</span>
+                    <span className="stat-value">{selectedCreature.health}</span>
+                    {renderStatBar(selectedCreature.health, 1200, '#ef4444')}
+                  </div>
+                  <div className="stat-row">
+                    <span className="stat-label">Damage</span>
+                    <span className="stat-value">{selectedCreature.damage}</span>
+                    {renderStatBar(selectedCreature.damage, 50, '#f59e0b')}
+                  </div>
+                  <div className="stat-row">
+                    <span className="stat-label">Speed</span>
+                    <span
+                      className="stat-value speed"
+                      style={{ color: SPEED_COLORS[selectedCreature.speed] }}
+                    >
+                      {selectedCreature.speed}
+                    </span>
+                  </div>
+                  <div className="stat-row">
+                    <span className="stat-label">Experience</span>
+                    <span className="stat-value xp">{selectedCreature.experience} XP</span>
+                  </div>
+                  <div className="stat-row">
+                    <span className="stat-label">Floors</span>
+                    <span className="stat-value">{selectedCreature.floors}</span>
+                  </div>
+                </div>
+              </section>
+
+              {/* Description */}
+              <section className="description-section">
+                <h2>Description</h2>
+                <p>{selectedCreature.description}</p>
+              </section>
+
+              {/* Appearance & Behavior */}
+              <section className="info-section">
+                <div className="info-block">
+                  <h3>Appearance</h3>
+                  <p>{selectedCreature.appearance}</p>
+                </div>
+                <div className="info-block">
+                  <h3>Behavior</h3>
+                  <p>{selectedCreature.behavior}</p>
+                </div>
+              </section>
+
+              {/* Abilities */}
+              <section className="abilities-section">
+                <h2>Abilities</h2>
+                <div className="abilities-list">
+                  {selectedCreature.abilities.map((ability, idx) => (
+                    <div key={idx} className="ability-card">
+                      <div className="ability-header">
+                        <h4>{ability.name}</h4>
+                        {ability.damage && (
+                          <span className="ability-damage">{ability.damage} dmg</span>
+                        )}
+                      </div>
+                      <p className="ability-description">{ability.description}</p>
+                      {ability.effect && (
+                        <p className="ability-effect">Effect: {ability.effect}</p>
+                      )}
+                    </div>
+                  ))}
+                </div>
+              </section>
+
+              {/* Weaknesses & Resistances */}
+              <section className="combat-section">
+                <div className="combat-block">
+                  <h3>Weaknesses</h3>
+                  <div className="tag-list">
+                    {selectedCreature.weaknesses.length > 0 ? (
+                      selectedCreature.weaknesses.map((w, idx) => (
+                        <span key={idx} className="tag weakness">{w}</span>
+                      ))
+                    ) : (
+                      <span className="no-data">None known</span>
+                    )}
+                  </div>
+                </div>
+                <div className="combat-block">
+                  <h3>Resistances</h3>
+                  <div className="tag-list">
+                    {selectedCreature.resistances.length > 0 ? (
+                      selectedCreature.resistances.map((r, idx) => (
+                        <span key={idx} className="tag resistance">{r}</span>
+                      ))
+                    ) : (
+                      <span className="no-data">None</span>
+                    )}
+                  </div>
+                </div>
+              </section>
+
+              {/* Loot */}
+              {selectedCreature.loot.length > 0 && (
+                <section className="loot-section">
+                  <h2>Loot Drops</h2>
+                  <div className="loot-list">
+                    {selectedCreature.loot.map((drop, idx) => (
+                      <div key={idx} className={`loot-item ${drop.chance.toLowerCase().replace(' ', '-')}`}>
+                        <span className="loot-name">{drop.item}</span>
+                        <span className="loot-chance">{drop.chance}</span>
+                      </div>
+                    ))}
+                  </div>
+                </section>
+              )}
+            </article>
+          ) : (
+            <div className="no-creature-selected">
+              <div className="placeholder-icon">📖</div>
+              <p>Select a creature to view details</p>
+              <p className="placeholder-hint">
+                Choose from the list on the left to learn about the denizens of the Citadel
+              </p>
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default Bestiary;

--- a/web/src/pages/index.ts
+++ b/web/src/pages/index.ts
@@ -33,3 +33,4 @@ export { DependencyViewer } from './DependencyViewer';
 export { RouteExplorer } from './RouteExplorer';
 export { MetricsDashboard } from './MetricsDashboard';
 export { LorePage } from './LorePage';
+export { Bestiary } from './Bestiary';


### PR DESCRIPTION
## Summary
- Add Bestiary page showcasing creatures of the Sunken Citadel
- Backend API with 12 detailed creature entries
- Comprehensive stats, abilities, and combat information
- Loot drop system with rarity tiers
- Dark crimson monster theme styling

## Creatures
| Category | Creatures |
|----------|-----------|
| Common | Hollow Walker, Dungeon Rat, Animated Armor, Tomb Spider |
| Elite | Bone Knight, Mimic, Shadow Stalker |
| Mini-Boss | The Warden, The Brood Mother |
| Boss | The Hollow King, The Amalgam |
| Unique | ??? (The Helpful Stranger) |

## Features
- Category filtering
- Search by name/description
- Detailed stat displays with visual bars
- Threat level skull indicators
- Ability cards with damage and effects
- Weakness/resistance tags
- Loot drops with rarity coloring

## Test plan
- [ ] Visit /bestiary page
- [ ] Filter by each category
- [ ] View creature details
- [ ] Test search functionality
- [ ] Verify responsive design

🤖 Generated with [Claude Code](https://claude.com/claude-code)