### PR TITLE
feat: emit DICE_ROLL events for D&D combat dice HUD

### DIFF
--- a/src/core/events.py
+++ b/src/core/events.py
@@ -147,6 +147,9 @@ class EventType(Enum):
     PLAYER_TURN_START = auto() # Player turn started
     PLAYER_TURN_END = auto()   # Player turn ended
 
+    # D&D dice roll events (v6.10 - animated dice display)
+    DICE_ROLL = auto()         # Dice roll for combat (roll_type, dice_notation, rolls, modifier, total, etc.)
+
     # Transition events (v6.1)
     TRANSITION_START = auto()  # Transition began (kind in data)
     TRANSITION_END = auto()    # Transition completed or skipped


### PR DESCRIPTION
## Summary
- Add DICE_ROLL event type to backend event system
- Integrate D&D dice combat into player and enemy attack resolution
- Emit DICE_ROLL events that trigger the 3D dice HUD in the frontend

## Changes

### Backend Event System
- Added `DICE_ROLL` event type to `EventType` enum in `src/core/events.py`

### Player Combat (`src/combat/battle_player_actions.py`)
- Import D&D combat functions (`make_attack_roll`, `make_damage_roll`)
- Check if player has ability scores to enable D&D combat
- Attack roll: 1d20 + attack modifier vs target AC
- Damage roll: weapon dice + damage modifier (doubled on crit)
- Emit DICE_ROLL events for both attack and damage rolls
- Support critical hits (natural 20) and fumbles (natural 1)
- Fallback to simple combat calculation if no ability scores

### Enemy Combat (`src/combat/enemy_turns.py`)
- Import D&D combat functions
- Use enemy's `attack_bonus` and `damage_dice` attributes
- Emit DICE_ROLL events for enemy attack and damage rolls
- Support field pulse amplification on damage
- Fallback to simple combat if player has no ability scores

### Event Data Structure
```python
DICE_ROLL event includes:
- roll_type: 'attack' | 'damage'
- dice_notation: '1d20', '1d6', etc.
- rolls: [int, ...]
- modifier: int
- total: int
- target_ac: int (for attack rolls)
- is_hit: bool
- is_critical: bool
- is_fumble: bool
- luck_applied: bool
- attacker_name: str
```

## Test plan
- [ ] Start a battle with a character that has rolled ability scores
- [ ] Attack an enemy - verify DICE_ROLL events appear in browser console
- [ ] Verify DiceRollHUD shows animated d20 for attack roll
- [ ] Verify DiceRollHUD shows weapon damage dice on hit
- [ ] Verify critical hits show doubled dice
- [ ] Let enemy attack - verify enemy DICE_ROLL events
- [ ] Test with character without ability scores - should use fallback combat

🤖 Generated with [Claude Code](https://claude.com/claude-code)