### PR TITLE
chore: add max-safe claude repo bot automation

### DIFF
--- a/.claude/bot-config.yml
+++ b/.claude/bot-config.yml
@@ -1,0 +1,50 @@
+bot:
+  default_branch: develop
+
+  # Directories the bot is allowed to analyze and modify.
+  scan_paths:
+    - src
+    - web/src
+    - server
+    - scripts
+
+  max_new_issues_per_run: 20
+
+  commands:
+    # Cheap checks to run before opening PRs (during fix stage).
+    # Autodetect mode - bot will infer from package.json, pyproject.toml, etc.
+    smoke: []
+    # Full verification checks run in PR CI and optionally on default-branch pushes.
+    verify: []
+
+  labels:
+    reported: "bot:reported"
+    queued: "bot:queued"
+    in_progress: "bot:in-progress"
+    pr_open: "bot:pr-open"
+    ready_to_merge: "bot:ready-to-merge"
+    verified: "bot:verified"
+    blocked: "bot:blocked"
+    automerge: "bot:automerge"
+
+  safety:
+    # Hard cap (adds+deletes) per PR to reduce risky changes.
+    max_changed_lines: 400
+
+    # Disallowed globs: bot will refuse to open a PR if diff touches these.
+    disallowed_globs:
+      - ".github/**"
+      - ".claude/**"
+      - "scripts/claude-bot/**"
+
+  pr:
+    enabled: true
+
+    # Auto-merge disabled - PRs require manual merge approval
+    auto_merge_on_ci: false
+    require_automerge_label: true
+
+    # merge|rebase|rebase-merge|squash
+    merge_style: squash
+
+    delete_branch_after_merge: true

--- a/.claude/skills/bot-daily-report/SKILL.md
+++ b/.claude/skills/bot-daily-report/SKILL.md
@@ -1,0 +1,15 @@
+---
+name: bot-daily-report
+description: Summarize today's bot activity (issues created, fixes committed, verifies).
+disable-model-invocation: true
+allowed-tools: Bash(git log:*), Read
+---
+
+# Daily report
+
+Generate a concise report of:
+- issues created/updated today
+- issues fixed (commits)
+- verify status
+
+Use this to post a daily status update (optional).

--- a/.claude/skills/bot-discover-issues/SKILL.md
+++ b/.claude/skills/bot-discover-issues/SKILL.md
@@ -1,0 +1,42 @@
+---
+name: bot-discover-issues
+description: Scan the repo (or a scope) and output a structured list of actionable issues to file as tickets.
+argument-hint: "[optional-scope-path]"
+disable-model-invocation: true
+allowed-tools: Read, Grep, Glob, Bash(./scripts/claude-bot/run_signals.sh:*)
+---
+
+# Discover issues in a repo scope
+
+**Arguments:** `$ARGUMENTS` (optional path scope). If omitted, use the repo's configured scan paths.
+
+## Goal
+
+Produce a JSON object that matches `schemas/issues.schema.json` containing an array of issues.
+
+## Requirements
+
+For each issue:
+- Must be **actionable**
+- Must include **evidence** (file paths + lines / symbols / concrete symptoms)
+- Must propose a **specific fix strategy**
+- Must be categorized:
+  - `type`: bug|security|performance|refactor|docs|test|ci|deps
+  - `severity`: critical|high|medium|low
+
+## Process
+
+1. Run signals collection:
+   - `./scripts/claude-bot/run_signals.sh`
+2. Inspect the configured scan paths (or `$ARGUMENTS` scope).
+3. Identify issues across:
+   - correctness, security, data races, error handling
+   - tests and CI reliability
+   - performance footguns
+   - maintainability / complexity hot spots
+4. Output issues in schema form.
+
+## Supporting files
+
+- Schema: `schemas/issues.schema.json`
+- Issue body template: `templates/issue_body.md`

--- a/.claude/skills/bot-discover-issues/schemas/issues.schema.json
+++ b/.claude/skills/bot-discover-issues/schemas/issues.schema.json
@@ -1,0 +1,94 @@
+{
+  "type": "object",
+  "properties": {
+    "issues": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "description",
+          "type",
+          "severity",
+          "paths",
+          "evidence",
+          "suggested_fix",
+          "confidence"
+        ],
+        "properties": {
+          "title": {
+            "type": "string",
+            "minLength": 5
+          },
+          "description": {
+            "type": "string",
+            "minLength": 20
+          },
+          "type": {
+            "type": "string",
+            "enum": [
+              "bug",
+              "security",
+              "performance",
+              "refactor",
+              "docs",
+              "test",
+              "ci",
+              "deps"
+            ]
+          },
+          "severity": {
+            "type": "string",
+            "enum": [
+              "critical",
+              "high",
+              "medium",
+              "low"
+            ]
+          },
+          "paths": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "minItems": 1
+          },
+          "evidence": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "minItems": 1
+          },
+          "repro": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "suggested_fix": {
+            "type": "string",
+            "minLength": 20
+          },
+          "confidence": {
+            "type": "number",
+            "minimum": 0,
+            "maximum": 1
+          },
+          "tags": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        }
+      }
+    },
+    "notes": {
+      "type": "string"
+    }
+  },
+  "required": [
+    "issues"
+  ]
+}

--- a/.claude/skills/bot-discover-issues/templates/issue_body.md
+++ b/.claude/skills/bot-discover-issues/templates/issue_body.md
@@ -1,0 +1,19 @@
+<!-- claude-bot:fingerprint: {{FINGERPRINT}} -->
+
+## Summary
+{{SUMMARY}}
+
+## Evidence
+{{EVIDENCE}}
+
+## Suggested fix
+{{SUGGESTED_FIX}}
+
+## Repro / validation
+{{REPRO}}
+
+## Metadata
+- Type: `{{TYPE}}`
+- Severity: `{{SEVERITY}}`
+- Confidence: `{{CONFIDENCE}}`
+- Paths: {{PATHS}}

--- a/.claude/skills/bot-fix-issues/SKILL.md
+++ b/.claude/skills/bot-fix-issues/SKILL.md
@@ -1,0 +1,31 @@
+---
+name: bot-fix-issues
+description: Solve queued bot issues by applying minimal diffs and preparing a commit per ticket.
+argument-hint: "[issue-number | 'all']"
+disable-model-invocation: true
+allowed-tools: Read, Edit, Grep, Glob, Bash(./scripts/claude-bot/run_smoke.sh:*), Bash(git status:*), Bash(git diff:*), Bash(git grep:*), Bash(git restore:*), Bash(git checkout:*), Bash(git add:*), Bash(git reset:*), Bash(git commit:*)
+---
+
+# Fix queued issues
+
+**Arguments:** `$ARGUMENTS` can be a single issue number or `all` (recommended).
+
+## Constraints
+
+- Only address **one ticket per commit**.
+- **Minimal change** needed to resolve the ticket.
+- Add/adjust tests if feasible.
+- Run smoke checks via `./scripts/claude-bot/run_smoke.sh` before committing.
+- If you cannot fix safely, stop and request human input; do not guess.
+
+## Output / behavior
+
+- Make code changes only; do **not** merge or close issues directly.
+- Leave repo in a state where a separate verify stage can confirm and close.
+
+Supporting docs:
+- Bot policy: `/bot-policy`
+- Triage rules: `/bot-triage`
+
+
+- The automation opens a PR per ticket; CI verifies and (optionally) merges.

--- a/.claude/skills/bot-gitea-ops/SKILL.md
+++ b/.claude/skills/bot-gitea-ops/SKILL.md
@@ -1,0 +1,16 @@
+---
+name: bot-gitea-ops
+description: Reference for how the bot interacts with Gitea (labels, issues, secrets, comments).
+disable-model-invocation: false
+user-invocable: true
+---
+
+# Gitea Ops Reference
+
+The automation scripts use the Gitea REST API to:
+- create/update labels
+- create/update issues
+- add comments
+- set repository Actions secrets
+
+See `scripts/claude-bot/bot.py` and `scripts/claude-bot/gitea_client.py` for implementation.

--- a/.claude/skills/bot-policy/SKILL.md
+++ b/.claude/skills/bot-policy/SKILL.md
@@ -1,0 +1,26 @@
+---
+name: bot-policy
+description: Guardrails for repo automation: safety, idempotence, and escalation rules.
+user-invocable: false
+disable-model-invocation: false
+---
+
+# Repo Bot Policy (read-only)
+
+You are operating inside a Git repository with automation that can file issues, propose fixes, and run verification.
+
+## Non-negotiables
+
+- **Never exfiltrate secrets**. Treat `.env*`, credentials files, tokens, keys, and CI secrets as sensitive and do not quote them.
+- **Be idempotent**. Prefer updating existing artifacts over creating duplicates.
+- **Prefer minimal diffs**. Small, localized changes; no drive-by refactors.
+- **Escalate when uncertain**. If you cannot reproduce, cannot prove correctness, or fixes are risky, label as blocked and ask for human input.
+
+## Ticket semantics
+
+- `bot:queued` = safe/clear enough to attempt a fix automatically.
+- `bot:blocked` = needs human decision, missing reproduction, or risky change.
+- `bot:fixed-pending-verify` = fix committed; waiting for verify stage.
+- `bot:verified` = post-verify confirmed.
+
+This policy applies across all other bot skills.

--- a/.claude/skills/bot-triage/SKILL.md
+++ b/.claude/skills/bot-triage/SKILL.md
@@ -1,0 +1,52 @@
+---
+name: bot-triage
+description: Label taxonomy and triage rules used by the repo bot.
+disable-model-invocation: false
+user-invocable: true
+---
+
+# Bot triage taxonomy
+
+## Type labels
+- `type:bug`
+- `type:security`
+- `type:performance`
+- `type:refactor`
+- `type:docs`
+- `type:test`
+- `type:ci`
+- `type:deps`
+
+## Severity labels
+- `sev:critical`
+- `sev:high`
+- `sev:medium`
+- `sev:low`
+
+## State labels
+- `bot:reported`
+- `bot:queued`
+- `bot:in-progress`
+- `bot:fixed-pending-verify`
+- `bot:verified`
+- `bot:blocked`
+
+## Queueing rules
+
+Queue automatically (`bot:queued`) **only if**:
+- fix is low-risk and local
+- there is evidence + an expected validation step
+
+Otherwise mark `bot:blocked` with a clear request.
+
+## Dedupe rules
+
+If a newly discovered issue matches an existing fingerprint marker:
+- update the existing issue body (append new evidence)
+- add a comment with a timestamped update
+
+
+## PR labels
+- `bot:pr-open`
+- `bot:ready-to-merge`
+- `bot:automerge` (opt-in to allow CI to auto-merge)

--- a/.claude/skills/bot-verify-and-close/SKILL.md
+++ b/.claude/skills/bot-verify-and-close/SKILL.md
@@ -1,0 +1,20 @@
+---
+name: bot-verify-and-close
+description: Run verification commands and close issues whose fixes survived verification.
+disable-model-invocation: true
+allowed-tools: Bash(./scripts/claude-bot/run_verify.sh:*), Bash(git log:*), Read
+---
+
+# Verify and close
+
+## Goal
+
+- Run repo verification (`./scripts/claude-bot/run_verify.sh`).
+- If verification passes:
+  - Close issues labeled `bot:fixed-pending-verify`
+  - Apply `bot:verified`
+- If verification fails:
+  - Do not close issues
+  - Add a comment with failure summary and next steps
+
+This should be run by CI after the fix stage.

--- a/.github/workflows/claude_discover.yml
+++ b/.github/workflows/claude_discover.yml
@@ -1,9 +1,11 @@
-name: Claude Bot - Nightly Discover
+name: Claude Bot - Discover (Manual)
+
+# NOTE: This workflow requires ANTHROPIC_API_KEY secret to run in CI.
+# Preferred usage: Run locally with your CLI auth instead:
+#   python scripts/claude-bot/bot.py discover
 
 on:
-  schedule:
-    - cron: "5 23 * * *"   # 23:05 UTC (adjust as needed)
-  workflow_dispatch:
+  workflow_dispatch:  # Manual trigger only
 
 permissions:
   contents: read

--- a/.github/workflows/claude_discover.yml
+++ b/.github/workflows/claude_discover.yml
@@ -1,0 +1,35 @@
+name: Claude Bot - Nightly Discover
+
+on:
+  schedule:
+    - cron: "5 23 * * *"   # 23:05 UTC (adjust as needed)
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  discover:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install Python deps
+        run: |
+          python3 -m pip install --upgrade pip
+          pip3 install -r scripts/claude-bot/requirements.txt
+
+      - name: Install Claude Code
+        run: |
+          curl -fsSL https://claude.ai/install.sh | bash
+
+      - name: Discover issues
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          python3 scripts/claude-bot/bot.py discover

--- a/.github/workflows/claude_fix_prs.yml
+++ b/.github/workflows/claude_fix_prs.yml
@@ -1,0 +1,39 @@
+name: Claude Bot - Nightly Fix (Open PRs)
+
+on:
+  schedule:
+    - cron: "10 0 * * *"   # 00:10 UTC (about 1h after discover)
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
+
+jobs:
+  fix:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          persist-credentials: true
+
+      - name: Install Python deps
+        run: |
+          python3 -m pip install --upgrade pip
+          pip3 install -r scripts/claude-bot/requirements.txt
+
+      - name: Install Claude Code
+        run: |
+          curl -fsSL https://claude.ai/install.sh | bash
+
+      - name: Fix queued issues and open PRs
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          git config user.email "claude-bot@users.noreply.github.com"
+          git config user.name "claude-bot"
+          python3 scripts/claude-bot/bot.py fix all

--- a/.github/workflows/claude_fix_prs.yml
+++ b/.github/workflows/claude_fix_prs.yml
@@ -1,9 +1,11 @@
-name: Claude Bot - Nightly Fix (Open PRs)
+name: Claude Bot - Fix PRs (Manual)
+
+# NOTE: This workflow requires ANTHROPIC_API_KEY secret to run in CI.
+# Preferred usage: Run locally with your CLI auth instead:
+#   python scripts/claude-bot/bot.py fix all
 
 on:
-  schedule:
-    - cron: "10 0 * * *"   # 00:10 UTC (about 1h after discover)
-  workflow_dispatch:
+  workflow_dispatch:  # Manual trigger only
 
 permissions:
   contents: write

--- a/.github/workflows/main_verify.yml
+++ b/.github/workflows/main_verify.yml
@@ -1,0 +1,28 @@
+name: Default Branch Verify
+
+on:
+  push:
+    branches:
+      - develop
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install Python deps
+        run: |
+          python3 -m pip install --upgrade pip
+          pip3 install -r scripts/claude-bot/requirements.txt
+
+      - name: Verify (full)
+        run: |
+          python3 scripts/claude-bot/bot.py run-verify

--- a/.github/workflows/pr_ci.yml
+++ b/.github/workflows/pr_ci.yml
@@ -1,0 +1,37 @@
+name: PR CI (Verify) + Optional Auto-merge
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout PR
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          persist-credentials: true
+
+      - name: Install Python deps
+        run: |
+          python3 -m pip install --upgrade pip
+          pip3 install -r scripts/claude-bot/requirements.txt
+
+      - name: Verify (full)
+        run: |
+          python3 scripts/claude-bot/bot.py run-verify
+
+      - name: Finalize (mark ready / auto-merge if allowed)
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          PR_NUMBER="${{ github.event.pull_request.number }}"
+          python3 scripts/claude-bot/bot.py pr-ci-success "$PR_NUMBER"

--- a/scripts/claude-bot/bot.py
+++ b/scripts/claude-bot/bot.py
@@ -1,0 +1,697 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse, json, os, sys, datetime, fnmatch, re
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+from config import load_config, BotConfig
+from github_client import GitHubClient, RepoRef, GitHubError
+from utils import (
+    repo_root, sh, die, parse_git_remote, fingerprint_issue, extract_fingerprint,
+    ensure_git_identity
+)
+from claude_runner import run_claude, ClaudeError
+
+# -------------------------
+# Labels used by the bot
+# -------------------------
+
+LABEL_SETS = {
+    # state machine
+    "bot:reported": "2f81f7",
+    "bot:queued": "0e8a16",
+    "bot:in-progress": "fbca04",
+    "bot:pr-open": "cfd3d7",
+    "bot:ready-to-merge": "0e8a16",
+    "bot:verified": "1d76db",
+    "bot:blocked": "b60205",
+    "bot:automerge": "5319e7",
+
+    # types
+    "type:bug": "d73a4a",
+    "type:security": "b60205",
+    "type:performance": "1d76db",
+    "type:refactor": "cfd3d7",
+    "type:docs": "0075ca",
+    "type:test": "a2eeef",
+    "type:ci": "5319e7",
+    "type:deps": "0366d6",
+
+    # severities
+    "sev:critical": "b60205",
+    "sev:high": "d93f0b",
+    "sev:medium": "fbca04",
+    "sev:low": "0e8a16",
+}
+
+TYPE_TO_LABEL = {
+    "bug": "type:bug",
+    "security": "type:security",
+    "performance": "type:performance",
+    "refactor": "type:refactor",
+    "docs": "type:docs",
+    "test": "type:test",
+    "ci": "type:ci",
+    "deps": "type:deps",
+}
+SEV_TO_LABEL = {
+    "critical": "sev:critical",
+    "high": "sev:high",
+    "medium": "sev:medium",
+    "low": "sev:low",
+}
+
+CLOSE_ISSUE_RE = re.compile(r"(?i)\bfixes\s+#(\d+)\b|\bcloses\s+#(\d+)\b|\bresolves\s+#(\d+)\b")
+
+# -------------------------
+# Helpers
+# -------------------------
+
+def infer_repo_ref(args_owner: Optional[str], args_repo: Optional[str], args_base_url: Optional[str]) -> RepoRef:
+    base_url = args_base_url or os.environ.get("GITHUB_BASE_URL")  # web base (https://github.com or GHES host)
+    owner = args_owner or os.environ.get("GITHUB_OWNER")
+    repo = args_repo or os.environ.get("GITHUB_REPO")
+
+    if base_url and owner and repo:
+        return RepoRef(base_url=base_url, owner=owner, repo=repo)
+
+    # infer from git remote
+    remote = sh(["git","remote","get-url","origin"]).stdout.strip()
+    base, o, r = parse_git_remote(remote)
+    return RepoRef(base_url=base_url or base, owner=owner or o, repo=repo or r)
+
+def require_token(token: Optional[str]) -> str:
+    t = token or os.environ.get("GITHUB_TOKEN")
+    if not t:
+        die("Missing GitHub token. In GitHub Actions, GITHUB_TOKEN is provided automatically. Otherwise set GITHUB_TOKEN.")
+    return t
+
+def ensure_labels(client: GitHubClient) -> None:
+    # List labels; create missing.
+    existing = client.get_json(f"/repos/{client.repo.owner}/{client.repo.repo}/labels", params={"per_page": 100, "page": 1}) or []
+    have = {l["name"] for l in existing}
+    for name, color in LABEL_SETS.items():
+        if name in have:
+            continue
+        try:
+            client.post_json(f"/repos/{client.repo.owner}/{client.repo.repo}/labels", {"name": name, "color": color})
+            print(f"Created label: {name}")
+        except Exception as e:
+            print(f"Warn: could not create label {name}: {e}")
+
+def list_issues(client: GitHubClient, *, state: str="open", labels: Optional[List[str]]=None, limit: int=100) -> List[Dict[str,Any]]:
+    out: List[Dict[str,Any]] = []
+    page = 1
+    while True:
+        params: Dict[str,Any] = {"state": state, "per_page": limit, "page": page}
+        if labels:
+            params["labels"] = ",".join(labels)
+        batch = client.get_json(f"/repos/{client.repo.owner}/{client.repo.repo}/issues", params=params) or []
+        # GitHub issues endpoint returns PRs too; filter by missing 'pull_request' key.
+        batch = [i for i in batch if "pull_request" not in i]
+        if not batch:
+            break
+        out.extend(batch)
+        page += 1
+    return out
+
+def list_pull_requests(client: GitHubClient, *, state: str="open", limit: int=100) -> List[Dict[str,Any]]:
+    out: List[Dict[str,Any]] = []
+    page = 1
+    while True:
+        params: Dict[str,Any] = {"state": state, "per_page": limit, "page": page}
+        batch = client.get_json(f"/repos/{client.repo.owner}/{client.repo.repo}/pulls", params=params) or []
+        if not batch:
+            break
+        out.extend(batch)
+        page += 1
+    return out
+
+def get_pull_request(client: GitHubClient, pr_number: int) -> Dict[str,Any]:
+    return client.get_json(f"/repos/{client.repo.owner}/{client.repo.repo}/pulls/{pr_number}")
+
+def get_issue(client: GitHubClient, number: int) -> Dict[str,Any]:
+    return client.get_json(f"/repos/{client.repo.owner}/{client.repo.repo}/issues/{number}")
+
+def create_pull_request(client: GitHubClient, *, head: str, base: str, title: str, body: str) -> Dict[str,Any]:
+    return client.post_json(f"/repos/{client.repo.owner}/{client.repo.repo}/pulls", {"head": head, "base": base, "title": title, "body": body})
+
+def merge_pull_request(client: GitHubClient, pr_number: int, *, merge_method: str, sha: Optional[str]=None) -> Dict[str,Any]:
+    body: Dict[str,Any] = {"merge_method": merge_method}
+    if sha:
+        body["sha"] = sha
+    return client.put_json(f"/repos/{client.repo.owner}/{client.repo.repo}/pulls/{pr_number}/merge", body)
+
+def comment_issue(client: GitHubClient, issue_number: int, body: str) -> None:
+    client.post_json(f"/repos/{client.repo.owner}/{client.repo.repo}/issues/{issue_number}/comments", {"body": body})
+
+def patch_issue(client: GitHubClient, issue_number: int, *, title: Optional[str]=None, body: Optional[str]=None, labels: Optional[List[str]]=None) -> None:
+    payload: Dict[str,Any] = {}
+    if title is not None:
+        payload["title"] = title
+    if body is not None:
+        payload["body"] = body
+    if labels is not None:
+        payload["labels"] = labels
+    if payload:
+        client.patch_json(f"/repos/{client.repo.owner}/{client.repo.repo}/issues/{issue_number}", payload)
+
+def create_or_update_issue(client: GitHubClient, *, title: str, body: str, labels: List[str], fingerprint: str) -> Tuple[int, bool]:
+    # Dedupe within open bot:reported issues by fingerprint marker in body
+    existing = list_issues(client, state="open", labels=["bot:reported"])
+    for iss in existing:
+        fp = extract_fingerprint(iss.get("body") or "")
+        if fp == fingerprint:
+            num = int(iss["number"])
+            patch_issue(client, num, title=title, body=body, labels=labels)
+            comment_issue(client, num, f"claude-bot update: fingerprint `{fingerprint}` refreshed at {datetime.datetime.utcnow().isoformat()}Z")
+            return num, False
+
+    created = client.post_json(f"/repos/{client.repo.owner}/{client.repo.repo}/issues", {"title": title, "body": body, "labels": labels})
+    return int(created["number"]), True
+
+# -------------------------
+# Commands: run smoke/verify
+# -------------------------
+
+def run_commands(kind: str, cfg: BotConfig) -> int:
+    cmds = cfg.commands_smoke if kind == "smoke" else cfg.commands_verify
+    if cmds:
+        print(f"Running configured {kind} commands:")
+        for c in cmds:
+            print(f"  $ {c}")
+            cp = sh(["bash","-lc",c], check=False, capture=True)
+            sys.stdout.write(cp.stdout)
+            sys.stderr.write(cp.stderr)
+            if cp.returncode != 0:
+                print(f"{kind} failed: {c} (rc={cp.returncode})")
+                return cp.returncode
+        return 0
+
+    print(f"No configured {kind} commands; attempting autodetect.")
+    candidates: List[str] = []
+    rr = repo_root()
+    if (rr/"package.json").exists():
+        candidates.append("npm test")
+    if (rr/"pyproject.toml").exists() or (rr/"pytest.ini").exists() or (rr/"setup.py").exists():
+        candidates.append("pytest -q")
+    if (rr/"go.mod").exists():
+        candidates.append("go test ./...")
+    if (rr/"Cargo.toml").exists():
+        candidates.append("cargo test")
+    if (rr/"Makefile").exists():
+        candidates.append("make test")
+    if kind == "smoke":
+        candidates = candidates[:1] if candidates else []
+
+    if not candidates:
+        print(f"No autodetected {kind} commands. Treating as success.")
+        return 0
+
+    for c in candidates:
+        print(f"  $ {c}")
+        cp = sh(["bash","-lc",c], check=False, capture=True)
+        sys.stdout.write(cp.stdout)
+        sys.stderr.write(cp.stderr)
+        if cp.returncode != 0:
+            print(f"{kind} failed: {c} (rc={cp.returncode})")
+            return cp.returncode
+    return 0
+
+# -------------------------
+# Discovery
+# -------------------------
+
+def load_issue_schema(rr: Path) -> Dict[str,Any]:
+    schema_path = rr/".claude/skills/bot-discover-issues/schemas/issues.schema.json"
+    return json.loads(schema_path.read_text(encoding="utf-8"))
+
+def build_discover_prompt(cfg: BotConfig) -> str:
+    scan = ", ".join(cfg.scan_paths)
+    return f'''You are a repository analysis agent.
+
+Analyze ONLY these scan paths: {scan}.
+
+1) Run ./scripts/claude-bot/run_signals.sh and consider its output.
+2) Inspect the code in the scan paths.
+3) Output a JSON object matching the provided JSON schema under key "issues".
+
+Hard constraints:
+- Each issue must include evidence (file paths + concrete facts).
+- Prefer fewer, higher-signal issues (max {cfg.max_new_issues_per_run}).
+- Avoid trivial style-only nits unless they create real defects.
+'''
+
+def cmd_discover(args: argparse.Namespace) -> None:
+    rr = repo_root()
+    cfg = load_config(rr)
+    repo = infer_repo_ref(args.owner, args.repo, args.base_url)
+    token = require_token(args.token)
+    client = GitHubClient(repo, token=token)
+    ensure_labels(client)
+
+    schema = load_issue_schema(rr)
+    allowed = "Read,Grep,Glob,Bash(./scripts/claude-bot/run_signals.sh:*)"
+    prompt = build_discover_prompt(cfg)
+
+    try:
+        res = run_claude(prompt, allowed_tools=allowed, json_schema=schema, max_turns=int(args.max_turns))
+        structured = res.get("structured_output") or {}
+        issues = structured.get("issues") or []
+    except ClaudeError as e:
+        die(str(e))
+
+    if not isinstance(issues, list):
+        die(f"Claude returned unexpected issues payload: {type(issues)}")
+
+    issues = issues[: cfg.max_new_issues_per_run]
+    template_path = rr/".claude/skills/bot-discover-issues/templates/issue_body.md"
+    template = template_path.read_text(encoding="utf-8")
+
+    created, updated = 0, 0
+    for it in issues:
+        title = it["title"].strip()
+        typ = it["type"]
+        sev = it["severity"]
+        paths = it.get("paths") or []
+        fp = fingerprint_issue(title, typ, sev, paths)
+
+        evidence = "\n".join([f"- {e}" for e in (it.get("evidence") or [])])
+        repro = "\n".join([f"- {e}" for e in (it.get("repro") or [])]) or "- (none provided)"
+        body = template
+        body = body.replace("{{FINGERPRINT}}", fp)
+        body = body.replace("{{SUMMARY}}", it["description"].strip())
+        body = body.replace("{{EVIDENCE}}", evidence)
+        body = body.replace("{{SUGGESTED_FIX}}", it["suggested_fix"].strip())
+        body = body.replace("{{REPRO}}", repro)
+        body = body.replace("{{TYPE}}", typ)
+        body = body.replace("{{SEVERITY}}", sev)
+        body = body.replace("{{CONFIDENCE}}", str(it.get("confidence", 0.5)))
+        body = body.replace("{{PATHS}}", ", ".join(paths) if paths else "(none)")
+
+        labels = [
+            "bot:reported",
+            "bot:queued",
+            TYPE_TO_LABEL.get(typ, "type:bug"),
+            SEV_TO_LABEL.get(sev, "sev:medium"),
+        ]
+        num, was_created = create_or_update_issue(client, title=title, body=body, labels=labels, fingerprint=fp)
+        if was_created:
+            created += 1
+            print(f"Created issue #{num}: {title}")
+        else:
+            updated += 1
+            print(f"Updated issue #{num}: {title}")
+
+    print(json.dumps({"created": created, "updated": updated, "total": len(issues)}, indent=2))
+
+# -------------------------
+# Fix -> PR
+# -------------------------
+
+def infer_type_from_labels(issue: Dict[str,Any]) -> str:
+    labs = [l.get("name","") for l in (issue.get("labels") or [])]
+    for t, lab in TYPE_TO_LABEL.items():
+        if lab in labs:
+            return t
+    return "bug"
+
+def infer_sev_label(issue: Dict[str,Any]) -> str:
+    labs = [l.get("name","") for l in (issue.get("labels") or [])]
+    for lab in SEV_TO_LABEL.values():
+        if lab in labs:
+            return lab
+    return "sev:medium"
+
+def extract_type_sev_labels(issue: Dict[str,Any]) -> List[str]:
+    labs = [l.get("name","") for l in (issue.get("labels") or [])]
+    keep: List[str] = []
+    for n in labs:
+        if n.startswith("type:") or n.startswith("sev:"):
+            keep.append(n)
+    out: List[str] = []
+    for n in keep:
+        if n not in out:
+            out.append(n)
+    return out
+
+def slugify(s: str, max_len: int=32) -> str:
+    s = s.lower()
+    s = re.sub(r"[^a-z0-9]+", "-", s).strip("-")
+    return s[:max_len] if len(s) > max_len else s
+
+def _load_yaml_cfg(rr: Path) -> Dict[str,Any]:
+    import yaml
+    return yaml.safe_load((rr/".claude/bot-config.yml").read_text(encoding="utf-8")) or {}
+
+def _safety_cfg(rr: Path) -> Tuple[int, List[str]]:
+    raw = _load_yaml_cfg(rr)
+    safety = ((raw.get("bot", {}) or {}).get("safety", {}) or {})
+    max_lines = int(safety.get("max_changed_lines", 400))
+    globs = list(safety.get("disallowed_globs", []) or [])
+    return max_lines, globs
+
+def _pr_cfg(rr: Path) -> Dict[str,Any]:
+    raw = _load_yaml_cfg(rr)
+    return ((raw.get("bot", {}) or {}).get("pr", {}) or {})
+
+def is_disallowed(path: str, disallowed_globs: List[str]) -> bool:
+    for g in disallowed_globs:
+        if fnmatch.fnmatch(path, g):
+            return True
+    return False
+
+def paths_within_allowed(scan_paths: List[str], changed_files: List[str]) -> Tuple[bool, str]:
+    allowed = [p.rstrip("/") + "/" for p in scan_paths]
+    for f in changed_files:
+        f2 = f[2:] if f.startswith("./") else f
+        if any(f2 == p.rstrip("/") for p in scan_paths):
+            continue
+        if any(f2.startswith(pref) for pref in allowed):
+            continue
+        return False, f"Changed file outside allowed scan_paths: {f2}"
+    return True, ""
+
+def compute_changed_lines(numstat_lines: List[str]) -> Tuple[int, Optional[str]]:
+    total = 0
+    for line in numstat_lines:
+        parts = line.split("\t")
+        if len(parts) < 3:
+            continue
+        a, d, path = parts[0], parts[1], parts[2]
+        if a == "-" or d == "-":
+            return total, f"Binary or non-text diff detected for {path} (numstat has '-')"
+        try:
+            total += int(a) + int(d)
+        except ValueError:
+            pass
+    return total, None
+
+def find_existing_pr_for_branch(client: GitHubClient, head_branch: str) -> Optional[Dict[str,Any]]:
+    prs = list_pull_requests(client, state="open")
+    for pr in prs:
+        head = ((pr.get("head") or {}).get("ref")) or ""
+        if head == head_branch:
+            return pr
+    return None
+
+def cmd_fix(args: argparse.Namespace) -> None:
+    rr = repo_root()
+    cfg = load_config(rr)
+    repo = infer_repo_ref(args.owner, args.repo, args.base_url)
+    token = require_token(args.token)
+    client = GitHubClient(repo, token=token)
+    ensure_labels(client)
+
+    issues = list_issues(client, state="open", labels=[cfg.labels.queued])
+    if args.issue != "all":
+        target = int(args.issue)
+        issues = [i for i in issues if int(i["number"]) == target]
+
+    if not issues:
+        print("No queued issues to fix.")
+        return
+
+    ensure_git_identity()
+
+    default_branch = cfg.default_branch
+    sh(["git","fetch","origin",default_branch], check=False)
+    sh(["git","checkout",default_branch], check=True)
+    sh(["git","reset","--hard",f"origin/{default_branch}"], check=False)
+
+    max_changed_lines, disallowed_globs = _safety_cfg(rr)
+
+    allowed_tools = "Read,Edit,Grep,Glob,Bash(./scripts/claude-bot/run_smoke.sh:*),Bash(git diff:*),Bash(git status:*),Bash(git restore:*),Bash(git checkout:*),Bash(git add:*),Bash(git reset:*),Bash(git grep:*)"
+
+    opened: List[Dict[str,Any]] = []
+
+    for iss in issues:
+        num = int(iss["number"])
+        full = get_issue(client, num)
+        title = full.get("title","").strip()
+        body = full.get("body","")
+
+        print(f"--- Fixing issue #{num}: {title}")
+
+        typ = infer_type_from_labels(full)
+        sev_label = infer_sev_label(full)
+
+        patch_issue(client, num, labels=[
+            cfg.labels.reported,
+            cfg.labels.in_progress,
+            TYPE_TO_LABEL.get(typ, "type:bug"),
+            sev_label,
+        ])
+
+        branch = f"bot/issue-{num}-{slugify(title)}"
+        sh(["git","checkout","-B",branch,f"origin/{default_branch}"], check=True)
+
+        prompt = f'''You are an autonomous coding agent.
+
+Task: Fix GitHub issue #{num}: {title}
+
+Issue body:
+{body}
+
+Rules:
+- Make the minimal safe code changes to resolve the issue.
+- Do NOT commit, do NOT push, do NOT open/merge PRs, do NOT close the issue.
+- Run: ./scripts/claude-bot/run_smoke.sh (must pass).
+- If you cannot fix safely, stop and explain what blocks you.
+'''
+
+        try:
+            _ = run_claude(prompt, allowed_tools=allowed_tools, json_schema=None, max_turns=int(args.max_turns))
+        except ClaudeError as e:
+            comment_issue(client, num, f"claude-bot failed while attempting fix:\n\n```\n{e}\n```")
+            patch_issue(client, num, labels=[cfg.labels.reported, cfg.labels.blocked] + extract_type_sev_labels(full))
+            sh(["git","checkout",default_branch], check=False)
+            sh(["git","reset","--hard",f"origin/{default_branch}"], check=False)
+            continue
+
+        st = sh(["git","status","--porcelain"]).stdout.strip()
+        if not st:
+            comment_issue(client, num, "claude-bot: no working tree changes produced. Marking as blocked.")
+            patch_issue(client, num, labels=[cfg.labels.reported, cfg.labels.blocked] + extract_type_sev_labels(full))
+            sh(["git","checkout",default_branch], check=False)
+            sh(["git","reset","--hard",f"origin/{default_branch}"], check=False)
+            continue
+
+        rc = run_commands("smoke", cfg)
+        if rc != 0:
+            comment_issue(client, num, f"claude-bot: smoke checks failed (rc={rc}). Marking as blocked.")
+            patch_issue(client, num, labels=[cfg.labels.reported, cfg.labels.blocked] + extract_type_sev_labels(full))
+            sh(["git","reset","--hard",f"origin/{default_branch}"], check=False)
+            sh(["git","checkout",default_branch], check=False)
+            continue
+
+        changed_files = [ln.strip() for ln in sh(["git","diff","--name-only"]).stdout.splitlines() if ln.strip()]
+        ok, msg = paths_within_allowed(cfg.scan_paths, changed_files)
+        if not ok:
+            comment_issue(client, num, f"claude-bot: refusing PR. {msg}")
+            patch_issue(client, num, labels=[cfg.labels.reported, cfg.labels.blocked] + extract_type_sev_labels(full))
+            sh(["git","reset","--hard",f"origin/{default_branch}"], check=False)
+            sh(["git","checkout",default_branch], check=False)
+            continue
+
+        blocked = False
+        for f in changed_files:
+            if is_disallowed(f, disallowed_globs):
+                comment_issue(client, num, f"claude-bot: refusing PR. Diff touches disallowed path: `{f}`")
+                patch_issue(client, num, labels=[cfg.labels.reported, cfg.labels.blocked] + extract_type_sev_labels(full))
+                sh(["git","reset","--hard",f"origin/{default_branch}"], check=False)
+                sh(["git","checkout",default_branch], check=False)
+                blocked = True
+                break
+        if blocked:
+            continue
+
+        numstat = [ln for ln in sh(["git","diff","--numstat"]).stdout.splitlines() if ln.strip()]
+        total_lines, err = compute_changed_lines(numstat)
+        if err:
+            comment_issue(client, num, f"claude-bot: refusing PR. {err}")
+            patch_issue(client, num, labels=[cfg.labels.reported, cfg.labels.blocked] + extract_type_sev_labels(full))
+            sh(["git","reset","--hard",f"origin/{default_branch}"], check=False)
+            sh(["git","checkout",default_branch], check=False)
+            continue
+        if total_lines > max_changed_lines:
+            comment_issue(client, num, f"claude-bot: refusing PR. Diff too large: {total_lines} changed lines > {max_changed_lines} cap.")
+            patch_issue(client, num, labels=[cfg.labels.reported, cfg.labels.blocked] + extract_type_sev_labels(full))
+            sh(["git","reset","--hard",f"origin/{default_branch}"], check=False)
+            sh(["git","checkout",default_branch], check=False)
+            continue
+
+        sh(["git","add","-A"], check=True)
+        commit_msg = f"fix: {title} (refs #{num})"
+        sh(["git","commit","-m",commit_msg], check=True)
+        sha = sh(["git","rev-parse","HEAD"]).stdout.strip()
+        print(f"Committed {sha} on {branch} for issue #{num}")
+
+        push = sh(["git","push","-u","origin",branch], check=False)
+        if push.returncode != 0:
+            comment_issue(client, num, f"claude-bot: commit {sha} created but push failed. Manual intervention required.")
+            patch_issue(client, num, labels=[cfg.labels.reported, cfg.labels.blocked] + extract_type_sev_labels(full))
+            sh(["git","checkout",default_branch], check=False)
+            sh(["git","reset","--hard",f"origin/{default_branch}"], check=False)
+            continue
+
+        existing_pr = find_existing_pr_for_branch(client, branch)
+        pr = None
+        if existing_pr:
+            pr = existing_pr
+            pr_num = int(pr["number"])
+        else:
+            pr_body = f'''<!-- claude-bot:issue:{num} -->
+{title}
+
+Fix commit: {sha}
+
+Fixes #{num}
+'''
+            try:
+                pr = create_pull_request(client, head=branch, base=default_branch, title=f"[bot] {title}", body=pr_body)
+                pr_num = int(pr["number"])
+            except GitHubError as e:
+                pr2 = find_existing_pr_for_branch(client, branch)
+                if pr2:
+                    pr = pr2
+                    pr_num = int(pr["number"])
+                else:
+                    comment_issue(client, num, f"claude-bot: failed to create PR for branch `{branch}`.\n\n```\n{e}\n```")
+                    patch_issue(client, num, labels=[cfg.labels.reported, cfg.labels.blocked] + extract_type_sev_labels(full))
+                    sh(["git","checkout",default_branch], check=False)
+                    sh(["git","reset","--hard",f"origin/{default_branch}"], check=False)
+                    continue
+
+        pr_url = pr.get("html_url") or ""
+        comment_issue(client, num, f"<!-- claude-bot:pr:{pr_num} -->\nclaude-bot: opened PR #{pr_num} for `{branch}`.\n\n{pr_url}")
+        patch_issue(client, num, labels=[cfg.labels.reported, cfg.labels.pr_open] + extract_type_sev_labels(full))
+
+        opened.append({"issue": num, "branch": branch, "commit": sha, "pr": pr_num, "url": pr_url})
+
+        sh(["git","checkout",default_branch], check=False)
+        sh(["git","reset","--hard",f"origin/{default_branch}"], check=False)
+
+    print(json.dumps({"opened_prs": opened, "count": len(opened)}, indent=2))
+
+# -------------------------
+# PR CI Finalize: mark ready / auto-merge
+# -------------------------
+
+def parse_issue_number_from_pr(pr: Dict[str,Any]) -> Optional[int]:
+    body = pr.get("body") or ""
+    m = re.search(r"<!--\s*claude-bot:issue:(\d+)\s*-->", body)
+    if m:
+        return int(m.group(1))
+    m2 = CLOSE_ISSUE_RE.search(body)
+    if m2:
+        for g in m2.groups():
+            if g:
+                return int(g)
+    return None
+
+def pr_has_label(client: GitHubClient, pr_number: int, label_name: str) -> bool:
+    # Labels for PRs are managed via the issues API on GitHub.
+    issue = get_issue(client, pr_number)
+    labs = issue.get("labels") or []
+    return any((l.get("name") == label_name) for l in labs)
+
+def cmd_pr_ci_success(args: argparse.Namespace) -> None:
+    rr = repo_root()
+    cfg = load_config(rr)
+    pr_cfg = _pr_cfg(rr)
+
+    repo = infer_repo_ref(args.owner, args.repo, args.base_url)
+    token = require_token(args.token)
+    client = GitHubClient(repo, token=token)
+    ensure_labels(client)
+
+    pr_number = int(args.pr_number)
+    pr = get_pull_request(client, pr_number)
+    issue_number = parse_issue_number_from_pr(pr)
+
+    if issue_number:
+        try:
+            issue_obj = get_issue(client, issue_number)
+            keep = extract_type_sev_labels(issue_obj)
+            patch_issue(client, issue_number, labels=[cfg.labels.reported, cfg.labels.ready_to_merge] + keep)
+            comment_issue(client, issue_number, f"claude-bot: PR #{pr_number} CI passed. Marked ready-to-merge.")
+        except Exception as e:
+            print(f"Warn: failed to update issue labels/comments: {e}")
+
+    auto_merge = bool(pr_cfg.get("auto_merge_on_ci", False))
+    require_label = bool(pr_cfg.get("require_automerge_label", True))
+    automerge_label = cfg.labels.automerge
+    merge_style = str(pr_cfg.get("merge_style","squash"))
+
+    if not auto_merge:
+        print("auto_merge_on_ci is false; not merging.")
+        return
+    if require_label and not pr_has_label(client, pr_number, automerge_label):
+        print(f"PR missing required label {automerge_label}; not merging.")
+        return
+
+    # Safety: require head sha match at merge time.
+    head_sha = ((pr.get("head") or {}).get("sha")) or None
+
+    try:
+        res = merge_pull_request(client, pr_number, merge_method=merge_style, sha=head_sha)
+        print(f"Merged PR #{pr_number} (method={merge_style}) -> {res}")
+        if issue_number:
+            issue_obj2 = get_issue(client, issue_number)
+            keep2 = extract_type_sev_labels(issue_obj2)
+            patch_issue(client, issue_number, labels=[cfg.labels.verified] + keep2)
+            comment_issue(client, issue_number, f"claude-bot: merged PR #{pr_number}. Issue should close via closing keywords in PR body.")
+    except Exception as e:
+        print(f"Auto-merge failed: {e}")
+        if issue_number:
+            issue_obj3 = get_issue(client, issue_number)
+            keep3 = extract_type_sev_labels(issue_obj3)
+            comment_issue(client, issue_number, f"claude-bot: auto-merge failed for PR #{pr_number}.\n\n```\n{e}\n```")
+            patch_issue(client, issue_number, labels=[cfg.labels.reported, cfg.labels.blocked] + keep3)
+
+# -------------------------
+# Main
+# -------------------------
+
+def cmd_infer(args: argparse.Namespace) -> None:
+    repo = infer_repo_ref(args.owner, args.repo, args.base_url)
+    print(json.dumps({"base_url": repo.base_url, "owner": repo.owner, "repo": repo.repo}, indent=2))
+
+def main() -> None:
+    ap = argparse.ArgumentParser(prog="bot.py")
+    ap.add_argument("--owner")
+    ap.add_argument("--repo")
+    ap.add_argument("--base-url", dest="base_url")
+    ap.add_argument("--token")
+
+    sub = ap.add_subparsers(dest="cmd", required=True)
+
+    p = sub.add_parser("infer")
+    p.set_defaults(fn=cmd_infer)
+
+    p = sub.add_parser("run-smoke")
+    p.set_defaults(fn=lambda args: sys.exit(run_commands("smoke", load_config(repo_root()))))
+
+    p = sub.add_parser("run-verify")
+    p.set_defaults(fn=lambda args: sys.exit(run_commands("verify", load_config(repo_root()))))
+
+    p = sub.add_parser("discover")
+    p.add_argument("--max-turns", default="8")
+    p.set_defaults(fn=cmd_discover)
+
+    p = sub.add_parser("fix")
+    p.add_argument("issue", help="issue number or 'all'")
+    p.add_argument("--max-turns", default="10")
+    p.set_defaults(fn=cmd_fix)
+
+    p = sub.add_parser("pr-ci-success")
+    p.add_argument("pr_number", help="pull request number")
+    p.set_defaults(fn=cmd_pr_ci_success)
+
+    args = ap.parse_args()
+    args.fn(args)
+
+if __name__ == "__main__":
+    main()

--- a/scripts/claude-bot/claude_runner.py
+++ b/scripts/claude-bot/claude_runner.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+import json, subprocess
+from typing import Any, Dict, Optional, List
+
+class ClaudeError(RuntimeError):
+    pass
+
+def run_claude(prompt: str, *, allowed_tools: Optional[str]=None, json_schema: Optional[Dict[str, Any]]=None, max_turns: int=8) -> Dict[str, Any]:
+    cmd: List[str] = ["claude", "-p", prompt, "--output-format", "json", "--max-turns", str(max_turns)]
+    if allowed_tools:
+        cmd += ["--allowedTools", allowed_tools]
+    if json_schema is not None:
+        cmd += ["--json-schema", json.dumps(json_schema)]
+    cp = subprocess.run(cmd, text=True, capture_output=True)
+    if cp.returncode != 0:
+        raise ClaudeError(f"claude failed (rc={cp.returncode}):\nSTDOUT:\n{cp.stdout}\nSTDERR:\n{cp.stderr}")
+    try:
+        return json.loads(cp.stdout)
+    except Exception as e:
+        raise ClaudeError(f"claude output was not JSON. error={e}\nRAW:\n{cp.stdout[:2000]}")

--- a/scripts/claude-bot/config.py
+++ b/scripts/claude-bot/config.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import List
+import yaml
+
+@dataclass
+class BotLabels:
+    reported: str
+    queued: str
+    in_progress: str
+    pr_open: str
+    ready_to_merge: str
+    verified: str
+    blocked: str
+    automerge: str
+
+@dataclass
+class BotConfig:
+    default_branch: str
+    scan_paths: List[str]
+    max_new_issues_per_run: int
+    commands_smoke: List[str]
+    commands_verify: List[str]
+    labels: BotLabels
+
+def load_config(repo_root: Path) -> BotConfig:
+    cfg_path = repo_root / ".claude" / "bot-config.yml"
+    if not cfg_path.exists():
+        example = repo_root / ".claude" / "bot-config.example.yml"
+        raise FileNotFoundError(f"Missing {cfg_path}. Copy from {example} and edit.")
+
+    raw = yaml.safe_load(cfg_path.read_text(encoding="utf-8")) or {}
+    bot = raw.get("bot", {}) or {}
+
+    labels_raw = bot.get("labels", {}) or {}
+    labels = BotLabels(
+        reported=labels_raw.get("reported","bot:reported"),
+        queued=labels_raw.get("queued","bot:queued"),
+        in_progress=labels_raw.get("in_progress","bot:in-progress"),
+        pr_open=labels_raw.get("pr_open","bot:pr-open"),
+        ready_to_merge=labels_raw.get("ready_to_merge","bot:ready-to-merge"),
+        verified=labels_raw.get("verified","bot:verified"),
+        blocked=labels_raw.get("blocked","bot:blocked"),
+        automerge=labels_raw.get("automerge","bot:automerge"),
+    )
+
+    commands = bot.get("commands", {}) or {}
+    return BotConfig(
+        default_branch=bot.get("default_branch","main"),
+        scan_paths=list(bot.get("scan_paths", ["src"]) or ["src"]),
+        max_new_issues_per_run=int(bot.get("max_new_issues_per_run", 20)),
+        commands_smoke=list(commands.get("smoke", []) or []),
+        commands_verify=list(commands.get("verify", []) or []),
+        labels=labels,
+    )

--- a/scripts/claude-bot/github_client.py
+++ b/scripts/claude-bot/github_client.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from typing import Any, Dict, Optional
+import requests
+
+class GitHubError(RuntimeError):
+    pass
+
+@dataclass(frozen=True)
+class RepoRef:
+    base_url: str   # e.g. https://github.com or GHES host
+    owner: str
+    repo: str
+
+def infer_api_base(base_url: str) -> str:
+    # Default to api.github.com for github.com; otherwise GHES commonly exposes /api/v3
+    override = os.environ.get("GITHUB_API_BASE_URL")
+    if override:
+        return override.rstrip("/")
+    host = base_url.rstrip("/")
+    if host.endswith("github.com"):
+        return "https://api.github.com"
+    return host + "/api/v3"
+
+class GitHubClient:
+    def __init__(self, repo: RepoRef, token: str):
+        self.repo = repo
+        self.api_base = infer_api_base(repo.base_url)
+        self.session = requests.Session()
+        self.session.headers.update({
+            "Authorization": f"Bearer {token}",
+            "Accept": "application/vnd.github+json",
+            # Pinning API version is recommended by GitHub; safe default:
+            "X-GitHub-Api-Version": "2022-11-28",
+            "User-Agent": "claude-repo-bot",
+        })
+
+    def _url(self, path: str) -> str:
+        if not path.startswith("/"):
+            path = "/" + path
+        return self.api_base + path
+
+    def request(self, method: str, path: str, *, params: Optional[Dict[str,Any]]=None, json_body: Optional[Dict[str,Any]]=None) -> Any:
+        r = self.session.request(method, self._url(path), params=params, json=json_body, timeout=60)
+        if r.status_code >= 400:
+            raise GitHubError(f"{method} {path} failed: {r.status_code} {r.text}")
+        if r.status_code == 204 or not r.text:
+            return None
+        return r.json()
+
+    def get_json(self, path: str, params: Optional[Dict[str,Any]]=None) -> Any:
+        return self.request("GET", path, params=params)
+
+    def post_json(self, path: str, json_body: Dict[str,Any]) -> Any:
+        return self.request("POST", path, json_body=json_body)
+
+    def patch_json(self, path: str, json_body: Dict[str,Any]) -> Any:
+        return self.request("PATCH", path, json_body=json_body)
+
+    def put_json(self, path: str, json_body: Optional[Dict[str,Any]]=None) -> Any:
+        return self.request("PUT", path, json_body=json_body or {})

--- a/scripts/claude-bot/requirements.txt
+++ b/scripts/claude-bot/requirements.txt
@@ -1,0 +1,2 @@
+requests>=2.31.0
+PyYAML>=6.0.1

--- a/scripts/claude-bot/run_signals.sh
+++ b/scripts/claude-bot/run_signals.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+echo "=== claude-bot signals ==="
+echo "date: $(date -u +%Y-%m-%dT%H:%M:%SZ)"
+echo "git HEAD: $(git rev-parse HEAD 2>/dev/null || true)"
+echo "git branch: $(git rev-parse --abbrev-ref HEAD 2>/dev/null || true)"
+echo "git status:"
+git status --porcelain=v1 || true
+echo
+
+# Optional quick lint hints (cheap):
+if command -v git >/dev/null; then
+  echo "Top TODO/FIXME hits (first 50):"
+  git grep -n -E "TODO\(|TODO:|FIXME\(|FIXME:" -- . || true | head -n 50 || true
+  echo
+fi
+
+echo "=== end signals ==="

--- a/scripts/claude-bot/run_smoke.sh
+++ b/scripts/claude-bot/run_smoke.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+set -euo pipefail
+python3 scripts/claude-bot/bot.py run-smoke

--- a/scripts/claude-bot/run_verify.sh
+++ b/scripts/claude-bot/run_verify.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+set -euo pipefail
+python3 scripts/claude-bot/bot.py run-verify

--- a/scripts/claude-bot/utils.py
+++ b/scripts/claude-bot/utils.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+import os, re, subprocess, json, hashlib
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, Any, Optional, Tuple
+
+def die(msg: str) -> None:
+    raise SystemExit(msg)
+
+def sh(cmd: list[str], *, cwd: Optional[str]=None, env: Optional[Dict[str,str]]=None, check: bool=True, capture: bool=True) -> subprocess.CompletedProcess:
+    return subprocess.run(cmd, cwd=cwd, env=env, check=check,
+                          text=True, capture_output=capture)
+
+def repo_root() -> Path:
+    cp = sh(["git", "rev-parse", "--show-toplevel"])
+    return Path(cp.stdout.strip())
+
+def parse_git_remote(url: str) -> Tuple[str,str,str]:
+    # returns (base_url, owner, repo)
+    # Supports:
+    # - https://host/owner/repo(.git)
+    # - http://host/owner/repo(.git)
+    # - ssh://git@host/owner/repo(.git)
+    # - git@host:owner/repo(.git)
+    u = url.strip()
+
+    # normalize ssh scp-like to ssh://
+    m = re.match(r"^(?P<user>[^@]+)@(?P<host>[^:]+):(?P<path>.+)$", u)
+    if m:
+        host = m.group("host")
+        path = m.group("path")
+        base = f"https://{host}"
+        parts = path.split("/")
+        if len(parts) < 2:
+            raise ValueError(f"Cannot parse remote: {url}")
+        owner, repo = parts[0], parts[1]
+        repo = repo[:-4] if repo.endswith(".git") else repo
+        return base, owner, repo
+
+    m = re.match(r"^(?P<scheme>https?)://(?P<host>[^/]+)/(?P<owner>[^/]+)/(?P<repo>[^/]+?)(?:\.git)?$", u)
+    if m:
+        base = f"{m.group('scheme')}://{m.group('host')}"
+        owner = m.group("owner")
+        repo = m.group("repo")
+        repo = repo[:-4] if repo.endswith(".git") else repo
+        return base, owner, repo
+
+    m = re.match(r"^ssh://(?:(?P<user>[^@]+)@)?(?P<host>[^/]+)/(?P<owner>[^/]+)/(?P<repo>[^/]+?)(?:\.git)?$", u)
+    if m:
+        base = f"https://{m.group('host')}"  # default; override via env if needed
+        owner = m.group("owner")
+        repo = m.group("repo")
+        repo = repo[:-4] if repo.endswith(".git") else repo
+        return base, owner, repo
+
+    raise ValueError(f"Unsupported git remote URL format: {url}")
+
+def fingerprint_issue(title: str, typ: str, severity: str, paths: list[str]) -> str:
+    payload = {"title": title.strip().lower(), "type": typ, "severity": severity, "paths": sorted([p.strip() for p in paths])}
+    h = hashlib.sha1(json.dumps(payload, sort_keys=True).encode("utf-8")).hexdigest()
+    return h
+
+FINGERPRINT_RE = re.compile(r"<!--\s*claude-bot:fingerprint:\s*([a-f0-9]{40})\s*-->")
+
+def extract_fingerprint(body: str) -> Optional[str]:
+    m = FINGERPRINT_RE.search(body or "")
+    return m.group(1) if m else None
+
+def ensure_git_identity() -> None:
+    # Ensure commits succeed in CI.
+    try:
+        sh(["git","config","user.email"], check=True)
+    except Exception:
+        sh(["git","config","user.email","claude-bot@local"], check=True)
+    try:
+        sh(["git","config","user.name"], check=True)
+    except Exception:
+        sh(["git","config","user.name","claude-bot"], check=True)
+
+def set_push_remote_with_token(base_url: str, owner: str, repo: str, username: str, token: str) -> None:
+    # Use basic auth with PAT: https://user:token@host/owner/repo.git
+    host = re.sub(r"^https?://", "", base_url.rstrip("/"))
+    remote = f"https://{username}:{token}@{host}/{owner}/{repo}.git"
+    sh(["git","remote","set-url","origin",remote], check=True)


### PR DESCRIPTION
## Summary
- Add GitHub Actions workflows for bot discover/fix (manual trigger only) and PR CI
- Add bot scripts (Python runner, config, utilities)
- Add Claude skills for bot policy, issue discovery, fixes, and triage
- Configure bot for develop branch with scan paths: src/, web/src/, server/, scripts/
- Disabled nightly cron schedules — prefer local CLI auth usage

## Configuration
- **Default branch:** develop
- **Scan paths:** src/, web/src/, server/, scripts/
- **Max changed lines:** 400
- **Auto-merge:** Disabled

## Local Usage (no API key needed)
```bash
python scripts/claude-bot/bot.py discover
python scripts/claude-bot/bot.py fix all
python scripts/claude-bot/bot.py run-verify
```

## Test plan
- [x] Bot script runs locally (`bot.py --help`, `bot.py infer`)
- [ ] Merge PR and verify PR CI workflow triggers on future PRs

🤖 Generated with [Claude Code](https://claude.ai/claude-code)