### PR TITLE
feat: add PostgreSQL backend for codebase health data

### DIFF
--- a/server/alembic/versions/20260113_0001_003_add_codebase_health.py
+++ b/server/alembic/versions/20260113_0001_003_add_codebase_health.py
@@ -1,0 +1,94 @@
+"""Add codebase health tables
+
+Revision ID: 003
+Revises: 002
+Create Date: 2026-01-13
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = '003'
+down_revision: Union[str, None] = '002'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # Create codebase_file_stats table
+    op.create_table(
+        'codebase_file_stats',
+        sa.Column('id', sa.Integer(), nullable=False),
+        sa.Column('path', sa.String(500), nullable=False),
+        sa.Column('loc', sa.Integer(), nullable=False),
+        sa.Column('nesting_depth', sa.Integer(), nullable=False),
+        sa.Column('file_type', sa.String(50), nullable=False),
+        sa.Column('area', sa.String(50), nullable=False),
+        sa.Column('size_category', sa.String(20), nullable=False),
+        sa.Column('created_at', sa.DateTime(), nullable=False),
+        sa.PrimaryKeyConstraint('id')
+    )
+    op.create_index(op.f('ix_codebase_file_stats_id'), 'codebase_file_stats', ['id'], unique=False)
+    op.create_index(op.f('ix_codebase_file_stats_path'), 'codebase_file_stats', ['path'], unique=True)
+    op.create_index(op.f('ix_codebase_file_stats_file_type'), 'codebase_file_stats', ['file_type'], unique=False)
+    op.create_index(op.f('ix_codebase_file_stats_area'), 'codebase_file_stats', ['area'], unique=False)
+
+    # Create codebase_refactor_todos table
+    op.create_table(
+        'codebase_refactor_todos',
+        sa.Column('id', sa.Integer(), nullable=False),
+        sa.Column('item_id', sa.String(50), nullable=False),
+        sa.Column('title', sa.String(200), nullable=False),
+        sa.Column('description', sa.Text(), nullable=False),
+        sa.Column('priority', sa.String(20), nullable=False),
+        sa.Column('status', sa.String(20), nullable=False, default='pending'),
+        sa.Column('category', sa.JSON(), nullable=False),
+        sa.Column('effort', sa.String(20), nullable=False),
+        sa.Column('affected_files', sa.JSON(), nullable=False),
+        sa.Column('details', sa.JSON(), nullable=False),
+        sa.Column('automated_reason', sa.Text(), nullable=True),
+        sa.Column('technique', sa.Text(), nullable=True),
+        sa.Column('created_at', sa.DateTime(), nullable=False),
+        sa.PrimaryKeyConstraint('id')
+    )
+    op.create_index(op.f('ix_codebase_refactor_todos_id'), 'codebase_refactor_todos', ['id'], unique=False)
+    op.create_index(op.f('ix_codebase_refactor_todos_item_id'), 'codebase_refactor_todos', ['item_id'], unique=True)
+    op.create_index(op.f('ix_codebase_refactor_todos_priority'), 'codebase_refactor_todos', ['priority'], unique=False)
+    op.create_index(op.f('ix_codebase_refactor_todos_status'), 'codebase_refactor_todos', ['status'], unique=False)
+
+    # Create codebase_scan_meta table
+    op.create_table(
+        'codebase_scan_meta',
+        sa.Column('id', sa.Integer(), nullable=False),
+        sa.Column('generated_at', sa.DateTime(), nullable=False),
+        sa.Column('total_files', sa.Integer(), nullable=False),
+        sa.Column('total_loc', sa.Integer(), nullable=False),
+        sa.Column('total_todos', sa.Integer(), nullable=False),
+        sa.Column('avg_loc', sa.Integer(), nullable=False),
+        sa.PrimaryKeyConstraint('id')
+    )
+    op.create_index(op.f('ix_codebase_scan_meta_id'), 'codebase_scan_meta', ['id'], unique=False)
+
+
+def downgrade() -> None:
+    # Drop codebase_scan_meta
+    op.drop_index(op.f('ix_codebase_scan_meta_id'), table_name='codebase_scan_meta')
+    op.drop_table('codebase_scan_meta')
+
+    # Drop codebase_refactor_todos
+    op.drop_index(op.f('ix_codebase_refactor_todos_status'), table_name='codebase_refactor_todos')
+    op.drop_index(op.f('ix_codebase_refactor_todos_priority'), table_name='codebase_refactor_todos')
+    op.drop_index(op.f('ix_codebase_refactor_todos_item_id'), table_name='codebase_refactor_todos')
+    op.drop_index(op.f('ix_codebase_refactor_todos_id'), table_name='codebase_refactor_todos')
+    op.drop_table('codebase_refactor_todos')
+
+    # Drop codebase_file_stats
+    op.drop_index(op.f('ix_codebase_file_stats_area'), table_name='codebase_file_stats')
+    op.drop_index(op.f('ix_codebase_file_stats_file_type'), table_name='codebase_file_stats')
+    op.drop_index(op.f('ix_codebase_file_stats_path'), table_name='codebase_file_stats')
+    op.drop_index(op.f('ix_codebase_file_stats_id'), table_name='codebase_file_stats')
+    op.drop_table('codebase_file_stats')

--- a/server/app/api/codebase_health.py
+++ b/server/app/api/codebase_health.py
@@ -1,0 +1,178 @@
+"""Codebase health API endpoints."""
+from typing import Optional, List
+from fastapi import APIRouter, Depends, Query
+from sqlalchemy import select, func, delete
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from ..core.database import get_db
+from ..models.codebase_health import (
+    CodebaseFileStats,
+    CodebaseRefactorTodo,
+    CodebaseScanMeta,
+)
+from ..schemas.codebase_health import (
+    FileStatsResponse,
+    FileStatsListResponse,
+    RefactorTodoResponse,
+    RefactorTodoListResponse,
+    ScanMetaResponse,
+    CodebaseStatsResponse,
+    AreaStats,
+)
+
+router = APIRouter(prefix="/api/codebase-health", tags=["codebase-health"])
+
+
+@router.get("/files", response_model=FileStatsListResponse)
+async def list_files(
+    db: AsyncSession = Depends(get_db),
+    page: int = Query(1, ge=1, description="Page number"),
+    page_size: int = Query(100, ge=1, le=1000, description="Items per page"),
+    area: Optional[str] = Query(None, description="Filter by area"),
+    file_type: Optional[str] = Query(None, description="Filter by file type"),
+    size_category: Optional[str] = Query(None, description="Filter by size category"),
+    search: Optional[str] = Query(None, description="Search in file path"),
+    sort_by: str = Query("loc", description="Sort by field: path, loc, file_type, area"),
+    sort_dir: str = Query("desc", description="Sort direction: asc, desc"),
+):
+    """List file statistics with pagination and filtering."""
+    # Build query
+    query = select(CodebaseFileStats)
+
+    # Apply filters
+    if area:
+        query = query.where(CodebaseFileStats.area == area)
+    if file_type:
+        query = query.where(CodebaseFileStats.file_type == file_type)
+    if size_category:
+        query = query.where(CodebaseFileStats.size_category == size_category)
+    if search:
+        query = query.where(CodebaseFileStats.path.ilike(f"%{search}%"))
+
+    # Get total count
+    count_query = select(func.count()).select_from(query.subquery())
+    total_result = await db.execute(count_query)
+    total = total_result.scalar() or 0
+
+    # Apply sorting
+    sort_column = getattr(CodebaseFileStats, sort_by, CodebaseFileStats.loc)
+    if sort_dir == "asc":
+        query = query.order_by(sort_column.asc())
+    else:
+        query = query.order_by(sort_column.desc())
+
+    # Apply pagination
+    offset = (page - 1) * page_size
+    query = query.offset(offset).limit(page_size)
+
+    # Execute query
+    result = await db.execute(query)
+    files = result.scalars().all()
+
+    return FileStatsListResponse(
+        files=[FileStatsResponse.model_validate(f) for f in files],
+        total=total,
+        page=page,
+        page_size=page_size,
+    )
+
+
+@router.get("/todos", response_model=RefactorTodoListResponse)
+async def list_todos(
+    db: AsyncSession = Depends(get_db),
+    priority: Optional[str] = Query(None, description="Filter by priority"),
+    status: Optional[str] = Query(None, description="Filter by status"),
+    search: Optional[str] = Query(None, description="Search in title/description"),
+):
+    """List refactor suggestions with filtering."""
+    query = select(CodebaseRefactorTodo)
+
+    if priority:
+        query = query.where(CodebaseRefactorTodo.priority == priority)
+    if status:
+        query = query.where(CodebaseRefactorTodo.status == status)
+    if search:
+        query = query.where(
+            CodebaseRefactorTodo.title.ilike(f"%{search}%") |
+            CodebaseRefactorTodo.description.ilike(f"%{search}%")
+        )
+
+    # Order by priority (critical first)
+    priority_order = func.case(
+        (CodebaseRefactorTodo.priority == "critical", 0),
+        (CodebaseRefactorTodo.priority == "high", 1),
+        (CodebaseRefactorTodo.priority == "medium", 2),
+        (CodebaseRefactorTodo.priority == "low", 3),
+        else_=4
+    )
+    query = query.order_by(priority_order, CodebaseRefactorTodo.title)
+
+    result = await db.execute(query)
+    todos = result.scalars().all()
+
+    return RefactorTodoListResponse(
+        todos=[RefactorTodoResponse.model_validate(t) for t in todos],
+        total=len(todos),
+    )
+
+
+@router.get("/stats", response_model=CodebaseStatsResponse)
+async def get_stats(db: AsyncSession = Depends(get_db)):
+    """Get aggregated codebase statistics."""
+    # Get scan metadata
+    meta_query = select(CodebaseScanMeta).limit(1)
+    meta_result = await db.execute(meta_query)
+    meta = meta_result.scalar_one_or_none()
+
+    # Get stats by area
+    area_query = select(
+        CodebaseFileStats.area,
+        func.count().label("count"),
+        func.sum(CodebaseFileStats.loc).label("total_loc")
+    ).group_by(CodebaseFileStats.area)
+    area_result = await db.execute(area_query)
+    area_rows = area_result.all()
+
+    by_area = {
+        row.area: AreaStats(count=row.count, total_loc=row.total_loc or 0)
+        for row in area_rows
+    }
+
+    # Get todos by priority
+    priority_query = select(
+        CodebaseRefactorTodo.priority,
+        func.count().label("count")
+    ).group_by(CodebaseRefactorTodo.priority)
+    priority_result = await db.execute(priority_query)
+    priority_rows = priority_result.all()
+
+    by_priority = {row.priority: row.count for row in priority_rows}
+
+    # Calculate totals
+    total_files = sum(s.count for s in by_area.values())
+    total_loc = sum(s.total_loc for s in by_area.values())
+    avg_loc = total_loc // total_files if total_files > 0 else 0
+    total_todos = sum(by_priority.values())
+
+    return CodebaseStatsResponse(
+        total_files=meta.total_files if meta else total_files,
+        total_loc=meta.total_loc if meta else total_loc,
+        avg_loc=meta.avg_loc if meta else avg_loc,
+        total_todos=meta.total_todos if meta else total_todos,
+        generated_at=meta.generated_at if meta else None,
+        by_area=by_area,
+        by_priority=by_priority,
+    )
+
+
+@router.get("/scan-info", response_model=Optional[ScanMetaResponse])
+async def get_scan_info(db: AsyncSession = Depends(get_db)):
+    """Get information about the latest scan."""
+    query = select(CodebaseScanMeta).limit(1)
+    result = await db.execute(query)
+    meta = result.scalar_one_or_none()
+
+    if not meta:
+        return None
+
+    return ScanMetaResponse.model_validate(meta)

--- a/server/app/main.py
+++ b/server/app/main.py
@@ -33,6 +33,7 @@ from .api.lore import router as lore_router
 from .api.bestiary import router as bestiary_router
 from .api.items import router as items_router
 from .api.gameguide import router as gameguide_router
+from .api.codebase_health import router as codebase_health_router
 
 
 @asynccontextmanager
@@ -108,6 +109,7 @@ def create_app() -> FastAPI:
     app.include_router(dependencies_router, tags=["dev-tools"])
     app.include_router(routes_router, tags=["dev-tools"])
     app.include_router(metrics_router, tags=["dev-tools"])
+    app.include_router(codebase_health_router, tags=["dev-tools"])
     app.include_router(lore_router, tags=["content"])
     app.include_router(bestiary_router, tags=["content"])
     app.include_router(items_router, tags=["content"])

--- a/server/app/models/__init__.py
+++ b/server/app/models/__init__.py
@@ -5,6 +5,7 @@ from .chat_message import ChatMessage, ChatChannel
 from .user_achievement import UserAchievement
 from .game_save import GameSave
 from .daily_challenge import DailyChallenge, DailyChallengeResult
+from .codebase_health import CodebaseFileStats, CodebaseRefactorTodo, CodebaseScanMeta
 
 __all__ = [
     "User",
@@ -15,4 +16,7 @@ __all__ = [
     "GameSave",
     "DailyChallenge",
     "DailyChallengeResult",
+    "CodebaseFileStats",
+    "CodebaseRefactorTodo",
+    "CodebaseScanMeta",
 ]

--- a/server/app/models/codebase_health.py
+++ b/server/app/models/codebase_health.py
@@ -1,0 +1,77 @@
+"""Codebase health models for storing file stats and refactor suggestions."""
+from datetime import datetime
+from typing import Optional, List
+
+from sqlalchemy import Integer, String, DateTime, Text, JSON
+from sqlalchemy.orm import Mapped, mapped_column
+
+from ..core.database import Base
+
+
+class CodebaseFileStats(Base):
+    """Stores file statistics from codebase health scans.
+
+    Each record represents a single file with its metrics.
+    Data is replaced entirely with each new scan (latest only).
+    """
+
+    __tablename__ = "codebase_file_stats"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, index=True)
+    path: Mapped[str] = mapped_column(String(500), unique=True, index=True, nullable=False)
+    loc: Mapped[int] = mapped_column(Integer, nullable=False)
+    nesting_depth: Mapped[int] = mapped_column(Integer, nullable=False)
+    file_type: Mapped[str] = mapped_column(String(50), nullable=False, index=True)
+    area: Mapped[str] = mapped_column(String(50), nullable=False, index=True)
+    size_category: Mapped[str] = mapped_column(String(20), nullable=False)
+    created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow)
+
+    def __repr__(self) -> str:
+        return f"<CodebaseFileStats(path={self.path}, loc={self.loc})>"
+
+
+class CodebaseRefactorTodo(Base):
+    """Stores refactoring suggestions from codebase health scans.
+
+    Each record represents a suggested refactoring task.
+    Data is replaced entirely with each new scan (latest only).
+    """
+
+    __tablename__ = "codebase_refactor_todos"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, index=True)
+    item_id: Mapped[str] = mapped_column(String(50), unique=True, index=True, nullable=False)
+    title: Mapped[str] = mapped_column(String(200), nullable=False)
+    description: Mapped[str] = mapped_column(Text, nullable=False)
+    priority: Mapped[str] = mapped_column(String(20), nullable=False, index=True)
+    status: Mapped[str] = mapped_column(String(20), nullable=False, default="pending", index=True)
+    category: Mapped[List[str]] = mapped_column(JSON, nullable=False, default=list)
+    effort: Mapped[str] = mapped_column(String(20), nullable=False)
+    affected_files: Mapped[List[str]] = mapped_column(JSON, nullable=False, default=list)
+    details: Mapped[List[str]] = mapped_column(JSON, nullable=False, default=list)
+    automated_reason: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
+    technique: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow)
+
+    def __repr__(self) -> str:
+        return f"<CodebaseRefactorTodo(id={self.item_id}, title={self.title})>"
+
+
+class CodebaseScanMeta(Base):
+    """Stores metadata about codebase health scans.
+
+    Only one record exists - the most recent scan.
+    Updated each time a new scan completes.
+    """
+
+    __tablename__ = "codebase_scan_meta"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, index=True)
+    generated_at: Mapped[datetime] = mapped_column(DateTime, nullable=False)
+    total_files: Mapped[int] = mapped_column(Integer, nullable=False)
+    total_loc: Mapped[int] = mapped_column(Integer, nullable=False)
+    total_todos: Mapped[int] = mapped_column(Integer, nullable=False)
+    avg_loc: Mapped[int] = mapped_column(Integer, nullable=False)
+
+    def __repr__(self) -> str:
+        return f"<CodebaseScanMeta(generated_at={self.generated_at}, files={self.total_files})>"

--- a/server/app/schemas/codebase_health.py
+++ b/server/app/schemas/codebase_health.py
@@ -1,0 +1,88 @@
+"""Pydantic schemas for codebase health API."""
+from datetime import datetime
+from typing import List, Optional, Dict, Any
+from pydantic import BaseModel
+
+
+class FileStatsResponse(BaseModel):
+    """Single file statistics."""
+    id: int
+    path: str
+    loc: int
+    nesting_depth: int
+    file_type: str
+    area: str
+    size_category: str
+
+    class Config:
+        from_attributes = True
+
+
+class FileStatsListResponse(BaseModel):
+    """Paginated list of file statistics."""
+    files: List[FileStatsResponse]
+    total: int
+    page: int
+    page_size: int
+
+
+class RefactorTodoResponse(BaseModel):
+    """Single refactor suggestion."""
+    id: int
+    item_id: str
+    title: str
+    description: str
+    priority: str
+    status: str
+    category: List[str]
+    effort: str
+    affected_files: List[str]
+    details: List[str]
+    automated_reason: Optional[str]
+    technique: Optional[str]
+
+    class Config:
+        from_attributes = True
+
+
+class RefactorTodoListResponse(BaseModel):
+    """List of refactor suggestions."""
+    todos: List[RefactorTodoResponse]
+    total: int
+
+
+class ScanMetaResponse(BaseModel):
+    """Scan metadata."""
+    generated_at: datetime
+    total_files: int
+    total_loc: int
+    total_todos: int
+    avg_loc: int
+
+    class Config:
+        from_attributes = True
+
+
+class AreaStats(BaseModel):
+    """Statistics for a single area."""
+    count: int
+    total_loc: int
+
+
+class CodebaseStatsResponse(BaseModel):
+    """Aggregated codebase statistics."""
+    total_files: int
+    total_loc: int
+    avg_loc: int
+    total_todos: int
+    generated_at: Optional[datetime]
+    by_area: Dict[str, AreaStats]
+    by_priority: Dict[str, int]
+
+
+class ScanTriggerResponse(BaseModel):
+    """Response from triggering a scan."""
+    success: bool
+    message: str
+    files_processed: int
+    todos_generated: int

--- a/web/src/hooks/useCodebaseHealth.ts
+++ b/web/src/hooks/useCodebaseHealth.ts
@@ -1,0 +1,281 @@
+/**
+ * Hook for fetching codebase health data from API with static fallback
+ */
+import { useState, useEffect, useCallback } from 'react';
+import type {
+  FileStats,
+  RefactorItem,
+  Area,
+  FileType,
+  SizeCategory,
+  RefactorPriority,
+  RefactorStatus,
+} from '../data/codebaseHealthData';
+
+// Import static data as fallback
+import {
+  FILE_STATS as STATIC_FILE_STATS,
+  REFACTOR_TODOS as STATIC_REFACTOR_TODOS,
+  GENERATED_AT as STATIC_GENERATED_AT,
+} from '../data/codebaseHealthData';
+
+const API_BASE = '/api/codebase-health';
+
+interface FileStatsFilters {
+  area?: Area;
+  fileType?: FileType;
+  sizeCategory?: SizeCategory;
+  search?: string;
+  sortBy?: 'path' | 'loc' | 'type' | 'area';
+  sortDir?: 'asc' | 'desc';
+  page?: number;
+  pageSize?: number;
+}
+
+interface TodoFilters {
+  priority?: RefactorPriority;
+  status?: RefactorStatus;
+  search?: string;
+}
+
+interface FileStatsResponse {
+  files: FileStats[];
+  total: number;
+  page: number;
+  page_size: number;
+}
+
+interface TodosResponse {
+  todos: RefactorItem[];
+  total: number;
+}
+
+interface StatsResponse {
+  total_files: number;
+  total_loc: number;
+  avg_loc: number;
+  total_todos: number;
+  generated_at: string | null;
+  by_area: Record<string, { count: number; total_loc: number }>;
+  by_priority: Record<string, number>;
+}
+
+/**
+ * Hook for fetching file stats from API
+ */
+export function useFileStats(filters: FileStatsFilters = {}) {
+  const [files, setFiles] = useState<FileStats[]>([]);
+  const [total, setTotal] = useState(0);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [usingFallback, setUsingFallback] = useState(false);
+
+  const fetchFiles = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+
+    try {
+      const params = new URLSearchParams();
+      if (filters.area) params.set('area', filters.area);
+      if (filters.fileType) params.set('file_type', filters.fileType);
+      if (filters.sizeCategory) params.set('size_category', filters.sizeCategory);
+      if (filters.search) params.set('search', filters.search);
+      if (filters.sortBy) params.set('sort_by', filters.sortBy);
+      if (filters.sortDir) params.set('sort_dir', filters.sortDir);
+      if (filters.page) params.set('page', filters.page.toString());
+      if (filters.pageSize) params.set('page_size', filters.pageSize.toString());
+
+      const response = await fetch(`${API_BASE}/files?${params}`);
+
+      if (!response.ok) {
+        throw new Error(`HTTP ${response.status}`);
+      }
+
+      const data: FileStatsResponse = await response.json();
+      setFiles(data.files);
+      setTotal(data.total);
+      setUsingFallback(false);
+    } catch (err) {
+      console.warn('API fetch failed, using static fallback:', err);
+      // Fall back to static data
+      let filteredFiles = [...STATIC_FILE_STATS];
+
+      if (filters.area) {
+        filteredFiles = filteredFiles.filter(f => f.area === filters.area);
+      }
+      if (filters.fileType) {
+        filteredFiles = filteredFiles.filter(f => f.fileType === filters.fileType);
+      }
+      if (filters.sizeCategory) {
+        filteredFiles = filteredFiles.filter(f => f.sizeCategory === filters.sizeCategory);
+      }
+      if (filters.search) {
+        const search = filters.search.toLowerCase();
+        filteredFiles = filteredFiles.filter(f => f.path.toLowerCase().includes(search));
+      }
+
+      // Sort
+      const sortBy = filters.sortBy || 'loc';
+      const sortDir = filters.sortDir || 'desc';
+      filteredFiles.sort((a, b) => {
+        let cmp = 0;
+        switch (sortBy) {
+          case 'path': cmp = a.path.localeCompare(b.path); break;
+          case 'loc': cmp = a.loc - b.loc; break;
+          case 'type': cmp = a.fileType.localeCompare(b.fileType); break;
+          case 'area': cmp = a.area.localeCompare(b.area); break;
+        }
+        return sortDir === 'asc' ? cmp : -cmp;
+      });
+
+      // Paginate
+      const page = filters.page || 1;
+      const pageSize = filters.pageSize || 100;
+      const start = (page - 1) * pageSize;
+      const paginatedFiles = filteredFiles.slice(start, start + pageSize);
+
+      setFiles(paginatedFiles);
+      setTotal(filteredFiles.length);
+      setUsingFallback(true);
+      setError(null);
+    } finally {
+      setLoading(false);
+    }
+  }, [filters.area, filters.fileType, filters.sizeCategory, filters.search, filters.sortBy, filters.sortDir, filters.page, filters.pageSize]);
+
+  useEffect(() => {
+    fetchFiles();
+  }, [fetchFiles]);
+
+  return { files, total, loading, error, usingFallback, refetch: fetchFiles };
+}
+
+/**
+ * Hook for fetching refactor todos from API
+ */
+export function useRefactorTodos(filters: TodoFilters = {}) {
+  const [todos, setTodos] = useState<RefactorItem[]>([]);
+  const [total, setTotal] = useState(0);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [usingFallback, setUsingFallback] = useState(false);
+
+  const fetchTodos = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+
+    try {
+      const params = new URLSearchParams();
+      if (filters.priority) params.set('priority', filters.priority);
+      if (filters.status) params.set('status', filters.status);
+      if (filters.search) params.set('search', filters.search);
+
+      const response = await fetch(`${API_BASE}/todos?${params}`);
+
+      if (!response.ok) {
+        throw new Error(`HTTP ${response.status}`);
+      }
+
+      const data: TodosResponse = await response.json();
+      setTodos(data.todos);
+      setTotal(data.total);
+      setUsingFallback(false);
+    } catch (err) {
+      console.warn('API fetch failed, using static fallback:', err);
+      // Fall back to static data
+      let filteredTodos = [...STATIC_REFACTOR_TODOS];
+
+      if (filters.priority) {
+        filteredTodos = filteredTodos.filter(t => t.priority === filters.priority);
+      }
+      if (filters.status) {
+        filteredTodos = filteredTodos.filter(t => t.status === filters.status);
+      }
+      if (filters.search) {
+        const search = filters.search.toLowerCase();
+        filteredTodos = filteredTodos.filter(t =>
+          t.title.toLowerCase().includes(search) ||
+          t.description.toLowerCase().includes(search)
+        );
+      }
+
+      setTodos(filteredTodos);
+      setTotal(filteredTodos.length);
+      setUsingFallback(true);
+      setError(null);
+    } finally {
+      setLoading(false);
+    }
+  }, [filters.priority, filters.status, filters.search]);
+
+  useEffect(() => {
+    fetchTodos();
+  }, [fetchTodos]);
+
+  return { todos, total, loading, error, usingFallback, refetch: fetchTodos };
+}
+
+/**
+ * Hook for fetching codebase stats from API
+ */
+export function useCodebaseStats() {
+  const [stats, setStats] = useState<StatsResponse | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [usingFallback, setUsingFallback] = useState(false);
+
+  const fetchStats = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+
+    try {
+      const response = await fetch(`${API_BASE}/stats`);
+
+      if (!response.ok) {
+        throw new Error(`HTTP ${response.status}`);
+      }
+
+      const data: StatsResponse = await response.json();
+      setStats(data);
+      setUsingFallback(false);
+    } catch (err) {
+      console.warn('API fetch failed, using static fallback:', err);
+      // Calculate stats from static data
+      const byArea: Record<string, { count: number; total_loc: number }> = {};
+      for (const file of STATIC_FILE_STATS) {
+        if (!byArea[file.area]) {
+          byArea[file.area] = { count: 0, total_loc: 0 };
+        }
+        byArea[file.area].count++;
+        byArea[file.area].total_loc += file.loc;
+      }
+
+      const byPriority: Record<string, number> = { critical: 0, high: 0, medium: 0, low: 0 };
+      for (const todo of STATIC_REFACTOR_TODOS) {
+        byPriority[todo.priority] = (byPriority[todo.priority] || 0) + 1;
+      }
+
+      const totalLoc = STATIC_FILE_STATS.reduce((sum, f) => sum + f.loc, 0);
+
+      setStats({
+        total_files: STATIC_FILE_STATS.length,
+        total_loc: totalLoc,
+        avg_loc: Math.round(totalLoc / STATIC_FILE_STATS.length),
+        total_todos: STATIC_REFACTOR_TODOS.length,
+        generated_at: STATIC_GENERATED_AT,
+        by_area: byArea,
+        by_priority: byPriority,
+      });
+      setUsingFallback(true);
+      setError(null);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchStats();
+  }, [fetchStats]);
+
+  return { stats, loading, error, usingFallback, refetch: fetchStats };
+}


### PR DESCRIPTION
## Summary
- Add database tables for storing codebase health data (file_stats, refactor_todos, scan_meta)
- Add API endpoints for fetching data (`/api/codebase-health/*`)
- Update generate script with `--database` flag to write to PostgreSQL
- Add frontend hooks with automatic fallback to static data

## Changes

### Database
- `CodebaseFileStats` model - stores file path, LOC, type, area, size category
- `CodebaseRefactorTodo` model - stores refactor suggestions with priority/status
- `CodebaseScanMeta` model - stores scan timestamp and totals

### API Endpoints
| Method | Path | Description |
|--------|------|-------------|
| GET | `/api/codebase-health/files` | List file stats with pagination/filtering |
| GET | `/api/codebase-health/todos` | List refactor suggestions |
| GET | `/api/codebase-health/stats` | Aggregated statistics |
| GET | `/api/codebase-health/scan-info` | Latest scan metadata |

### Script Usage
```bash
# Generate TypeScript only (existing behavior)
python scripts/generate_codebase_health.py

# Generate TypeScript AND write to database
python scripts/generate_codebase_health.py --database

# Write to database only (skip TypeScript)
python scripts/generate_codebase_health.py --database-only
```

### Frontend Hooks
- `useFileStats(filters)` - fetch files with filtering
- `useRefactorTodos(filters)` - fetch todos with filtering
- `useCodebaseStats()` - fetch aggregated stats
- All hooks automatically fall back to static data if API unavailable

## Test plan
- [ ] Run migration: `alembic upgrade head`
- [ ] Run script: `python scripts/generate_codebase_health.py --database`
- [ ] Test API: `curl http://localhost:8000/api/codebase-health/stats`
- [ ] Verify frontend still works (uses static fallback until migration runs)
- [ ] TypeScript build: `cd web && npx tsc --noEmit`

🤖 Generated with [Claude Code](https://claude.com/claude-code)